### PR TITLE
fix template to add right includes

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.6.0
+version: 0.6.1
 appVersion: 1.1.1
 maintainers:
   - name: Miri Ignatiev

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -237,7 +237,7 @@ logzio-fluentd logzio-helm/logzio-fluentd
 ## Change log
 
  - **0.6.1**:
-   - Fix bug for `extraConfig` (#114).
+   - Fix bug for `extraConfig` ([#114](https://github.com/logzio/logzio-helm/issues/114)).
  - **0.6.0**:
    - Added `daemonset.priorityClassName` and `windowsDaemonset.priorityClassName`.
 

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -235,8 +235,15 @@ logzio-fluentd logzio-helm/logzio-fluentd
 
 
 ## Change log
- - **0.6.0**
+
+ - **0.6.1**:
+   - Fix bug for `extraConfig` (#114).
+ - **0.6.0**:
    - Added `daemonset.priorityClassName` and `windowsDaemonset.priorityClassName`.
+
+<details>
+  <summary markdown="span"> Expand to check old versions </summary>
+
  - **0.5.0**:
    - Add support for `daemonset.affinity` value.
    - Add support for fargate logging.
@@ -262,3 +269,5 @@ logzio-fluentd logzio-helm/logzio-fluentd
     - Fix templates name - allow dyncmically change it.
  - **0.0.1**:
     - Initial release.
+
+</details>

--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -47,10 +47,9 @@ Builds the fluent.conf with all the includes
 {{- printf .Values.configMapIncludes }}
 {{- if .Values.configmap.extraConfig -}}
 {{- range $key, $value := fromYaml .Values.configmap.extraConfig }}
-{{- printf "@include %s" $key }}
+{{- printf "@include %s\n" $key }}
 {{- end -}}
 {{- end -}}
-{{- printf "\n" }}
 {{- printf "%s" .Values.configmap.fluent }}
 {{- end -}}
 


### PR DESCRIPTION
This PR fixes #114 :
- Fix the template that is responsible for adding the includes for the fluentd config.