### PR TITLE
logzio-monitoring-0.1.22

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics and traces from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, and Fluentd for logs.
 type: application
-version: 0.1.21
+version: 0.1.22
 
 sources:
   - https://github.com/logzio/logzio-helm
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "0.0.21"
+    version: "0.0.22"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
 

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -123,6 +123,13 @@ logzio-monitoring logzio-helm/logzio-monitoring
 ```
 
 ## Changelog
+- **0.1.22**:
+	- Upgrade `logzio-k8s-telemetry` Chart to `0.0.22`:
+    - **breaking changes:** Add separate span metrics component that includes the following resources:
+      - `deployment-spm.yaml`
+      - `service-spm.yaml`
+      - `configmap-spm.yaml`
+    - Updated collector image -> `0.70.0`
 - **0.1.21**:
 	- Upgrade `logzio-fluentd` Chart to `0.18.0`:
 		- Added `warn` log level detection.


### PR DESCRIPTION
- **0.1.22**:
	- Upgrade `logzio-k8s-telemetry` Chart to `0.0.22`:
    - **breaking changes:** Add separate span metrics component that includes the following resources:
      - `deployment-spm.yaml`
      - `service-spm.yaml`
      - `configmap-spm.yaml`
    - Updated collector image -> `0.70.0`