### PR TITLE
Add toleration to all DaemonSets

### DIFF
--- a/filebeat/Chart.yaml
+++ b/filebeat/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: logzio-k8s-logs
 description: A Helm chart for shipping k8s logs to logz.io via Filebeat.
-version: 0.0.1
+version: 0.0.2
 appVersion: 7.8.1

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -146,6 +146,7 @@ Give your logs some time to get from your system to ours, and then open [Logz.io
 | `daemonset.fieldsUnderRoot` | If this option is set to true, the custom fields are stored as top-level fields in the output document instead of being grouped under a `fields` sub-dictionary. | `"true"` |
 | `daemonset.securityContext` | Configurable [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for Filebeat DaemonSet pod execution environment. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/filebeat/values.yaml) |
 | `daemonset.resources` | Allows you to set the resources for Filebeat Daemonset. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/filebeat/values.yaml) |
+| `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. Leave empty to remove tolerations and honor all node taints. | `- operator: Exists` (aka, ignore all taints) |
 | `daemonset.volumes` | Templatable string of additional `volumes` to be passed to the DaemonSet. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/filebeat/values.yaml) |
 | `daemonset.volumeMounts` | Templatable string of additional `volumeMounts` to be passed to the DaemonSet. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/filebeat/values.yaml) |
 | `secrets.logzioShippingToken`| Secret with your [logzio shipping token](https://app.logz.io/#/dashboard/settings/general). | `""` |

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -146,7 +146,7 @@ Give your logs some time to get from your system to ours, and then open [Logz.io
 | `daemonset.fieldsUnderRoot` | If this option is set to true, the custom fields are stored as top-level fields in the output document instead of being grouped under a `fields` sub-dictionary. | `"true"` |
 | `daemonset.securityContext` | Configurable [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for Filebeat DaemonSet pod execution environment. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/filebeat/values.yaml) |
 | `daemonset.resources` | Allows you to set the resources for Filebeat Daemonset. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/filebeat/values.yaml) |
-| `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. Leave empty to remove tolerations and honor all node taints. | `{}` |
+| `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. | `{}` |
 | `daemonset.volumes` | Templatable string of additional `volumes` to be passed to the DaemonSet. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/filebeat/values.yaml) |
 | `daemonset.volumeMounts` | Templatable string of additional `volumeMounts` to be passed to the DaemonSet. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/filebeat/values.yaml) |
 | `secrets.logzioShippingToken`| Secret with your [logzio shipping token](https://app.logz.io/#/dashboard/settings/general). | `""` |

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -173,5 +173,7 @@ helm uninstall --namespace=kube-system logzio-k8s-logs
 
 
 ## Change log
+ - **0.0.2**:
+    - Added option to set tolerations for daemonset (Thanks [jlewis42lines](https://github.com/jlewis42lines)!).
  - **0.0.1**:
     - Initial release.

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -146,7 +146,7 @@ Give your logs some time to get from your system to ours, and then open [Logz.io
 | `daemonset.fieldsUnderRoot` | If this option is set to true, the custom fields are stored as top-level fields in the output document instead of being grouped under a `fields` sub-dictionary. | `"true"` |
 | `daemonset.securityContext` | Configurable [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for Filebeat DaemonSet pod execution environment. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/filebeat/values.yaml) |
 | `daemonset.resources` | Allows you to set the resources for Filebeat Daemonset. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/filebeat/values.yaml) |
-| `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. Leave empty to remove tolerations and honor all node taints. | `- operator: Exists` (aka, ignore all taints) |
+| `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. Leave empty to remove tolerations and honor all node taints. | `{}` |
 | `daemonset.volumes` | Templatable string of additional `volumes` to be passed to the DaemonSet. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/filebeat/values.yaml) |
 | `daemonset.volumeMounts` | Templatable string of additional `volumeMounts` to be passed to the DaemonSet. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/filebeat/values.yaml) |
 | `secrets.logzioShippingToken`| Secret with your [logzio shipping token](https://app.logz.io/#/dashboard/settings/general). | `""` |

--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -70,6 +70,10 @@ spec:
           readOnly: {{ .readOnly }}
           subPath: {{ .subPath }}
       {{- end }}
+      {{- if .Values.daemonset.tolerations }}
+      tolerations:
+{{ toYaml .Values.daemonset.tolerations | indent 6 }}
+      {{- end }}
       volumes:
       - name: varlibdockercontainers
         hostPath:

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -143,6 +143,8 @@ daemonset:
     requests:
       cpu: 100m
       memory: 100Mi
+  tolerations:
+  - operator: Exists
   volumes:
     - name: cert
       configMap:

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -143,8 +143,7 @@ daemonset:
     requests:
       cpu: 100m
       memory: 100Mi
-  tolerations:
-  - operator: Exists
+  tolerations: {}
   volumes:
     - name: cert
       configMap:

--- a/metricbeat/Chart.yaml
+++ b/metricbeat/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: logzio-k8s-metrics
 description: A Helm chart for shipping k8s metrics to logzio.io
-version: 0.0.5
+version: 0.0.6
 appVersion: 7.9.1

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -193,6 +193,7 @@ Give your metrics some time to get from your system to ours, and then open [Logz
 | `daemonset.resources` | Allows you to set the resources for Metricbeat Deployment. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |
 | `daemonset.secretMounts` | Allows you to easily mount a secret as a file inside the DaemonSet. Useful for mounting certificates and other secrets. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |
 | `daemonset.sslVerificationMode` | Set the ssl verification mode for Metricbeat | `"none"` |
+| `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. Leave empty to remove tolerations and honor all node taints. | `- operator: Exists` (aka, ignore all taints) |
 | `deployment.leanConfig` | When set to `true`, sets the Deployment's Metricbeat modules to the minimal configuration required to populate Logz.io's dashboards. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |
 | `deployment.extraVolumeMounts` | Templatable string of additional volumeMounts to be passed to the Deployment. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |
 | `deployment.extraVolumes` | Templatable string of additional `volumes` to be passed to the Deployment. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -234,8 +234,10 @@ helm uninstall --namespace=kube-system logzio-k8s-metrics
 
 
 ## Change log
+  - **0.0.6**:
+    - Added option to set tolerations for daemonset (Thanks [jlewis42lines](https://github.com/jlewis42lines)!).
   - **0.0.5**:
-    - Mangage Logz.io metrics related secrets in helm
+    - Mangage Logz.io metrics related secrets in helm.
   - **0.0.4**:
     - Support lean configuration for modules in Deployment and Daemonset to match build-in dashboards in Logz.io.
     - Support custom configuration for modules in Deployment and Daemonset.

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -193,7 +193,7 @@ Give your metrics some time to get from your system to ours, and then open [Logz
 | `daemonset.resources` | Allows you to set the resources for Metricbeat Deployment. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |
 | `daemonset.secretMounts` | Allows you to easily mount a secret as a file inside the DaemonSet. Useful for mounting certificates and other secrets. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |
 | `daemonset.sslVerificationMode` | Set the ssl verification mode for Metricbeat | `"none"` |
-| `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. Leave empty to remove tolerations and honor all node taints. | `- operator: Exists` (aka, ignore all taints) |
+| `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. Leave empty to remove tolerations and honor all node taints. | `{}` |
 | `deployment.leanConfig` | When set to `true`, sets the Deployment's Metricbeat modules to the minimal configuration required to populate Logz.io's dashboards. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |
 | `deployment.extraVolumeMounts` | Templatable string of additional volumeMounts to be passed to the Deployment. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |
 | `deployment.extraVolumes` | Templatable string of additional `volumes` to be passed to the Deployment. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -193,7 +193,7 @@ Give your metrics some time to get from your system to ours, and then open [Logz
 | `daemonset.resources` | Allows you to set the resources for Metricbeat Deployment. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |
 | `daemonset.secretMounts` | Allows you to easily mount a secret as a file inside the DaemonSet. Useful for mounting certificates and other secrets. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |
 | `daemonset.sslVerificationMode` | Set the ssl verification mode for Metricbeat | `"none"` |
-| `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. Leave empty to remove tolerations and honor all node taints. | `{}` |
+| `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. | `{}` |
 | `deployment.leanConfig` | When set to `true`, sets the Deployment's Metricbeat modules to the minimal configuration required to populate Logz.io's dashboards. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |
 | `deployment.extraVolumeMounts` | Templatable string of additional volumeMounts to be passed to the Deployment. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |
 | `deployment.extraVolumes` | Templatable string of additional `volumes` to be passed to the Deployment. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/metricbeat/values.yaml). |

--- a/metricbeat/templates/daemonset.yaml
+++ b/metricbeat/templates/daemonset.yaml
@@ -99,6 +99,10 @@ spec:
         {{- if .Values.extraVolumeMounts | default .Values.daemonset.extraVolumeMounts }}
 {{ toYaml ( .Values.extraVolumeMounts | default .Values.daemonset.extraVolumeMounts ) | indent 8 }}
         {{- end }}
+      {{- if .Values.daemonset.tolerations }}
+      tolerations:
+{{ toYaml .Values.daemonset.tolerations | indent 6 }}
+      {{- end }}
       volumes:
       {{- range .Values.secretMounts | default .Values.daemonset.secretMounts }}
       - name: {{ .name }}

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -176,6 +176,8 @@ daemonset:
     requests:
       cpu: 100m
       memory: 100Mi
+  tolerations:
+  - operator: Exists
   secretMounts:
   - name: cert
     secretName: logzio-cert

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -176,8 +176,7 @@ daemonset:
     requests:
       cpu: 100m
       memory: 100Mi
-  tolerations:
-  - operator: Exists
+  tolerations: {}
   secretMounts:
   - name: cert
     secretName: logzio-cert


### PR DESCRIPTION
By default, add a blanket toleration to the filebeat and metricbeat DaemonSets, with the option to remove the toleration and accept all taints (for backward compatibility).

This is technically a breaking change, as it changes the current default behavior. However, I think most people will want the DaemonSet pods to ignore all taints, so I believe this is the proper default going forward.