### PR TITLE
Update metricbeat default clusterRoleRules

### DIFF
--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -40,6 +40,7 @@ clusterRoleRules:
   resources:
   - statefulsets
   - deployments
+  - replicasets
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources:


### PR DESCRIPTION
When deploying metricbeat 7.9.0 using helm chart 0.0.2, I get the following error in the metricbeat deployment.

```
E0902 16:56:02.014021       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.3/tools/cache/reflector.go:125: Failed to list *v1.ReplicaSet: replicasets.apps is forbidden: User "system:serviceaccount:kube-system:metricbeat" cannot list resource "replicasets" in API group "apps" at the cluster scope
```

I was able to fix this by overriding `clusterRoleRules`, but I thought updating the default values in https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml#L39 might save others some time.

I'm using kube-state-metrics v1.9.7 on AWS EKS 1.17.

EDIT:
Looking at the kubernetes module guide for metricbeat 7.9, you might want to see `nonResourceURLs` as well. https://www.elastic.co/guide/en/beats/metricbeat/7.9/metricbeat-module-kubernetes.html