### PR TITLE
bug fixes, versions bump

### DIFF
--- a/charts/opentelemetry/Chart.yaml
+++ b/charts/opentelemetry/Chart.yaml
@@ -9,26 +9,26 @@ sources:
   - https://github.com/kubernetes/kube-state-metrics
 dependencies:
   - name: kube-state-metrics
-    version: "2.13.2"
+    version: "4.7.0"
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: kubeStateMetrics.enabled
   - name: prometheus-node-exporter
-    version: "1.18.0"
+    version: "2.0.4"
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: nodeExporter.enabled
   - name: prometheus-pushgateway
-    version: "1.9.0"
+    version: "1.16.1"
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: pushGateway.enabled
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.24.0
+appVersion: 0.42.0
 
 maintainers:
 - name: yotamloe

--- a/charts/opentelemetry/README.md
+++ b/charts/opentelemetry/README.md
@@ -161,12 +161,21 @@ kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.tain
 ```
 
 ## Change log
-* 0.2.2 - Windows exporter installer jobs will now run only when username and password are provided.
+* 0.2.3 - 
+  <ul>
+  <li>Fixed an issue where the windows reverse proxy daemonset is listed as a resource when there are no windows nodes. </li>
+  <li>Disabled the usage of the depracted PodSecurityPolicy (psp).</li>
+  <li>Node exporter chart version bump to 2.0.4.</li>
+  <li>Kube state metrics chart version bump to 4.7.0.</li>
+  <li>Prometheus push gateway chart version bump to 1.16.1.</li>
+  </ul>
 
-* 0.2.1 - Added Windows exporter installer as a scheduled job. 
+* 0.2.2 - Windows exporter installer jobs will now run only when username and password are provided.
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>
+
+* 0.2.1 - Added Windows exporter installer as a scheduled job.
 
 * 0.2.0 -
   <ul>

--- a/charts/opentelemetry/templates/daemonset.yaml
+++ b/charts/opentelemetry/templates/daemonset.yaml
@@ -27,6 +27,8 @@ spec:
 {{- end }}
 
 ---
+{{- if .Values.secrets.windowsNodeUsername }}
+{{- if .Values.secrets.windowsNodePassword }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -74,3 +76,5 @@ spec:
         runAsNonRoot: false
       nodeSelector:
         kubernetes.io/os: windows
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry/values.yaml
+++ b/charts/opentelemetry/values.yaml
@@ -311,7 +311,11 @@ windowsExporterInstallerJob:
 kube-state-metrics:
   nodeSelector:
     kubernetes.io/os: linux
+  podSecurityPolicy:
+    enabled: false
 
 prometheus-node-exporter:
   nodeSelector:
     kubernetes.io/os: linux
+  rbac:
+    pspEnabled: false


### PR DESCRIPTION
Fixed an issue where the windows reverse proxy daemonset is listed as a resource when there are no windows nodes. 
Disabled the usage of the depracted PodSecurityPolicy (psp).
Node exporter chart version bump to 2.0.4.
Kube state metrics chart version bump to 4.7.0.
Prometheus push gateway chart version bump to 1.16.1.