### PR TITLE
adding env variable flexability

### DIFF
--- a/charts/filebeat/Chart.yaml
+++ b/charts/filebeat/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: logzio-k8s-logs
 description: A Helm chart for shipping k8s logs to logz.io via Filebeat and Winlogbeat.
-version: 0.0.5
+version: 0.1.0
 appVersion: 7.8.1

--- a/charts/filebeat/templates/daemonset.yaml
+++ b/charts/filebeat/templates/daemonset.yaml
@@ -32,21 +32,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: LOGZIO_LOGS_SHIPPING_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: logzio-logs-secret
-              key: logzio-logs-shipping-token
-        - name: LOGZIO_LOGS_LISTENER_HOST
-          valueFrom:
-            secretKeyRef:
-              name: logzio-logs-secret
-              key: logzio-logs-listener
-        - name: CLUSTER_NAME
-          valueFrom:
-            secretKeyRef:
-              name: logzio-logs-secret
-              key: cluster-name
         - name: IGNORE_OLDER
           value: {{ .Values.daemonset.ignoreOlder }}
         - name: LOGZIO_CODEC
@@ -55,6 +40,12 @@ spec:
           value: {{ .Values.daemonset.logzioType }}
         - name: FIELDS_UNDER_ROOT
           value: {{ quote .Values.daemonset.fieldsUnderRoot }}
+        envFrom:
+        - secretRef:
+             name: {{ .Values.secrets.name }}
+{{- if .Values.extraEnvFrom }}
+{{- toYaml .Values.extraEnvFrom | nindent 8 }}
+{{- end }}
         securityContext: {{ toYaml ( .Values.daemonset.securityContext ) | nindent 10 }}
         resources: {{ toYaml ( .Values.daemonset.resources ) | nindent 10 }}
         volumeMounts:
@@ -124,21 +115,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: LOGZIO_LOGS_SHIPPING_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: logzio-logs-secret
-              key: logzio-logs-shipping-token
-        - name: LOGZIO_LOGS_LISTENER_HOST
-          valueFrom:
-            secretKeyRef:
-              name: logzio-logs-secret
-              key: logzio-logs-listener
-        - name: CLUSTER_NAME
-          valueFrom:
-            secretKeyRef:
-              name: logzio-logs-secret
-              key: cluster-name
         - name: IGNORE_OLDER
           value: {{ .Values.winlogbeatDaemonset.ignoreOlder }}
         - name: LOGZIO_CODEC
@@ -147,6 +123,12 @@ spec:
           value: {{ .Values.winlogbeatDaemonset.logzioType }}
         - name: FIELDS_UNDER_ROOT
           value: {{ quote .Values.winlogbeatDaemonset.fieldsUnderRoot }}
+        envFrom:
+        - secretRef:
+             name: {{ .Values.secrets.name }}
+{{- if .Values.extraEnvFrom }}
+{{- toYaml .Values.extraEnvFrom | nindent 8 }}
+{{- end }}
         resources: {{ toYaml ( .Values.winlogbeatDaemonset.resources ) | nindent 10 }}
         volumeMounts:
         - name: data
@@ -209,21 +191,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: LOGZIO_LOGS_SHIPPING_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: logzio-logs-secret
-              key: logzio-logs-shipping-token
-        - name: LOGZIO_LOGS_LISTENER_HOST
-          valueFrom:
-            secretKeyRef:
-              name: logzio-logs-secret
-              key: logzio-logs-listener
-        - name: CLUSTER_NAME
-          valueFrom:
-            secretKeyRef:
-              name: logzio-logs-secret
-              key: cluster-name
         - name: IGNORE_OLDER
           value: {{ .Values.filebeatWindowsDaemonset.ignoreOlder }}
         - name: LOGZIO_CODEC
@@ -232,6 +199,12 @@ spec:
           value: {{ .Values.filebeatWindowsDaemonset.logzioType }}
         - name: FIELDS_UNDER_ROOT
           value: {{ quote .Values.filebeatWindowsDaemonset.fieldsUnderRoot }}
+        envFrom:
+        - secretRef:
+             name: {{ .Values.secrets.name }}
+{{- if .Values.extraEnvFrom }}
+{{- toYaml .Values.extraEnvFrom | nindent 8 }}
+{{- end }}
         resources: {{ toYaml ( .Values.filebeatWindowsDaemonset.resources ) | nindent 10 }}
         volumeMounts:
         - name: data

--- a/charts/filebeat/templates/secrets.yaml
+++ b/charts/filebeat/templates/secrets.yaml
@@ -2,11 +2,11 @@
 apiVersion: {{ .Values.apiVersions.secret }}
 kind: Secret
 metadata:
-  name: logzio-logs-secret
+  name: {{ .Values.secrets.name }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
-  logzio-logs-shipping-token: {{ .Values.secrets.logzioShippingToken }}
-  logzio-logs-listener: {{ template "logzio.listenerHost" . }}
-  cluster-name: {{ .Values.secrets.clusterName }}
+  LOGZIO_LOGS_SHIPPING_TOKEN: {{ .Values.secrets.logzioShippingToken }}
+  LOGZIO_LOGS_LISTENER_HOST: {{ template "logzio.listenerHost" . }}
+  CLUSTER_NAME: {{ .Values.secrets.clusterName }}
 {{- end -}}

--- a/charts/filebeat/templates/secrets.yaml
+++ b/charts/filebeat/templates/secrets.yaml
@@ -9,10 +9,8 @@ stringData:
   {{- if .Values.secrets.logzioShippingToken }}
   LOGZIO_LOGS_SHIPPING_TOKEN: {{ .Values.secrets.logzioShippingToken }}
   {{- end }}
-  {{- if .Values.secrets.logzioShippingToken }}
   LOGZIO_LOGS_LISTENER_HOST: {{ template "logzio.listenerHost" . }}
-  {{- end }}
-  {{- if .Values.secrets.logzioShippingToken }}
+  {{- if .Values.secrets.clusterName }}
   CLUSTER_NAME: {{ .Values.secrets.clusterName }}
   {{- end }}
 {{- end -}}

--- a/charts/filebeat/templates/secrets.yaml
+++ b/charts/filebeat/templates/secrets.yaml
@@ -6,7 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
+  {{- if .Values.secrets.logzioShippingToken }}
   LOGZIO_LOGS_SHIPPING_TOKEN: {{ .Values.secrets.logzioShippingToken }}
+  {{- end }}
+  {{- if .Values.secrets.logzioShippingToken }}
   LOGZIO_LOGS_LISTENER_HOST: {{ template "logzio.listenerHost" . }}
+  {{- end }}
+  {{- if .Values.secrets.logzioShippingToken }}
   CLUSTER_NAME: {{ .Values.secrets.clusterName }}
+  {{- end }}
 {{- end -}}

--- a/charts/filebeat/values.yaml
+++ b/charts/filebeat/values.yaml
@@ -9,9 +9,7 @@ winlogbeatImageTag: 0.0.1
 filebeatWindowsImage: docker.io/logzio/logzio-filebeat-win
 filebeatWindowsImageTag: 0.0.1
 
-extraEnvFrom:
-- secretRef:
-     name: test
+extraEnvFrom: []
 
 apiVersions:
   configMap: v1

--- a/charts/filebeat/values.yaml
+++ b/charts/filebeat/values.yaml
@@ -9,6 +9,10 @@ winlogbeatImageTag: 0.0.1
 filebeatWindowsImage: docker.io/logzio/logzio-filebeat-win
 filebeatWindowsImageTag: 0.0.1
 
+extraEnvFrom:
+- secretRef:
+     name: test
+
 apiVersions:
   configMap: v1
   daemonset: apps/v1
@@ -324,7 +328,8 @@ filebeatWindowsDaemonset:
       readOnly: true
 
 secrets:
-  create: true
+  create: false
   logzioShippingToken: ""
   logzioRegion: " "
   clusterName: ""
+  name: logzio-logs-secret

--- a/charts/filebeat/values.yaml
+++ b/charts/filebeat/values.yaml
@@ -328,7 +328,7 @@ filebeatWindowsDaemonset:
       readOnly: true
 
 secrets:
-  create: false
+  create: true
   logzioShippingToken: ""
   logzioRegion: " "
   clusterName: ""


### PR DESCRIPTION
The current chart forces the user to provide LOGZIO_LOGS_SHIPPING_TOKEN, LOGZIO_LOGS_LISTENER_HOST, and CLUSTER_NAME in the same secret. 

We need to provide these variables in different secrets due to deployment restrictions for deploying this charts with GitOps. 

We want to provide the CLUSTER_NAME in a separate secret/input from LOGZIO_LOGS_SHIPPING_TOKEN.