### PR TITLE
upgrade image fluentd

### DIFF
--- a/.github/workflows/git-secrets.yml
+++ b/.github/workflows/git-secrets.yml
@@ -1,23 +1,19 @@
 name: git-secrets
-
 # Controls when the workflow will run
 # Triggers the workflow on push or pull request events but only for the main branch
 on: [push]
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "main"
   git-secrets:
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Check Out Source Code
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v3
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Installing dependencies
@@ -26,6 +22,7 @@ jobs:
       - name: Installing scanning tool
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          ln -s "$(which echo)" /usr/local/bin/say
           brew install git-secrets
           git secrets --install
           git secrets --register-aws 

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.10.0
-appVersion: 1.1.1
+version: 0.11.0
+appVersion: 1.2.0
 maintainers:
   - name: Miri Ignatiev
     email: miri.ignatiev@logz.io

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -63,7 +63,7 @@ helm install -n monitoring \
 | Parameter | Description | Default |
 |---|---|---|
 | `image` | The logzio-fluentd docker image. | `logzio/logzio-fluentd` |
-| `imageTag` | The logzio-fluentd docker image tag. | `1.1.1` |
+| `imageTag` | The logzio-fluentd docker image tag. | `1.2.0` |
 | `nameOverride` | Overrides the Chart name for resources. | `""` |
 | `fullnameOverride` | Overrides the full name of the resources. | `""` |
 | `apiVersions.daemonset` | Daemonset API version. | `apps/v1` |
@@ -260,14 +260,19 @@ logzio-fluentd logzio-helm/logzio-fluentd
 
 
 ## Change log
+ - **0.11.0**:
+   - Upgrade image `logzio/logzio-fluentd:1.2.0`:
+     - Upgrade to `fluentd 1.15`.
+     - Upgrade plugin `fluent-plugin-kubernetes_metadata_filter` to `3.1.2`.
  - **0.10.0**:
    - Added an option to parse `log_type` annotation into `log_type` field.
- - **0.9.0**:
-   - Added a default value for `env_id` field.
+
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>
-
+ 
+ - **0.9.0**:
+   - Added a default value for `env_id` field.
  - **0.8.0**:
    - Add ability to add environment id with `env_id` field.
  - **0.7.0**:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -1,5 +1,5 @@
 image: logzio/logzio-fluentd
-imageTag: 1.1.1
+imageTag: 1.2.0
 
 windowsImage: logzio/fluentd-windows
 windowsImageTag: 0.0.1


### PR DESCRIPTION
 - **0.11.0**:
   - Upgrade image `logzio/logzio-fluentd:1.2.0`:
     - Upgrade to `fluentd 1.15`.
     - Upgrade plugin `fluent-plugin-kubernetes_metadata_filter` to `3.1.2`.

This PR also contains a fix for the `git-secrets` action.