### PR TITLE
Add support for fargate logging

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.4.2
+version: 0.5.0
 appVersion: 1.1.1
 maintainers:
   - name: Miri Ignatiev

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.4.1
+version: 0.4.2
 appVersion: 1.1.1
 maintainers:
   - name: Miri Ignatiev

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -69,10 +69,12 @@ helm install -n monitoring \
 | `apiVersions.configmap` | Configmap API version. | `v1` |
 | `apiVersions.secret` | Secret API version. | `v1` |
 | `namespace` | Chart's namespace. | `monitoring` |
+| `fargateLogRouter.enabled` | Boolen to decide if to configure fargate log router | `false` |
 | `isRBAC` | Specifies whether the Chart should be compatible to a RBAC cluster. If you're running on a non-RBAC cluster, set to `false`.  | `true` |
 | `serviceAccount.name` | Name of the service account. | `""` |
 | `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 | `daemonset.nodeSelector` | Set [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. | `{}` |
+| `daemonset.affinity` | Set [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for all DaemonSet pods. |  |
 | `daemonset.fluentdSystemdConf` | Controls whether Fluentd system messages will be enabled. | `disable` |
 | `daemonset.fluentdPrometheusConf` | Controls the launch of a prometheus plugin that monitors Fluentd. | `disable` |
 | `daemonset.includeNamespace` | Use if you wish to send logs from specific k8s namespaces, space delimited. Should be in the following format: `kubernetes.var.log.containers.**_<<NAMESPACE-TO-INCLUDE>>_** kubernetes.var.log.containers.**_<<ANOTHER-NAMESPACE>>_**`. | `""` |
@@ -217,8 +219,23 @@ To determine if a node uses taints as well as to display the taint keys, run:
 kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.taints}"
 ```
 
+## Sending logs from eks on fargate
+
+If you want to ship logs from pods that are running on fargate set the `fargateLogRouter.enabled` value to true, the follwing will deploy a dedicated `aws-observability` namespace and a `configmap` for fargate log router. More information about eks fargate logging can be found [here](https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html)
+```
+helm install \
+--set fargateLogRouter.enabled=true \
+--set secrets.logzioShippingToken='<<LOG-SHIPPING-TOKEN>>' \
+--set secrets.logzioListener='<<LISTENER-HOST>>' \
+logzio-fluentd logzio-helm/logzio-fluentd
+```
+
+
 
 ## Change log
+ - **0.4.2**:
+   - Add support for `daemonset.affinity` value.
+   - Add support for fargate logging.
  - **0.4.1**:
    - Upgrade default image version to `logzio/logzio-fluentd:1.1.1`.
  - **0.4.0**:

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -233,7 +233,7 @@ logzio-fluentd logzio-helm/logzio-fluentd
 
 
 ## Change log
- - **0.4.2**:
+ - **0.5.0**:
    - Add support for `daemonset.affinity` value.
    - Add support for fargate logging.
  - **0.4.1**:

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -74,7 +74,7 @@ helm install -n monitoring \
 | `serviceAccount.name` | Name of the service account. | `""` |
 | `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 | `daemonset.nodeSelector` | Set [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. | `{}` |
-| `daemonset.affinity` | Set [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for all DaemonSet pods. |  |
+| `daemonset.affinity` | Set [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) rules for the scheduler to determine where all DaemonSet pods can be placed. |  |
 | `daemonset.fluentdSystemdConf` | Controls whether Fluentd system messages will be enabled. | `disable` |
 | `daemonset.fluentdPrometheusConf` | Controls the launch of a prometheus plugin that monitors Fluentd. | `disable` |
 | `daemonset.includeNamespace` | Use if you wish to send logs from specific k8s namespaces, space delimited. Should be in the following format: `kubernetes.var.log.containers.**_<<NAMESPACE-TO-INCLUDE>>_** kubernetes.var.log.containers.**_<<ANOTHER-NAMESPACE>>_**`. | `""` |

--- a/charts/fluentd/templates/aws-observability-namespace.yaml
+++ b/charts/fluentd/templates/aws-observability-namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.fargateLogRouter.enabled }}
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: aws-observability
+  labels:
+    aws-observability: enabled
+{{- end }}

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -20,6 +20,10 @@ spec:
       serviceAccount: {{ template "fluentd.serviceAccount" . }}
       serviceAccountName: {{ template "fluentd.serviceAccount" . }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
       {{- if .Values.daemonset.tolerations }}
       tolerations:
 {{ toYaml .Values.daemonset.tolerations | indent 6 }}

--- a/charts/fluentd/templates/fargate-logging-configmap.yaml
+++ b/charts/fluentd/templates/fargate-logging-configmap.yaml
@@ -1,0 +1,29 @@
+{{ if .Values.fargateLogRouter.enabled }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: aws-logging
+  namespace: aws-observability
+data:
+  filters.conf: |
+    [FILTER]
+      Name modify
+      Match *
+      Add token {{ .Values.secrets.logzioShippingToken }}
+      Add type {{ .Values.daemonset.logType }}
+      Rename log message
+    [FILTER]
+      Name kubernetes
+      Match kube.*
+      Merge_Log On
+      Keep_Log Off
+      K8S-Logging.Parser On
+      K8S-Logging.Exclude On
+  output.conf: |
+    [OUTPUT]
+      Name  es
+      Match *
+      Host  {{ .Values.secrets.logzioListener }}
+      Port  5050
+      Index logzioCustomerIndex
+{{ end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -24,12 +24,23 @@ isRBAC: true
 serviceAccount:
   name: ""
 
+fargateLogRouter:
+  ebabled: false
+
 daemonset:
   tolerations:
   - key: node-role.kubernetes.io/master
     effect: NoSchedule
   nodeSelector:
     os: linux
+  # Prevent node exporter deamonset deploymment on fargate nodes
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: DoesNotExist
   fluentdSystemdConf: disable
   fluentdPrometheusConf: disable
   includeNamespace: ""

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics and traces from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, and Fluentd for logs.
 type: application
-version: 0.0.3
+version: 0.0.4
 
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: logzio-fluentd
-    version: "0.4.1"
+    version: "0.4.2"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "0.0.1"
+    version: "0.0.2"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
 

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics and traces from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, and Fluentd for logs.
 type: application
-version: 0.0.4
+version: 0.1.0
 
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: logzio-fluentd
-    version: "0.4.2"
+    version: "0.5.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -94,8 +94,31 @@ For example, if in `logzio-telemetry`'s `values.yaml` file there's a parameter n
 --set logzio-k8s-telemetry.someField="my new value"
 ```
 
-## Changelog
+### Sending telemetry data from eks on fargate
 
+If you want to ship logs from pods that are running on fargate set the `fargateLogRouter.enabled` value to true, the follwing will deploy a dedicated `aws-observability` namespace and a `configmap` for fargate log router. More information about eks fargate logging can be found [here](https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html)
+```sh
+helm install -n monitoring \
+--set logs.enabled=true \
+--set logzio-fluentd.fargateLogRouter.enabled=true \
+--set logzio-fluentd.secrets.logzioShippingToken="<<LOG-SHIPPING-TOKEN>>" \
+--set logzio-fluentd.secrets.logzioListener="<<LISTENER-HOST>>" \
+--set metricsOrTraces.enabled=true \
+--set logzio-k8s-telemetry.metrics.enabled=true \
+--set logzio-k8s-telemetry.secrets.MetricsToken="<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>" \
+--set logzio-k8s-telemetry.secrets.ListenerHost="https://<<LISTENER-HOST>>:8053" \
+--set logzio-k8s-telemetry.secrets.p8s_logzio_name="<<ENV-TAG>>" \
+--set logzio-k8s-telemetry.traces.enabled=true \
+--set logzio-k8s-telemetry.secrets.TracesToken="<<TRACES-SHIPPING-TOKEN>>" \
+--set logzio-k8s-telemetry.secrets.LogzioRegion="<<LOGZIO-REGION>>" \
+logzio-monitoring logzio-helm/logzio-monitoring
+```
+
+## Changelog
+- **0.0.4**:
+	- Add support for fargate logging
+	- Upgrade `logzio-fluentd` Chart to `0.4.2`.
+	- Upgrade `logzio-telemetry` Chart to `0.0.2`.
 - **0.0.3**:
 	- Upgrade `logzio-fluentd` Chart to `0.4.1`.
 - **0.0.2**:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -115,9 +115,9 @@ logzio-monitoring logzio-helm/logzio-monitoring
 ```
 
 ## Changelog
-- **0.0.4**:
+- **0.1.0**:
 	- Add support for fargate logging
-	- Upgrade `logzio-fluentd` Chart to `0.4.2`.
+	- Upgrade `logzio-fluentd` Chart to `0.5.0`.
 	- Upgrade `logzio-telemetry` Chart to `0.0.2`.
 - **0.0.3**:
 	- Upgrade `logzio-fluentd` Chart to `0.4.1`.

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -186,4 +186,6 @@ helm uninstall logzio-k8s-telemetry
 
 
 ## Change log
+* 0.0.2
+  - Add default `nodeAffinity` to prevent node exporter deamonset deploymment on fargate nodes
 * 0.0.1 - Initial release

--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -11,7 +11,6 @@ containers:
     command:
       - /{{ .Values.command.name }}
       - --config=/conf/relay.yaml
-      - --metrics-addr=0.0.0.0:8888
       {{- range .Values.command.extraArgs }}
       - {{ . }}
       {{- end }}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -192,8 +192,6 @@ tracesConfig:
       logs:
         level: "info"  
 
-
-
 metricsConfig:
   extensions:
     health_check: {}
@@ -289,10 +287,7 @@ metricsConfig:
         receivers:
           - prometheus
 
-
-
 config:
-
   extensions:
     health_check: {}
     pprof:
@@ -305,6 +300,7 @@ config:
     memory_limiter: null
   receivers:
     prometheus:
+      disable_start_time: true
       config:
         global:
           scrape_interval: 15s
@@ -389,7 +385,7 @@ config:
         http:
           endpoint: "0.0.0.0:4318"
     zipkin:
-      endpoint: "0.0.0.0:9411"        
+      endpoint: "0.0.0.0:9411"
   service:
     extensions:
       - pprof
@@ -418,10 +414,10 @@ config:
 
 image:
   # If you want to use the contrib image `otel/opentelemetry-collector-contrib`, you also need to change `command.name` value to `otelcontribcol`.
-  repository: otel/opentelemetry-collector-contrib
+  repository: logzio/otel-collector-distro
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.42.0"
+  tag: "v0.56.0"
 nginxWindowsImage:
   # Reverse proxy image to enable metrics scraping from windows nodes
   repository: logzio/logzio-windows-node-reverse-proxy
@@ -438,7 +434,7 @@ imagePullSecrets: []
 
 # OpenTelemetry Collector executable
 command:
-  name: otelcol-contrib
+  name: otelcol-logzio
   extraArgs: []
 
 serviceAccount:

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -530,8 +530,8 @@ standaloneCollector:
 
   resources:
     limits:
-      cpu: 256m
-      memory: 512Mi
+      cpu: 2560m
+      memory: 5120Mi
 
   podAnnotations: {}
   # Configuration override that will be merged into the agent's default config

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -586,6 +586,14 @@ kube-state-metrics:
 prometheus-node-exporter:
   nodeSelector:
     kubernetes.io/os: linux
+  # Prevent node exporter deamonset deploymment on fargate nodes
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: DoesNotExist
   rbac:
     pspEnabled: false
 


### PR DESCRIPTION
This PR adds support for fargate and hybrid (fargate nodes + ec2 nodes) eks clusters.
* Added deployment of `aws-observability` namespace and log router `configmap`, reference to [fargate logging docs](https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html) 
* Added `affinity` support to our chart to prevent daemon set deployment on fargate (otherwise daemon set pods will be stuck on pending)
* switch to logzio distro 
* add `disable_start_time` feature
#### fluentd chart:
 - **0.5.0**:
   - Add support for `daemonset.affinity` value.
   - Add support for fargate logging.
   - Updte readme
 #### logzio-telemetry chart:
- 0.0.2
  - Add default `nodeAffinity` to prevent node exporter daemon set deployment 
 #### logzio-monitoring chart:
- **0.1.0**:
	- Add support for fargate logging
	- Upgrade `logzio-fluentd` Chart to `0.5.0`.
	- Upgrade `logzio-telemetry` Chart to `0.0.2`.
 