### PR TITLE
Fluentbit - upgrade image version to 0.1.2

### DIFF
--- a/charts/fluentbit/Chart.yaml
+++ b/charts/fluentbit/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - fluent-bit
   - fluentd
 type: application
-version: 0.0.1
-appVersion: 0.0.1
+version: 0.0.2
+appVersion: 0.1.2
 sources:
   - https://github.com/logzio/logzio-helm
   - https://github.com/fluent/fluent-bit/

--- a/charts/fluentbit/README.md
+++ b/charts/fluentbit/README.md
@@ -91,4 +91,5 @@ kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.tain
 
 ## Change log
 
+* 0.0.2 - Upgrade docker image to v0.1.2.
 * 0.0.1 - Initial realese

--- a/charts/fluentbit/values.yaml
+++ b/charts/fluentbit/values.yaml
@@ -12,7 +12,7 @@ replicaCount: 1
 image:
   repository: logzio/fluent-bit-output
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
-  tag: "0.1.0"
+  tag: "0.1.2"
   pullPolicy: Always
 
 testFramework:


### PR DESCRIPTION
This PR upgrades the base image of the the Fluentbit Chart to 0.1.2 (that uses fluentbit 1.8.14).