### PR TITLE
Added support for changing the secretName

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.6.1
+version: 0.7.0
 appVersion: 1.1.1
 maintainers:
   - name: Miri Ignatiev

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -239,14 +239,17 @@ logzio-fluentd logzio-helm/logzio-fluentd
 
 ## Change log
 
+ - **0.7.0**:
+   - Add ability to change the secret name with `secretName`. [#133](https://github.com/logzio/logzio-helm/pull/133)
  - **0.6.1**:
    - Fix bug for `extraConfig` ([#114](https://github.com/logzio/logzio-helm/issues/114)).
- - **0.6.0**:
-   - Added `daemonset.priorityClassName` and `windowsDaemonset.priorityClassName`.
+
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>
 
+ - **0.6.0**:
+   - Added `daemonset.priorityClassName` and `windowsDaemonset.priorityClassName`.
  - **0.5.0**:
    - Add support for `daemonset.affinity` value.
    - Add support for fargate logging.

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -40,6 +40,8 @@ helm install -n monitoring \
 logzio-fluentd logzio-helm/logzio-fluentd
 ```
 
+In case it's not possible or secure to add the secret from the helm chart (e.g. no secure value-file storage) it is possible to override the name of the secret by overriding secretName in the values file. This way an external secret with the keys logzioShippingToken and logzioListener can be placed by other means. 
+
 #### 4. Check Logz.io for your logs
 
 Give your logs some time to get from your system to ours, and then open [Logz.io](https://app.logz.io/).
@@ -129,6 +131,7 @@ helm install -n monitoring \
 | `clusterRole.rules` | Configurable [cluster role rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) that Fluentd uses to access Kubernetes resources. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 | `secrets.logzioShippingToken` | Secret with your [logzio shipping token](https://app.logz.io/#/dashboard/settings/general). | `""` |
 | `secrets.logzioListener` | Secret with your logzio listener host. `listener.logz.io`. | `" "` |
+| `secretName` | Name of the secret in case it's placed from an external source. | `logzio-logs-secret` |
 | `configMapIncludes` | Initial includes for `fluent.conf`. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 | `configmap.extraConfig` | If needed, more Fluentd configuration can be added with this field. | `{}` |
 | `configmap.fluent` | Configuration for `fluent.conf`. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -55,12 +55,12 @@ spec:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:
             secretKeyRef:
-              name: logzio-logs-secret
+              name: {{ .Values.secretName }}
               key: logzio-log-shipping-token
         - name: LOGZIO_LOG_LISTENER
           valueFrom:
             secretKeyRef:
-              name: logzio-logs-secret
+              name: {{ .Values.secretName }}
               key: logzio-log-listener
         - name: LOGZIO_BUFFER_TYPE
           value: {{ .Values.daemonset.logzioBufferType | quote }}
@@ -178,12 +178,12 @@ spec:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:
             secretKeyRef:
-              name: logzio-logs-secret
+              name: {{ .Values.secretName }}
               key: logzio-log-shipping-token
         - name: LOGZIO_LOG_LISTENER
           valueFrom:
             secretKeyRef:
-              name: logzio-logs-secret
+              name: {{ .Values.secretName }}
               key: logzio-log-listener
         - name: LOGZIO_BUFFER_TYPE
           value: {{ .Values.windowsDaemonset.logzioBufferType | quote }}

--- a/charts/fluentd/templates/secret.yaml
+++ b/charts/fluentd/templates/secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ .Values.apiVersions.secret }}
 kind: Secret
 metadata:
-  name: logzio-logs-secret
+  name: {{ .Values.secretName }}
   namespace: {{ .Values.namespace }}
 type: Opaque
 stringData:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -128,6 +128,8 @@ secrets:
   logzioShippingToken: ""
   logzioListener: ""
 
+secretName: logzio-logs-secret
+
 configMapIncludes: |
   @include "#{ENV['FLUENTD_SYSTEMD_CONF'] || 'systemd'}.conf"
   @include "#{ENV['FLUENTD_PROMETHEUS_CONF'] || 'prometheus'}.conf"


### PR DESCRIPTION
In our environment we manage/place secrets only by means of the Secret storage driver or Vault. With this fix we can set an other secret name for fluentd so we can reference a secret managed by an external source.