### PR TITLE
Fluentd updates

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.0.4
-appVersion: 1.0.1
+version: 0.1.0
+appVersion: 1.0.2
 maintainers:
   - name: Miri Ignatiev
     email: miri.ignatiev@logz.io

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -77,7 +77,8 @@ helm install -n monitoring \
 | `daemonset.includeNamespace` | Use if you wish to send logs from specific k8s namespaces, space delimited. Should be in the following format: `kubernetes.var.log.containers.**_<<NAMESPACE-TO-INCLUDE>>_** kubernetes.var.log.containers.**_<<ANOTHER-NAMESPACE>>_**`. | `""` |
 | `daemonset.kubernetesVerifySsl` | Enables to validate SSL certificates. | `true` |
 | `daemonset.auditLogFormat` | Match Fluentd's format for kube-apiserver audit logs. Set to `audit-json` if your audit logs are in json format. | `audit` |
-| `daemonset.containerdRuntime` | Determines whether to use a configuration for a Containerd runtime. Set to `false` if your cluster doesn't use Containerd as CRI. | `true` |
+| `daemonset.containerdRuntime` | **Deprecated from chart version 0.1.0.** Determines whether to use a configuration for a Containerd runtime. Set to `false` if your cluster doesn't use Containerd as CRI. | `true` |
+| `daemonset.cri` | Container runtime interface of the cluster. Used to determine which configuration to use when concatenating partial logs. Valid options are: `docker`, `containerd`. | `containerd` |
 | `daemonset.logzioBufferType` | Specifies which plugin to use as the backend. | `file` |
 | `daemonset.logzioBufferPath` | Path of the buffer. | `/var/log/fluentd-buffers/stackdriver.buffer` |
 | `daemonset.logzioOverflowAction` | Controls the behavior when the queue becomes full. | `block` |
@@ -103,7 +104,9 @@ helm install -n monitoring \
 | `configmap.kubernetes` | Configuration for `kubernetes.conf`. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 | `configmap.system` | Configuration for `system.conf`. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 | `configmap.systemd` | Configuration for `systemd.conf`. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
-| `configmap.kubernetesContainerd` | Configuration for `kubernetes-containerd.conf`. This is the configuration that's being used when `daemonset.containerdRuntime` is set to `true` | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
+| `configmap.kubernetesContainerd` | **Deprecated from chart version 0.1.0.** Configuration for `kubernetes-containerd.conf`. This is the configuration that's being used when `daemonset.containerdRuntime` is set to `true` | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
+| `configmap.partialDocker` | Configuration for `partial-docker.conf`. Used to concatenate partial logs that split due to large size, for docker cri. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
+| `configmap.partialContainerd` | Configuration for `partial-containerd.conf`. Used to concatenate partial logs that split due to large size, for containerd cri. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 | `configmap.audit` | Configuration for `audit.conf`. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 | `configmap.auditJson` | Configuration for `audit-json.conf`. This is the configuration that's being used when `daemonset.auditLogFormat` is set to `audit-json` | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 
@@ -170,6 +173,11 @@ For the above example, we could use the following regex expressions to demarcate
 
 ## Change log
 
+ - **0.1.0**:
+    - Upgrade default image version to `logzio/logzio-fluentd:1.0.2` which also supports ARM architecture.
+    - Deprecated variables: `daemonset.containerdRuntime`, `configmap.kubernetesContainerd`.
+    - Added `configmap.partialDocker`, `configmap.partialContainerd` that concatenate logs that split due to large size (over 16k). To learn more go to the [configuration table](https://github.com/logzio/logzio-helm/tree/master/charts/fluentd#configuration).
+    - Added `daemonset.cri` to match the partial log config to the cluster's CRI. To learn more go to the [configuration table](https://github.com/logzio/logzio-helm/tree/master/charts/fluentd#configuration).
  - **0.0.4**:
     - Refactor configmaps
  - **0.0.3**:

--- a/charts/fluentd/templates/configmap.yaml
+++ b/charts/fluentd/templates/configmap.yaml
@@ -14,11 +14,13 @@ data:
 
   systemd.conf: {{ toYaml .Values.configmap.systemd | indent 2 }}
 
-  kubernetes-containerd.conf: {{ toYaml .Values.configmap.kubernetesContainerd | indent 2 }}
-
   audit.conf: {{ toYaml .Values.configmap.audit | indent 2 }}
 
   audit-json.conf: {{ toYaml .Values.configmap.auditJson | indent 2 }}
+
+  partial-docker.conf: {{ toYaml .Values.configmap.partialDocker | indent 2 }}
+
+  partial-containerd.conf: {{ toYaml .Values.configmap.partialContainerd | indent 2 }}
 
 {{- if .Values.configmap.extraConfig }}
 {{- range $key, $value := fromYaml .Values.configmap.extraConfig }}

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -83,10 +83,8 @@ spec:
           value: {{ .Values.daemonset.kubernetesVerifySsl | quote }}
         - name: AUDIT_LOG_FORMAT
           value: {{ .Values.daemonset.auditLogFormat }}
-        {{- if .Values.daemonset.containerdRuntime }}
-        - name: FLUENTD_KUBERNETES_CONTAINERD_CONF
-          value: "kubernetes-containerd"
-        {{- end }}
+        - name: CRI
+          value: {{ .Values.daemonset.cri | quote }}
         {{- if .Values.daemonset.extraEnv }}
 {{ toYaml .Values.daemonset.extraEnv | indent 8 }}
         {{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -1,5 +1,5 @@
 image: logzio/logzio-fluentd
-imageTag: 1.0.1
+imageTag: 1.0.2
 
 nameOverride: ""
 fullnameOverride: ""
@@ -29,7 +29,7 @@ daemonset:
   includeNamespace: ""
   kubernetesVerifySsl: true
   auditLogFormat: audit
-  containerdRuntime: true
+  cri: containerd
   logzioBufferType: file
   logzioBufferPath: /var/log/fluentd-buffers/stackdriver.buffer
   logzioOverflowAction: block
@@ -72,7 +72,7 @@ secrets:
 configMapIncludes: |
   @include "#{ENV['FLUENTD_SYSTEMD_CONF'] || 'systemd'}.conf"
   @include "#{ENV['FLUENTD_PROMETHEUS_CONF'] || 'prometheus'}.conf"
-  @include "#{ENV['FLUENTD_KUBERNETES_CONTAINERD_CONF'] || 'kubernetes'}.conf"
+  @include kubernetes.conf
   @include system.conf
   @include conf.d/*.conf
 
@@ -111,7 +111,7 @@ configmap:
 
   kubernetes: |
     <label @FLUENT_LOG>
-      <match fluent.*>
+      <match fluent.**>
         @type null
       </match>
     </label>
@@ -121,12 +121,26 @@ configmap:
       @id in_tail_container_logs
       path /var/log/containers/*.log
       pos_file /var/log/fluentd-containers.log.pos
-      exclude_path /var/log/containers/fluentd*.log
+      # The following line removes fluentd containers logs:
+      exclude_path /var/log/containers/*fluentd*.log
       tag logzio.kubernetes.*
       read_from_head true
       <parse>
-        @type json
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
+        @type multi_format
+        <pattern>
+          # for docker cri
+          format json
+          time_key time
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+          keep_time_key true
+        </pattern>
+        <pattern>
+          # for containerd cri
+          # format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+          format /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
+          time_format %Y-%m-%dT%H:%M:%S.%N%:z
+          keep_time_key true
+        </pattern>
       </parse>
     </source>
 
@@ -176,7 +190,7 @@ configmap:
         @type none
       </parse>
     </source>
-
+    
     <source>
       @type tail
       @id in_tail_kubelet
@@ -260,7 +274,7 @@ configmap:
         @type kubernetes
       </parse>
     </source>
-
+    
     <source>
       @type tail
       @id in_tail_cluster_autoscaler
@@ -283,6 +297,8 @@ configmap:
       languages all
       multiline_flush_interval 0.1
     </match>
+
+    @include "partial-#{ENV['CRI']}.conf"
 
     # This adds type to the log && change key log to message
     <filter **>
@@ -349,199 +365,6 @@ configmap:
       tag bootkube
     </source>
 
-  kubernetesContainerd: |
-    <label @FLUENT_LOG>
-      <match fluent.*>
-        @type null
-      </match>
-    </label>
-
-    <source>
-      @type tail
-      @id in_tail_container_logs
-      path /var/log/containers/*.log
-      pos_file /var/log/fluentd-containers.log.pos
-      exclude_path /var/log/containers/fluentd*.log
-      tag logzio.kubernetes.*
-      read_from_head true
-      <parse>
-        @type regexp
-        expression /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_minion
-      path /var/log/salt/minion
-      pos_file /var/log/fluentd-salt.pos
-      tag logzio.salt
-      <parse>
-        @type regexp
-        expression /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
-        time_format %Y-%m-%d %H:%M:%S
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_startupscript
-      path /var/log/startupscript.log
-      pos_file /var/log/fluentd-startupscript.log.pos
-      tag logzio.startupscript
-      <parse>
-        @type syslog
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_docker
-      path /var/log/docker.log
-      pos_file /var/log/fluentd-docker.log.pos
-      tag logzio.docker
-      <parse>
-        @type regexp
-        expression /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_etcd
-      path /var/log/etcd.log
-      pos_file /var/log/fluentd-etcd.log.pos
-      tag logzio.etcd
-      <parse>
-        @type none
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_kubelet
-      multiline_flush_interval 5s
-      path /var/log/kubelet.log
-      pos_file /var/log/fluentd-kubelet.log.pos
-      tag logzio.kubelet
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_kube_proxy
-      multiline_flush_interval 5s
-      path /var/log/kube-proxy.log
-      pos_file /var/log/fluentd-kube-proxy.log.pos
-      tag logzio.kube-proxy
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_kube_apiserver
-      multiline_flush_interval 5s
-      path /var/log/kube-apiserver.log
-      pos_file /var/log/fluentd-kube-apiserver.log.pos
-      tag logzio.kube-apiserver
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_kube_controller_manager
-      multiline_flush_interval 5s
-      path /var/log/kube-controller-manager.log
-      pos_file /var/log/fluentd-kube-controller-manager.log.pos
-      tag logzio.kube-controller-manager
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_kube_scheduler
-      multiline_flush_interval 5s
-      path /var/log/kube-scheduler.log
-      pos_file /var/log/fluentd-kube-scheduler.log.pos
-      tag logzio.kube-scheduler
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_rescheduler
-      multiline_flush_interval 5s
-      path /var/log/rescheduler.log
-      pos_file /var/log/fluentd-rescheduler.log.pos
-      tag logzio.rescheduler
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_glbc
-      multiline_flush_interval 5s
-      path /var/log/glbc.log
-      pos_file /var/log/fluentd-glbc.log.pos
-      tag logzio.glbc
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_cluster_autoscaler
-      multiline_flush_interval 5s
-      path /var/log/cluster-autoscaler.log
-      pos_file /var/log/fluentd-cluster-autoscaler.log.pos
-      tag logzio.cluster-autoscaler
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    @include "#{ENV['AUDIT_LOG_FORMAT'] || 'audit'}.conf"
-
-    # This handles multiline exceptions automatically: https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions
-    <match logzio.**>
-      @type detect_exceptions
-      remove_tag_prefix logzio
-      message log
-      languages all
-      multiline_flush_interval 0.1
-    </match>
-
-    # This adds type to the log && change key log to message
-    <filter **>
-      @type record_modifier
-      <record>
-        type  k8s
-        message ${record["log"]}
-      </record>
-      remove_keys log
-    </filter>
-
-    <filter kubernetes.**>
-      @type kubernetes_metadata
-      @id filter_kube_metadata
-      kubernetes_url "#{ENV['FLUENT_FILTER_KUBERNETES_URL'] || 'https://' + ENV.fetch('KUBERNETES_SERVICE_HOST') + ':' + ENV.fetch('KUBERNETES_SERVICE_PORT') + '/api'}"
-      verify_ssl "#{ENV['KUBERNETES_VERIFY_SSL'] || true}"
-    </filter>
-
   audit: |
     # Example:
     # 2017-02-09T00:15:57.992775796Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" ip="104.132.1.72" method="GET" user="kubecfg" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
@@ -582,3 +405,28 @@ configmap:
         time_format %Y-%m-%dT%T.%L%Z
       </parse>
     </source>
+
+
+  partialDocker: |
+    # Concat docker cri partial log
+    # https://github.com/fluent-plugins-nursery/fluent-plugin-concat
+    # https://github.com/moby/moby/issues/34620#issuecomment-619369707
+    <filter **>
+      @type concat
+      key log
+      use_first_timestamp true
+      multiline_end_regexp /\n$/
+      separator ""
+    </filter>
+
+  partialContainerd: |
+    # Concat containerd cri partial log
+    # https://github.com/fluent/fluentd-kubernetes-daemonset/issues/412#issuecomment-636536767
+    <filter **>
+      @type concat
+      key log
+      use_first_timestamp true
+      partial_key logtag
+      partial_value P
+      separator ""
+    </filter>


### PR DESCRIPTION
In this PR:
* Upgrade default image version to the latest, with ARM support.
* Add filters to configmap, that concatenate logs that were split due to size.
* Add env var to daemonset.
* Exclude sending Fluentd logs.