### PR TITLE
Upgrade fluent chart, add default log type

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics and traces from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, and Fluentd for logs.
 type: application
-version: 0.0.1
+version: 0.0.2
 
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: logzio-fluentd
-    version: "0.3.0"
+    version: "0.4.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -96,4 +96,7 @@ For example, if in `logzio-telemetry`'s `values.yaml` file there's a parameter n
 
 ## Changelog
 
+- **0.0.2**:
+	- Upgrade `logzio-fluentd` Chart to `0.4.0`.
+	- Set default logs type to `agent-k8s`.
 - **0.0.1**: Initial release.

--- a/charts/logzio-monitoring/values.yaml
+++ b/charts/logzio-monitoring/values.yaml
@@ -2,3 +2,7 @@ logs:
   enabled: false
 metricsOrTraces:
   enabled: false
+
+logzio-fluentd:
+  daemonset:
+    logType: "agent-k8s"


### PR DESCRIPTION
This PR:
- Upgrades the `logzio-fluentd` Chart to `0.4.0`.
- Sets default log type to `agent-k8s`.