### PR TITLE
fix: allow external secretName instead of a default one

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.16.0
-appVersion: 1.2.0
+version: 0.17.0
+appVersion: 1.3.0
 maintainers:
   - name: Miri Ignatiev
     email: miri.ignatiev@logz.io

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -261,20 +261,18 @@ logzio-fluentd logzio-helm/logzio-fluentd
 
 
 ## Change log
+ - **0.17.0**:
+   - Add `secrets.enabled` to control secret creation and management. ([#194](https://github.com/logzio/logzio-helm/pull/194))
  - **0.16.0**:
    - Inreased memory request and limit to 500Mi, cpu request to 200m.
  - **0.15.0**:
    - Added dedot processor - auto replace `.` in log field to `_`.
- - **0.14.0**:
-   - Fix typo in `fargateLogRouter`
-
-
-
-
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>
  
+  - **0.14.0**:
+   - Fix typo in `fargateLogRouter`
  - **0.13.0**:
    - Removal of field `log_type`. Auto populating `type` instead.
  - **0.12.0**:

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -134,6 +134,7 @@ helm install -n monitoring \
 | `clusterRole.rules` | Configurable [cluster role rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) that Fluentd uses to access Kubernetes resources. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 | `secrets.logzioShippingToken` | Secret with your [logzio shipping token](https://app.logz.io/#/dashboard/settings/general). | `""` |
 | `secrets.logzioListener` | Secret with your logzio listener host. `listener.logz.io`. | `" "` |
+| `secrets.enabled` | When `true`, the logzio secret will be created and managed by this Chart. If you're managing the logzio secret by yourself, set to `false`. | `true` |
 | `secretName` | Name of the secret in case it's placed from an external source. | `logzio-logs-secret` |
 | `configMapIncludes` | Initial includes for `fluent.conf`. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 | `configmap.extraConfig` | If needed, more Fluentd configuration can be added with this field. | `{}` |

--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -75,3 +75,11 @@ Builds the list for exclude paths in the tail for the containers - windows
 {{- print .Values.windowsDaemonset.excludeFluentdPath }}
 {{- end -}}
 {{- end -}}
+
+{{- define "logzio.secretName" }}
+{{- if .Values.secretName }}
+{{- print .Values.secretName }}
+{{- else }}
+{{- print .Values.defaultSecretName }}
+{{- end -}}
+{{- end -}}

--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -77,9 +77,5 @@ Builds the list for exclude paths in the tail for the containers - windows
 {{- end -}}
 
 {{- define "logzio.secretName" }}
-{{- if .Values.secretName }}
 {{- print .Values.secretName }}
-{{- else }}
-{{- print .Values.defaultSecretName }}
-{{- end -}}
 {{- end -}}

--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -75,7 +75,3 @@ Builds the list for exclude paths in the tail for the containers - windows
 {{- print .Values.windowsDaemonset.excludeFluentdPath }}
 {{- end -}}
 {{- end -}}
-
-{{- define "logzio.secretName" }}
-{{- print .Values.secretName }}
-{{- end -}}

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -55,12 +55,12 @@ spec:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.secretName }}
+              name: {{ include "logzio.secretName" . }}
               key: logzio-log-shipping-token
         - name: LOGZIO_LOG_LISTENER
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.secretName }}
+              name: {{ include "logzio.secretName" . }}
               key: logzio-log-listener
         - name: LOGZIO_BUFFER_TYPE
           value: {{ .Values.daemonset.logzioBufferType | quote }}
@@ -182,12 +182,12 @@ spec:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.secretName }}
+              name: {{ include "logzio.secretName" . }}
               key: logzio-log-shipping-token
         - name: LOGZIO_LOG_LISTENER
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.secretName }}
+              name: {{ include "logzio.secretName" . }}
               key: logzio-log-listener
         - name: LOGZIO_BUFFER_TYPE
           value: {{ .Values.windowsDaemonset.logzioBufferType | quote }}

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -55,12 +55,12 @@ spec:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ include "logzio.secretName" . }}
+              name: {{ .Values.secretName }}
               key: logzio-log-shipping-token
         - name: LOGZIO_LOG_LISTENER
           valueFrom:
             secretKeyRef:
-              name: {{ include "logzio.secretName" . }}
+              name: {{ .Values.secretName }}
               key: logzio-log-listener
         - name: LOGZIO_BUFFER_TYPE
           value: {{ .Values.daemonset.logzioBufferType | quote }}
@@ -182,12 +182,12 @@ spec:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ include "logzio.secretName" . }}
+              name: {{ .Values.secretName }}
               key: logzio-log-shipping-token
         - name: LOGZIO_LOG_LISTENER
           valueFrom:
             secretKeyRef:
-              name: {{ include "logzio.secretName" . }}
+              name: {{ .Values.secretName }}
               key: logzio-log-listener
         - name: LOGZIO_BUFFER_TYPE
           value: {{ .Values.windowsDaemonset.logzioBufferType | quote }}

--- a/charts/fluentd/templates/secret.yaml
+++ b/charts/fluentd/templates/secret.yaml
@@ -1,9 +1,11 @@
+{{- if not .Values.secretName -}}
 apiVersion: {{ .Values.apiVersions.secret }}
 kind: Secret
 metadata:
-  name: {{ .Values.secretName }}
+  name: logzio-logs-secret
   namespace: {{ .Values.namespace }}
 type: Opaque
 stringData:
   logzio-log-shipping-token: {{ required "Logzio shipping token is required!" .Values.secrets.logzioShippingToken }}
   logzio-log-listener: {{ template "logzio.listenerHost" . }}
+{{- end }}

--- a/charts/fluentd/templates/secret.yaml
+++ b/charts/fluentd/templates/secret.yaml
@@ -1,8 +1,8 @@
-{{- if not .Values.secretName -}}
+{{- if .Values.secrets.enabled -}}
 apiVersion: {{ .Values.apiVersions.secret }}
 kind: Secret
 metadata:
-  name: logzio-logs-secret
+  name: {{ .Values.secretName }}
   namespace: {{ .Values.namespace }}
 type: Opaque
 stringData:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -131,7 +131,7 @@ secrets:
   logzioShippingToken: ""
   logzioListener: ""
 
-secretName: "logzio-logs-secret"
+secretName: logzio-logs-secret
 
 configMapIncludes: |
   @include "#{ENV['FLUENTD_SYSTEMD_CONF'] || 'systemd'}.conf"

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -130,7 +130,7 @@ secrets:
   logzioShippingToken: ""
   logzioListener: ""
 
-secretName: logzio-logs-secret
+defaultSecretName: logzio-logs-secret
 
 configMapIncludes: |
   @include "#{ENV['FLUENTD_SYSTEMD_CONF'] || 'systemd'}.conf"

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -131,6 +131,7 @@ secrets:
   logzioListener: ""
 
 defaultSecretName: logzio-logs-secret
+secretName: ""
 
 configMapIncludes: |
   @include "#{ENV['FLUENTD_SYSTEMD_CONF'] || 'systemd'}.conf"
@@ -255,7 +256,7 @@ configmap:
         @type none
       </parse>
     </source>
-    
+
     <source>
       @type tail
       @id in_tail_kubelet
@@ -339,7 +340,7 @@ configmap:
         @type kubernetes
       </parse>
     </source>
-    
+
     <source>
       @type tail
       @id in_tail_cluster_autoscaler

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -127,11 +127,11 @@ clusterRole:
     - watch
 
 secrets:
+  enabled: true
   logzioShippingToken: ""
   logzioListener: ""
 
-defaultSecretName: logzio-logs-secret
-secretName: ""
+secretName: "logzio-logs-secret"
 
 configMapIncludes: |
   @include "#{ENV['FLUENTD_SYSTEMD_CONF'] || 'systemd'}.conf"


### PR DESCRIPTION
Currently it's not possible to use an external secret source although stated in the documentation: 

> it is possible to override the name of the secret by overriding secretName in the values file. This way an external secret with the keys logzioShippingToken and logzioListener can be placed by other means. 

This commit allows the support of a GitOps approach, where values are pushed into git and should never expose any secrets. 

Ideally this should be covered for all other charts in this repository, otherwise it's not clear how to deploy these charts automatically (GitOps wise at least).

