### PR TITLE
Add nodeSelector to fluentd helm chart

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.1.1
+version: 0.2.0
 appVersion: 1.0.2
 maintainers:
   - name: Miri Ignatiev

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.1.0
+version: 0.1.1
 appVersion: 1.0.2
 maintainers:
   - name: Miri Ignatiev

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -174,7 +174,7 @@ For the above example, we could use the following regex expressions to demarcate
 
 ## Change log
 
- - **0.1.1**:
+ - **0.2.0**:
     - Added `daemonset.nodeSelector`.
  - **0.1.0**:
     - Upgrade default image version to `logzio/logzio-fluentd:1.0.2` which also supports ARM architecture.

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -72,6 +72,7 @@ helm install -n monitoring \
 | `isRBAC` | Specifies whether the Chart should be compatible to a RBAC cluster. If you're running on a non-RBAC cluster, set to `false`.  | `true` |
 | `serviceAccount.name` | Name of the service account. | `""` |
 | `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
+| `daemonset.nodeSelector` | Set [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 | `daemonset.fluentdSystemdConf` | Controls whether Fluentd system messages will be enabled. | `disable` |
 | `daemonset.fluentdPrometheusConf` | Controls the launch of a prometheus plugin that monitors Fluentd. | `disable` |
 | `daemonset.includeNamespace` | Use if you wish to send logs from specific k8s namespaces, space delimited. Should be in the following format: `kubernetes.var.log.containers.**_<<NAMESPACE-TO-INCLUDE>>_** kubernetes.var.log.containers.**_<<ANOTHER-NAMESPACE>>_**`. | `""` |
@@ -173,6 +174,8 @@ For the above example, we could use the following regex expressions to demarcate
 
 ## Change log
 
+ - **0.1.1**:
+    - Added `daemonset.nodeSelector`.
  - **0.1.0**:
     - Upgrade default image version to `logzio/logzio-fluentd:1.0.2` which also supports ARM architecture.
     - Deprecated variables: `daemonset.containerdRuntime`, `configmap.kubernetesContainerd`.

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -72,7 +72,7 @@ helm install -n monitoring \
 | `isRBAC` | Specifies whether the Chart should be compatible to a RBAC cluster. If you're running on a non-RBAC cluster, set to `false`.  | `true` |
 | `serviceAccount.name` | Name of the service account. | `""` |
 | `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
-| `daemonset.nodeSelector` | Set [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
+| `daemonset.nodeSelector` | Set [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. | `{}` |
 | `daemonset.fluentdSystemdConf` | Controls whether Fluentd system messages will be enabled. | `disable` |
 | `daemonset.fluentdPrometheusConf` | Controls the launch of a prometheus plugin that monitors Fluentd. | `disable` |
 | `daemonset.includeNamespace` | Use if you wish to send logs from specific k8s namespaces, space delimited. Should be in the following format: `kubernetes.var.log.containers.**_<<NAMESPACE-TO-INCLUDE>>_** kubernetes.var.log.containers.**_<<ANOTHER-NAMESPACE>>_**`. | `""` |

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -23,6 +23,8 @@ spec:
       {{- if .Values.daemonset.tolerations }}
       tolerations:
 {{ toYaml .Values.daemonset.tolerations | indent 6 }}
+      nodeSelector:
+{{ toYaml .Values.daemonset.nodeSelector | indent 8 }}
       {{- end }}
       # Because the image's entrypoint requires to write on /fluentd/etc but we mount configmap there which is read-only,
       # this initContainers workaround or other is needed.

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -23,6 +23,8 @@ spec:
       {{- if .Values.daemonset.tolerations }}
       tolerations:
 {{ toYaml .Values.daemonset.tolerations | indent 6 }}
+      {{- end }}
+      {{- if .Values.daemonset.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.daemonset.nodeSelector | indent 8 }}
       {{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -24,6 +24,7 @@ daemonset:
   tolerations:
   - key: node-role.kubernetes.io/master
     effect: NoSchedule
+  nodeSelector: {}
   fluentdSystemdConf: disable
   fluentdPrometheusConf: disable
   includeNamespace: ""


### PR DESCRIPTION
Closes #65 

- I'm not sure about the version change. I assume `0.1.1` for this but I need guidance if it is wrong. Just let me know if it needs to be changed.

This PR is required to enable for the example use case:

If you have the following node pools in your Kubernetes cluster with the settings below:

- Node pool 1
```
tolerations:
- key: "environment"
  operator: "Equal"
  value: "production"
  effect: "NoSchedule"
```

- Node pool 2
Without tolerations config.

Consider a helm release installed with the values.yaml below:
```
daemonset:
  tolerations:
  - key: environment
    operator: "Equal"
    value: "production"
    effect: NoSchedule
...
... other configs are implicit
...
```

You would have pods running in the `Node pool 1` because you have the tolerations setting, but also pods will run in the `Node pool 2` because this node pool doesn't have any restriction.

With `nodeSelector` you can deploy the DaemonSet only to the `Node pool 1` if you specify it.

```
daemonset:
  nodeSelector: # This ensures you will only run pods in nodes with the following labels
    environment: production
  tolerations:
  - key: environment
    operator: "Equal"
    value: "production"
    effect: NoSchedule
```

