### PR TITLE
logzio-trivy watch

### DIFF
--- a/charts/logzio-trivy/Chart.yaml
+++ b/charts/logzio-trivy/Chart.yaml
@@ -5,13 +5,13 @@ keywords:
   - logging
   - trivy
   - security
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.2.0
+appVersion: 0.2.0
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: trivy-operator
-    version: "0.11.1"
+    version: "0.12.1"
     repository: "https://aquasecurity.github.io/helm-charts/"
 maintainers:
   - name: Miri Bar

--- a/charts/logzio-trivy/README.md
+++ b/charts/logzio-trivy/README.md
@@ -20,7 +20,7 @@ helm repo update
 Use the following command, and replace the placeholders with your parameters:
 
 ```sh
-helm install -n monitoring \
+helm install -n monitoring --create-namespace \
 --set env_id="<<ENV-ID>>" \
 --set secrets.logzioShippingToken="<<LOG-SHIPPING-TOKEN>>" \
 --set secrets.logzioListener="<<LISTENER-HOST>>" \
@@ -48,7 +48,7 @@ However, you can modify the Chart by using the `--set` flag in your `helm instal
 | `schedule` | Time for daily scanning for security reports and send them to Logz.io, in format "HH:MM" | `"07:00"` |
 | `restartPolicy` | Container restart policy | `OnFailure` |
 | `image` | Container image | `logzio/trivy-to-logzio` |
-| `imageTag` | Container image tag | `0.1.0` |
+| `imageTag` | Container image tag | `0.2.0` |
 | `env_id` | The name for your environment's identifier, to easily identify the telemetry data for each environment | `""` |
 | `terminationGracePeriodSeconds` | Termination period (in seconds) to wait before killing Fluentd pod process on pod shutdown. | `30` |
 | `serviceAccount.create` | Specifies whether to create a service account for the cron job | `true` |
@@ -62,7 +62,7 @@ However, you can modify the Chart by using the `--set` flag in your `helm instal
 
 ## Changelog
 
-- **0.1.1**:
+- **0.2.0**:
   - Upgrade to image `logzio/trivy-to-logzio:0.2.0`:
     - Watch for new reports, in addition to daily scan.
 - **0.1.0**:

--- a/charts/logzio-trivy/README.md
+++ b/charts/logzio-trivy/README.md
@@ -62,6 +62,9 @@ However, you can modify the Chart by using the `--set` flag in your `helm instal
 
 ## Changelog
 
+- **0.1.1**:
+  - Upgrade to image `logzio/trivy-to-logzio:0.2.0`:
+    - Watch for new reports, in addition to daily scan.
 - **0.1.0**:
   - Upgrade to image `logzio/trivy-to-logzio:0.1.0`.
   - **Breaking changes**:

--- a/charts/logzio-trivy/templates/deployment.yaml
+++ b/charts/logzio-trivy/templates/deployment.yaml
@@ -19,7 +19,6 @@ spec:
       containers:
       - name: trivy-to-logzio
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-        imagePullPolicy: Always
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:

--- a/charts/logzio-trivy/values.yaml
+++ b/charts/logzio-trivy/values.yaml
@@ -6,7 +6,7 @@ nameOverride: ""
 fullnameOverride: ""
 schedule: "07:00"
 image: logzio/trivy-to-logzio
-imageTag: 0.1.0
+imageTag: 0.2.0
 env_id: ""
 terminationGracePeriodSeconds: 30
 serviceAccount:


### PR DESCRIPTION
- Upgrade to image 0.2.0 to continuously watch for reports created/changed.
- Upgrade Trivy Operator Helm Chart dependency to 0.12.1