### PR TITLE
logzio-telemetry-0.0.9

### DIFF
--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -245,7 +245,7 @@ helm uninstall logzio-k8s-telemetry
 
 
 ## Change log
-* 0.0.8
+* 0.0.9
   - Remove `decision_wait` `num_traces` `expected_new_traces_per_sec` options from the tail sampling proccessor, in order to use the otel default values for the proccessor
   - Fix typos
 * 0.0.8

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -246,6 +246,9 @@ helm uninstall logzio-k8s-telemetry
 
 ## Change log
 * 0.0.8
+  - Remove `decision_wait` `num_traces` `expected_new_traces_per_sec` options from the tail sampling proccessor, in order to use the otel default values for the proccessor
+  - Fix typos
+* 0.0.8
   - Changed default value for `env_id`
 * 0.0.7
   - Added default value for `env_id`

--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -68,12 +68,12 @@ containers:
         valueFrom:
           secretKeyRef:
             name: logzio-secret
-            key: sampeling-probability
+            key: sampling-probability
       - name: SAMPLING_LATENCY
         valueFrom:
           secretKeyRef:
             name: logzio-secret
-            key: sampeling-latency
+            key: sampling-latency
 {{ if .Values.spm.enabled }}
       - name: SPM_TOKEN
         valueFrom:

--- a/charts/logzio-telemetry/templates/secrets.yaml
+++ b/charts/logzio-telemetry/templates/secrets.yaml
@@ -15,8 +15,8 @@ stringData:
 {{- if .Values.traces.enabled }}
   logzio-traces-shipping-token: {{ .Values.secrets.TracesToken }}
   logzio-listener-region: {{ .Values.secrets.LogzioRegion}}
-  sampeling-latency: {{ .Values.secrets.SampelingLatency | quote }}
-  sampeling-probability: {{ .Values.secrets.SampelingProbability | quote}}
+  sampling-latency: {{ .Values.secrets.SamplingLatency | quote }}
+  sampling-probability: {{ .Values.secrets.SamplingProbability | quote}}
 {{ if .Values.spm.enabled }}
   logzio-spm-shipping-token: {{ .Values.secrets.SpmToken }}
 {{ end }}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -151,9 +151,6 @@ baseCollectorConfig:
           action: insert
     memory_limiter: null
     tail_sampling:
-      decision_wait: 30s
-      num_traces: 1000
-      expected_new_traces_per_sec: 20
       policies:
         [
             {


### PR DESCRIPTION
  - Remove `decision_wait` `num_traces` `expected_new_traces_per_sec` options from the tail sampling proccessor, in order to use the otel default values for the proccessor
  - Fix typos