### PR TITLE
logzio-telemetry `0.0.3` logzio-monitoring `0.1.1`

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "0.0.2"
+    version: "0.0.3"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
 

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics and traces from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, and Fluentd for logs.
 type: application
-version: 0.1.0
+version: 0.1.1
 
 sources:
   - https://github.com/logzio/logzio-helm

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -115,6 +115,8 @@ logzio-monitoring logzio-helm/logzio-monitoring
 ```
 
 ## Changelog
+- **0.1.1**:
+	- Upgrade `logzio-telemetry` Chart to `0.0.3`.
 - **0.1.0**:
 	- Add support for fargate logging
 	- Upgrade `logzio-fluentd` Chart to `0.5.0`.

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -11,15 +11,15 @@ dependencies:
   - name: kube-state-metrics
     version: "4.13.0"
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: kubeStateMetrics.enabled
+    condition: metrics.enabled, kubeStateMetrics.enabled
   - name: prometheus-node-exporter
     version: "3.3.0"
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: nodeExporter.enabled
+    condition: metrics.enabled, nodeExporter.enabled
   - name: prometheus-pushgateway
     version: "1.18.2"
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: pushGateway.enabled
+    condition: metrics.enabled, pushGateway.enabled
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -9,26 +9,26 @@ sources:
   - https://github.com/kubernetes/kube-state-metrics
 dependencies:
   - name: kube-state-metrics
-    version: "4.7.0"
+    version: "4.13.0"
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: metrics.enabled, kubeStateMetrics.enabled
+    condition: kubeStateMetrics.enabled
   - name: prometheus-node-exporter
-    version: "2.0.4"
+    version: "3.3.0"
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: metrics.enabled, nodeExporter.enabled
+    condition: nodeExporter.enabled
   - name: prometheus-pushgateway
-    version: "1.16.1"
+    version: "1.18.2"
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: metrics.enabled, pushGateway.enabled
+    condition: pushGateway.enabled
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.42.0
+appVersion: 0.56.0
 
 maintainers:
 - name: yotamloe

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -186,6 +186,12 @@ helm uninstall logzio-k8s-telemetry
 
 
 ## Change log
+* 0.0.3
+  - Dep: kube-state-metrics -> `4.13.0`
+  - Dep: prometheus-node-exporter -> `3.3.0`
+  - Dep: prometheus-pushgateway -> `1.18.2`
+  - Remove batch processor from metrics pipeline
+  - Modify resource limitations
 * 0.0.2
   - Add default `nodeAffinity` to prevent node exporter deamonset deploymment on fargate nodes
 * 0.0.1 - Initial release

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -283,7 +283,6 @@ metricsConfig:
           - prometheusremotewrite
         processors:
           - memory_limiter
-          - batch
         receivers:
           - prometheus
 
@@ -526,8 +525,8 @@ standaloneCollector:
 
   resources:
     limits:
-      cpu: 2560m
-      memory: 5120Mi
+      cpu: 1280m
+      memory: 2560Mi
 
   podAnnotations: {}
   # Configuration override that will be merged into the agent's default config


### PR DESCRIPTION
### logzio-telemetry:
- Dep: kube-state-metrics -> `4.13.0`
- Dep: prometheus-node-exporter -> `3.3.0`
- Dep: prometheus-pushgateway -> `1.18.2`
- Remove batch processor from metrics pipeline
- Modify resource limitations