### PR TITLE
derive secrets from values

### DIFF
--- a/metricbeat/templates/daemonset.yaml
+++ b/metricbeat/templates/daemonset.yaml
@@ -55,17 +55,17 @@ spec:
         - name: KUBE_STATE_METRICS_NAMESPACE
           valueFrom:
             secretKeyRef:
-              name: cluster-details
+              name: logzio-metrics-secret
               key: kube-state-metrics-namespace
         - name: KUBE_STATE_METRICS_PORT
           valueFrom:
             secretKeyRef:
-              name: cluster-details
+              name: logzio-metrics-secret
               key: kube-state-metrics-port
         - name: CLUSTER_NAME
           valueFrom:
             secretKeyRef:
-              name: cluster-details
+              name: logzio-metrics-secret
               key: cluster-name
         - name: SSL_VERIFICATION_MODE
           value: {{ .Values.daemonset.sslVerificationMode }}

--- a/metricbeat/templates/deployment.yaml
+++ b/metricbeat/templates/deployment.yaml
@@ -43,17 +43,17 @@ spec:
         - name: KUBE_STATE_METRICS_NAMESPACE
           valueFrom:
             secretKeyRef:
-              name: cluster-details
+              name: logzio-metrics-secret
               key: kube-state-metrics-namespace
         - name: KUBE_STATE_METRICS_PORT
           valueFrom:
             secretKeyRef:
-              name: cluster-details
+              name: logzio-metrics-secret
               key: kube-state-metrics-port
         - name: CLUSTER_NAME
           valueFrom:
             secretKeyRef:
-              name: cluster-details
+              name: logzio-metrics-secret
               key: cluster-name
         securityContext: {{ toYaml ( .Values.podSecurityContext | default .Values.deployment.securityContext ) | nindent 10 }}
         resources: {{ toYaml ( .Values.resources | default .Values.deployment.resources ) | nindent 10 }}

--- a/metricbeat/templates/secrets.yaml
+++ b/metricbeat/templates/secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: {{ .Values.apiVersions.secret }}
+kind: Secret
+metadata:
+  name: logzio-metrics-secret
+  namespace: {{ .Values.namespace }}
+type: Opaque
+stringData:
+  logzio-metrics-shipping-token: {{ .Values.secrets.logzioShippingToken }}
+  logzio-metrics-listener: {{ template "logzio.listenerHost" . }}
+  kube-state-metrics-port: 
+  cluster-name: {{ .Values.secrets.clusterName }}

--- a/metricbeat/templates/secrets.yaml
+++ b/metricbeat/templates/secrets.yaml
@@ -7,5 +7,6 @@ type: Opaque
 stringData:
   logzio-metrics-shipping-token: {{ .Values.secrets.logzioShippingToken }}
   logzio-metrics-listener: {{ template "logzio.listenerHost" . }}
-  kube-state-metrics-port: 
+  kube-state-metrics-port: {{ .Values.secrets.kube-state-metrics-port }}
+  kube-state-metrics-namespace: {{ .Values.secrets.kube-state-metrics-namespace }}
   cluster-name: {{ .Values.secrets.clusterName }}

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -344,3 +344,4 @@ secrets:
   logzioRegion: " "
   clusterName: ""
   kube-state-metrics-port: "8080"
+  kube-state-metrics-values: "kube-system"

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -338,3 +338,9 @@ deployment:
     mountPath: "/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt"
     readOnly: true
     subPath: SectigoRSADomainValidationSecureServerCA.crt
+
+secrets:
+  logzioShippingToken: ""
+  logzioRegion: " "
+  clusterName: ""
+  kube-state-metrics-port: "8080"


### PR DESCRIPTION
This PR is to make the metricbeat derive secrets from values, similarly to the way the filebeat chart does it.


I can see these are in active development, but I wish the two charts had a more similar user experience. If I want to use filebeat and metricbeat, I'd end up storing the same secret information in duplicate, and using two different ways of creating the secrets.

It would be great too if the secrets were configurable, so both charts could be made to rely on the same secret for logzio login information.