### PR TITLE
logzio-trivy - remove unused reports

### DIFF
--- a/charts/logzio-trivy/Chart.yaml
+++ b/charts/logzio-trivy/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: trivy-operator
-    version: "0.13.0"
+    version: "0.13.1"
     repository: "https://aquasecurity.github.io/helm-charts/"
 maintainers:
   - name: Miri Bar

--- a/charts/logzio-trivy/Chart.yaml
+++ b/charts/logzio-trivy/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: trivy-operator
-    version: "0.12.1"
+    version: "0.13.0"
     repository: "https://aquasecurity.github.io/helm-charts/"
 maintainers:
   - name: Miri Bar

--- a/charts/logzio-trivy/Chart.yaml
+++ b/charts/logzio-trivy/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - trivy
   - security
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.2.0
 sources:
   - https://github.com/logzio/logzio-helm

--- a/charts/logzio-trivy/Chart.yaml
+++ b/charts/logzio-trivy/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - trivy
   - security
 version: 0.2.1
-appVersion: 0.2.0
+appVersion: 0.2.1
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:

--- a/charts/logzio-trivy/README.md
+++ b/charts/logzio-trivy/README.md
@@ -69,6 +69,7 @@ However, you can modify the Chart by using the `--set` flag in your `helm instal
 - **0.2.1**:
   - Default to disable unused reports (config audit, rbac assessment, infra assessment, cluster compliance).
   - Bump Trivy-Operator version to `0.13.0`.
+  - Bump logzio-trivy version to `0.2.1`.
 - **0.2.0**:
   - Upgrade to image `logzio/trivy-to-logzio:0.2.0`:
     - Watch for new reports, in addition to daily scan.

--- a/charts/logzio-trivy/README.md
+++ b/charts/logzio-trivy/README.md
@@ -68,6 +68,7 @@ However, you can modify the Chart by using the `--set` flag in your `helm instal
 
 - **0.2.1**:
   - Default to disable unused reports (config audit, rbac assessment, infra assessment, cluster compliance).
+  - Bump Trivy-Operator version to `0.13.0`.
 - **0.2.0**:
   - Upgrade to image `logzio/trivy-to-logzio:0.2.0`:
     - Watch for new reports, in addition to daily scan.

--- a/charts/logzio-trivy/README.md
+++ b/charts/logzio-trivy/README.md
@@ -44,9 +44,9 @@ However, you can modify the Chart by using the `--set` flag in your `helm instal
 | --- | --- | --- |
 | `trivy-operator.trivy.ignoreUnfixed` | Whether to show only fixed vulnerabilities in vulnerabilities reported by Trivy. | `false` |
 | `trivy-operator.operator.configAuditScannerEnabled` | The flag to enable configuration audit scanner | `false` |
-| `trivy-operator.operator.rbacAssessmentScannerEnabled` | The flag to enable rbac assessment scanner | `true` |
-| `trivy-operator.operator.infraAssessmentScannerEnabled` | The flag to enable infra assessment scanner | `true` |
-| `trivy-operator.operator.clusterComplianceEnabled` | The flag to enable cluster compliance scanner | `true` |
+| `trivy-operator.operator.rbacAssessmentScannerEnabled` | The flag to enable rbac assessment scanner | `false` |
+| `trivy-operator.operator.infraAssessmentScannerEnabled` | The flag to enable infra assessment scanner | `false` |
+| `trivy-operator.operator.clusterComplianceEnabled` | The flag to enable cluster compliance scanner | `false` |
 | `nameOverride` | Overrides the Chart name for resources. | `""` |
 | `fullnameOverride` | Overrides the full name of the resources. | `""` |
 | `schedule` | Time for daily scanning for security reports and send them to Logz.io, in format "HH:MM" | `"07:00"` |

--- a/charts/logzio-trivy/README.md
+++ b/charts/logzio-trivy/README.md
@@ -43,6 +43,10 @@ However, you can modify the Chart by using the `--set` flag in your `helm instal
 | Parameter	| Description | Default |
 | --- | --- | --- |
 | `trivy-operator.trivy.ignoreUnfixed` | Whether to show only fixed vulnerabilities in vulnerabilities reported by Trivy. | `false` |
+| `trivy-operator.operator.configAuditScannerEnabled` | The flag to enable configuration audit scanner | `false` |
+| `trivy-operator.operator.rbacAssessmentScannerEnabled` | The flag to enable rbac assessment scanner | `true` |
+| `trivy-operator.operator.infraAssessmentScannerEnabled` | The flag to enable infra assessment scanner | `true` |
+| `trivy-operator.operator.clusterComplianceEnabled` | The flag to enable cluster compliance scanner | `true` |
 | `nameOverride` | Overrides the Chart name for resources. | `""` |
 | `fullnameOverride` | Overrides the full name of the resources. | `""` |
 | `schedule` | Time for daily scanning for security reports and send them to Logz.io, in format "HH:MM" | `"07:00"` |
@@ -62,6 +66,8 @@ However, you can modify the Chart by using the `--set` flag in your `helm instal
 
 ## Changelog
 
+- **0.2.1**:
+  - Default to disable unused reports (config audit, rbac assessment, infra assessment, cluster compliance).
 - **0.2.0**:
   - Upgrade to image `logzio/trivy-to-logzio:0.2.0`:
     - Watch for new reports, in addition to daily scan.

--- a/charts/logzio-trivy/values.yaml
+++ b/charts/logzio-trivy/values.yaml
@@ -3,9 +3,9 @@ trivy-operator:
     ignoreUnfixed: false
   operator:
     configAuditScannerEnabled: false
-    rbacAssessmentScannerEnabled: true
-    infraAssessmentScannerEnabled: true
-    clusterComplianceEnabled: true
+    rbacAssessmentScannerEnabled: false
+    infraAssessmentScannerEnabled: false
+    clusterComplianceEnabled: false
 
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/logzio-trivy/values.yaml
+++ b/charts/logzio-trivy/values.yaml
@@ -11,7 +11,7 @@ nameOverride: ""
 fullnameOverride: ""
 schedule: "07:00"
 image: logzio/trivy-to-logzio
-imageTag: 0.2.0
+imageTag: 0.2.1
 env_id: ""
 terminationGracePeriodSeconds: 30
 serviceAccount:

--- a/charts/logzio-trivy/values.yaml
+++ b/charts/logzio-trivy/values.yaml
@@ -1,6 +1,11 @@
 trivy-operator:
   trivy:
     ignoreUnfixed: false
+  operator:
+    configAuditScannerEnabled: false
+    rbacAssessmentScannerEnabled: true
+    infraAssessmentScannerEnabled: true
+    clusterComplianceEnabled: true
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Since we currently only using the vulnerability reports, it's unnecessary for trivy to create the rest of the reports. This PR makes it the default behaviour.
Also:
- Bump version for Trivy-opertor.
- Bump version for logzio-trivy