### PR TITLE
logzio-monitoring bump logzio-trivy version

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 0.3.0
+version: 0.4.0
 
 sources:
   - https://github.com/logzio/logzio-helm
@@ -16,7 +16,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy
-    version: "0.0.2"
+    version: "0.1.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: securityReport.enabled
 

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -128,11 +128,23 @@ logzio-monitoring logzio-helm/logzio-monitoring
 ```
 
 ## Changelog
+- **0.4.0**:
+	- Upgrade `logzio-trivy` Chart to `0.1.0`:
+		- **Breaking changes:**
+			- Deprecation of CronJob, using Deployment instead.
+			- Scanning for reports will occur once upon container deployment, then once a day at the scheduled time.
+			- Not using cron expressions anymore. Instead, set a time for the daily run in form of HH:MM.
 - **0.3.0**:
 	- Upgrade `logzio-k8s-telemetry` Chart to `0.0.24`:
 	- **breaking changes:** Changes default collector mode to `daemonset`:
       - Controlled using the `logzio-k8s-telemetry.collector.mode` value - supports `daemonset` and `standalone`.
     - Increased memory and cpu limits for the collector pods, to `1024Mi` and `512m`.
+
+
+
+<details>
+  <summary markdown="span"> Expand to check old versions </summary>
+
 - **0.2.1.**:
 	- Upgrade `logzio-trivy` Chart to `0.0.2`:
 		- Bug fix for cron expression.
@@ -141,12 +153,6 @@ logzio-monitoring logzio-helm/logzio-monitoring
 - **0.1.25**:
 	- Upgrade `logzio-k8s-telemetry` Chart to `0.0.23`:
 		- Updated metrics filter.
-
-
-<details>
-  <summary markdown="span"> Expand to check old versions </summary>
-
-
 - **0.1.24**:
 	- Upgrade `logzio-fluentd` Chart to `0.20.0`:
 		- Added support for fluentd monitoring for windows pods.


### PR DESCRIPTION
In logzio-monitoring, bump version of logzio-trivy from `0.0.2` to `0.1.0`.