### PR TITLE
update readmes to point to logzio monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@ This repo contains Helm charts for shipping logs, metrics and traces to Logz.io.
 
 Please look in the chart directories for the documentation for each chart.
 
+
+* [Logzio Monitoring](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-monitoring) - A unified chart for shipping logs, metrics and traces.
 * [Dotnet Monitor](https://github.com/logzio/logzio-helm/tree/master/charts/dotnet-monitor)
 * [Filebeat](https://github.com/logzio/logzio-helm/tree/master/charts/filebeat)
 * [Fluentbit](https://github.com/logzio/logzio-helm/tree/master/charts/fluentbit)
 * [Fluentd](https://github.com/logzio/logzio-helm/tree/master/charts/fluentd)
-* [Opentelemetry for metrics](https://github.com/logzio/logzio-helm/tree/master/charts/opentelemetry)
-* [Opentelemetry for traces](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-otel-traces)
 * [Opentelemetry for spm](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-otel-spm)
-

--- a/charts/filebeat/README.md
+++ b/charts/filebeat/README.md
@@ -4,6 +4,8 @@ Helm is a tool for managing packages of pre-configured Kubernetes resources usin
 Logzio-k8s-logs allows you to ship logs from your Kubernetes cluster to Logz.io.
 You can either deploy this Daemonset with the standrad configuration, or with autodiscover configuration. For further information about Filebeat's autodiscover please see [Autodiscover documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover.html).
 
+**Note**: This chart is for shipping logs only. For a chart that ships all telemetry (logs, metrics, traces) - use our [Logzio Monitoring chart](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-monitoring).
+
 
 ### Prerequisites:
 * [Helm CLI](https://helm.sh/docs/intro/install/) installed

--- a/charts/fluentbit/README.md
+++ b/charts/fluentbit/README.md
@@ -1,12 +1,12 @@
-
 # Logzio fluentbit helm chart
 
 ##  Overview
 
 You can use this Helm chart to ship Kubernetes logs to Logz.io with fluentbit.
+This chart is based on the [fluent-bit](https://github.com/fluent/helm-charts/tree/main/charts/fluent-bit) Helm chart. 
 
+**Note**: This chart is for shipping logs only. For a chart that ships all telemetry (logs, metrics, traces) - use our [Logzio Monitoring chart](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-monitoring).
 
-**Note:** This chart is based on the [fluent-bit](https://github.com/fluent/helm-charts/tree/main/charts/fluent-bit) Helm chart. 
 #### Standard configuration
 
 ##### Deploy the Helm chart

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -5,7 +5,9 @@
 Logzio-fluentd allows you to ship logs from your Kubernetes cluster to Logz.io, using Fluentd.
 Fluentd is flexible enough and has the proper plugins to distribute logs to different third parties such as Logz.io.
 
-**Note:** The chart defaults to configuration for Conatinerd CRI. If your cluster uses Docker as CRI, please refer to `daemonset.containerdRuntime` in the [configuration table](https://github.com/logzio/logzio-helm/tree/master/charts/fluentd#configuration).
+The chart defaults to configuration for Conatinerd CRI. If your cluster uses Docker as CRI, please refer to `daemonset.containerdRuntime` in the [configuration table](https://github.com/logzio/logzio-helm/tree/master/charts/fluentd#configuration).
+
+**Note**: This chart is for shipping logs only. For a chart that ships all telemetry (logs, metrics, traces) - use our [Logzio Monitoring chart](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-monitoring).
 
 ### Deploying the Chart:
 

--- a/charts/logzio-otel-traces/README.md
+++ b/charts/logzio-otel-traces/README.md
@@ -1,6 +1,11 @@
 
 # Logzio-otel-traces
 
+## Warning ⚠️ : This chart is deprecated and no longer maintained.
+
+Migrate to [Logzio Monitoring chart](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-monitoring).
+
+
 ##  Overview
 
 You can use a Helm chart to ship Traces to Logz.io via the OpenTelemetry collector.
@@ -9,6 +14,8 @@ The Helm tool is used to manage packages of pre-configured Kubernetes resources 
 **logzio-otel-traces** allows you to ship traces from your Kubernetes cluster to Logz.io with the OpenTelemetry collector.
 
 **Note:** This chart is a fork of the [opentelemtry-collector](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) Helm chart.
+
+**Note**: This chart is for shipping traces only. For a chart that ships all telemetry (logs, metrics, traces) - use our [Logzio Monitoring chart](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-monitoring).
 
 #### Standard configuration
 

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -1,5 +1,6 @@
-
 # Logzio-k8s-telemetry
+
+**Note**: This chart is for shipping metrics and traces only. For a chart that ships all telemetry (logs, metrics, traces) - use our [Logzio Monitoring chart](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-monitoring).
 
 ##  Overview
 
@@ -11,6 +12,8 @@ The Helm tool is used to manage packages of pre-configured Kubernetes resources 
 **Note:** This chart is a fork of the [opentelemtry-collector](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) Helm chart. 
 It is also dependent on the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) and [prometheus-node-exporter](https://github.com/helm/charts/tree/master/stable/prometheus-node-exporter) charts, which are installed by default. 
 To disable the dependency during installation, set `kubeStateMetrics.enabled` and `nodeExporter` to `false`.
+
+
 
 #### Before installing the chart
 Check if you have any taints on your nodes:

--- a/charts/opentelemetry/README.md
+++ b/charts/opentelemetry/README.md
@@ -1,5 +1,8 @@
-
 # Logzio-otel-k8s-metrics
+
+## Warning ⚠️ : This chart is deprecated and no longer maintained
+
+Migrate to [Logzio Monitoring chart](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-monitoring).
 
 ##  Overview
 
@@ -11,6 +14,8 @@ The Helm tool is used to manage packages of pre-configured Kubernetes resources 
 **Note:** This chart is a fork of the [opentelemtry-collector](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) Helm chart. 
 It is also dependent on the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) and [prometheus-node-exporter](https://github.com/helm/charts/tree/master/stable/prometheus-node-exporter) charts, which are installed by default. 
 To disable the dependency during installation, set `kubeStateMetrics.enabled` and `nodeExporter` to `false`.
+
+**Note**: This chart is for shipping metrics only. For a chart that ships all telemetry (logs, metrics, traces) - use our [Logzio Monitoring chart](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-monitoring).
 
 #### Before installing the chart
 


### PR DESCRIPTION
In this PR:
- In main readme:
  - Remove links to `opentelemetry` (metrics only), `logzio-otel-traces` (traces only).
  - Add link to `logzio-monitoring (unified chart).
- Add deprecation note for `opentelemetry` (metrics only), `logzio-otel-traces` (traces only).
- Add note that references `logzio-monitoring` in: `fluentd`, `fluentbit`, `filebeat`, `logzio-telemetry`, `opentelemetry`, `logzio-otel-traces`.