### PR TITLE
Add namespace override support

### DIFF
--- a/charts/filebeat/Chart.yaml
+++ b/charts/filebeat/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: logzio-k8s-logs
 description: A Helm chart for shipping k8s logs to logz.io via Filebeat and Winlogbeat.
-version: 0.0.5
+version: 0.0.6
 appVersion: 7.8.1

--- a/charts/filebeat/README.md
+++ b/charts/filebeat/README.md
@@ -130,7 +130,7 @@ Give your logs some time to get from your system to ours, and then open [Logz.io
 | `winglogbeatImageTag` | The winlogbeat docker image tag. | `0.0.1` |
 | `nameOverride` | Overrides the Chart name for resources. | `""` |
 | `fullnameOverride` | Overrides the full name of the resources. | `filebeat` |
-| `namespaceOverride` | Overrides the namespace of the resources. | `.Release.Namespace` |
+| `namespaceOverride` | Overrides the namespace of the resources. | `""` |
 | `apiVersions.configMap` | ConfigMap API version. | `v1` |
 | `apiVersions.daemonset` | Daemonset API version. | `apps/v1` |
 | `apiVersions.clusterRoleBinding` | ClusterRoleBinding API version. | `rbac.authorization.k8s.io/v1` |

--- a/charts/filebeat/README.md
+++ b/charts/filebeat/README.md
@@ -130,6 +130,7 @@ Give your logs some time to get from your system to ours, and then open [Logz.io
 | `winglogbeatImageTag` | The winlogbeat docker image tag. | `0.0.1` |
 | `nameOverride` | Overrides the Chart name for resources. | `""` |
 | `fullnameOverride` | Overrides the full name of the resources. | `filebeat` |
+| `namespaceOverride` | Overrides the namespace of the resources. | `.Release.Namespace` |
 | `apiVersions.configMap` | ConfigMap API version. | `v1` |
 | `apiVersions.daemonset` | Daemonset API version. | `apps/v1` |
 | `apiVersions.clusterRoleBinding` | ClusterRoleBinding API version. | `rbac.authorization.k8s.io/v1` |
@@ -229,6 +230,8 @@ kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.tain
 
 
 ## Change log
+ - **0.0.6**:
+    - Added namespace override support, with new parameter `namespaceOverride`.
  - **0.0.5**:
     - Allow ability to toggle secrets creation, with new parameter `secrets.create`.
  - **0.0.4**:

--- a/charts/filebeat/templates/_helpers.tpl
+++ b/charts/filebeat/templates/_helpers.tpl
@@ -38,3 +38,10 @@ Convert logzio region code to listener host
 {{- printf "listener-%s.logz.io" .Values.secrets.logzioRegion -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the namespace name
+*/}}
+{{- define "filebeat.namespace" -}}
+{{ .Values.namespaceOverride | default .Release.Namespace }}
+{{- end -}}

--- a/charts/filebeat/templates/clusterrolebinding.yaml
+++ b/charts/filebeat/templates/clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ template "filebeat.serviceAccount" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "filebeat.namespace" . }}
 roleRef:
   kind: ClusterRole
   name: filebeat

--- a/charts/filebeat/templates/configmap.yaml
+++ b/charts/filebeat/templates/configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ .Values.apiVersions.configMap }}
 kind: ConfigMap
 metadata:
   name: logzio-logs-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "filebeat.namespace" . }}
   labels:
     k8s-app: filebeat
 data:
@@ -20,7 +20,7 @@ apiVersion: {{ .Values.apiVersions.configMap }}
 kind: ConfigMap
 metadata:
   name: filebeat-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "filebeat.namespace" . }}
   labels:
     k8s-app: filebeat
 data:
@@ -48,7 +48,7 @@ apiVersion: {{ .Values.apiVersions.configMap }}
 kind: ConfigMap
 metadata:
   name: winlogbeat-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "filebeat.namespace" . }}
   labels:
     k8s-app: filebeat
 data:
@@ -66,7 +66,7 @@ apiVersion: {{ .Values.apiVersions.configMap }}
 kind: ConfigMap
 metadata:
   name: filebeat-windows-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "filebeat.namespace" . }}
   labels:
     k8s-app: filebeat
 data:

--- a/charts/filebeat/templates/daemonset.yaml
+++ b/charts/filebeat/templates/daemonset.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ .Values.apiVersions.daemonset }}
 kind: DaemonSet
 metadata:
   name: filebeat
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "filebeat.namespace" . }}
   labels:
     k8s-app: filebeat
 spec:
@@ -98,7 +98,7 @@ apiVersion: {{ .Values.apiVersions.daemonset }}
 kind: DaemonSet
 metadata:
   name: winlogbeat
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "filebeat.namespace" . }}
   labels:
     k8s-app: filebeat
 spec:
@@ -183,7 +183,7 @@ apiVersion: {{ .Values.apiVersions.daemonset }}
 kind: DaemonSet
 metadata:
   name: filebeat-win
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "filebeat.namespace" . }}
   labels:
     k8s-app: filebeat
 spec:

--- a/charts/filebeat/templates/secrets.yaml
+++ b/charts/filebeat/templates/secrets.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ .Values.apiVersions.secret }}
 kind: Secret
 metadata:
   name: logzio-logs-secret
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "filebeat.namespace" . }}
 type: Opaque
 stringData:
   logzio-logs-shipping-token: {{ .Values.secrets.logzioShippingToken }}

--- a/charts/filebeat/templates/serviceaccount.yaml
+++ b/charts/filebeat/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ .Values.apiVersions.serviceAccount }}
 kind: ServiceAccount
 metadata:
   name: filebeat
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "filebeat.namespace" . }}
   labels:
     k8s-app: filebeat
 {{- end -}}

--- a/charts/filebeat/values.yaml
+++ b/charts/filebeat/values.yaml
@@ -1,6 +1,7 @@
 image: docker.elastic.co/beats/filebeat
 imageTag: 7.8.1
 nameOverride: ""
+namespaceOverride: ""
 fullnameOverride: filebeat
 
 winlogbeatImage: docker.io/logzio/logzio-winlogbeat


### PR DESCRIPTION
Added `namespaceOverride` support, so we can use this chart as part of an umbrella chart that deploys charts to different namespaces.