### PR TITLE
Fargate log router config - fluentd 0.20.1

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.20.1
+version: 0.20.2
 appVersion: 1.3.1
 maintainers:
   - name: Miri Ignatiev

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.20.2
+version: 0.20.1
 appVersion: 1.3.1
 maintainers:
   - name: Miri Ignatiev

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.20.0
+version: 0.20.1
 appVersion: 1.3.1
 maintainers:
   - name: Miri Ignatiev

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -278,8 +278,6 @@ When enabling promehteus configuration, the pod collects and exposes fluentd met
  - **0.20.1**:
    - Added log level detection for fargate log router
    - Remove `namespace` value, replaced by `Realese.namespace` in all templates
- - **0.20.1**:
-   - Updated fargate log router configuration to add `log_level` field
  - **0.20.0**:
    - Upgraded windows image to `logzio/windows:0.0.2`:
      - Added prometheus monitor plugin

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -276,6 +276,9 @@ When enabling promehteus configuration, the pod collects and exposes fluentd met
 
 ## Change log
  - **0.20.1**:
+   - Added log level detection for fargate log router
+   - Remove `namespace` value, replaced by `Realese.namespace` in all templates
+ - **0.20.1**:
    - Updated fargate log router configuration to add `log_level` field
  - **0.20.0**:
    - Upgraded windows image to `logzio/windows:0.0.2`:
@@ -286,13 +289,13 @@ When enabling promehteus configuration, the pod collects and exposes fluentd met
    - Upgraded image to `logzio/logzio-fluentd:1.3.1`:
      - Added prometheus monitor plugin
    - Updated `daemonset.fluentdPrometheusConf` - now controls prometheus config for collecting and exposing fluentd metrics.
- - **0.18.0**:
-   - Added log_level detection for "warn" level.
 
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>
 
+ - **0.18.0**:
+   - Added log_level detection for "warn" level.
  - **0.17.0**:
    - Add `secrets.enabled` to control secret creation and management. ([#194](https://github.com/logzio/logzio-helm/pull/194))
  - **0.16.0**:

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -275,6 +275,8 @@ When enabling promehteus configuration, the pod collects and exposes fluentd met
 
 
 ## Change log
+ - **0.20.1**:
+   - Updated fargate log router configuration to add `log_level` field
  - **0.20.0**:
    - Upgraded windows image to `logzio/windows:0.0.2`:
      - Added prometheus monitor plugin

--- a/charts/fluentd/templates/clusterrole.yaml
+++ b/charts/fluentd/templates/clusterrole.yaml
@@ -3,6 +3,6 @@ apiVersion: {{ .Values.apiVersions.clusterRole }}
 kind: ClusterRole
 metadata:
   name: {{ include "fluentd.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 rules: {{ toYaml .Values.clusterRole.rules | nindent 2 -}}
 {{- end }}

--- a/charts/fluentd/templates/clusterrolebinding.yaml
+++ b/charts/fluentd/templates/clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "fluentd.serviceAccount" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/fluentd/templates/configmap-monitoring.yaml
+++ b/charts/fluentd/templates/configmap-monitoring.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ .Values.apiVersions.configmap }}
 kind: ConfigMap
 metadata:
   name: {{ include "fluentd.fullname" . }}-monitoring
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: {{ .Values.k8sApp }}
 data:

--- a/charts/fluentd/templates/configmap.yaml
+++ b/charts/fluentd/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ .Values.apiVersions.configmap }}
 kind: ConfigMap
 metadata:
   name: {{ include "fluentd.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace}}
   labels:
     k8s-app: {{ .Values.k8sApp }}
 data:

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ .Values.apiVersions.daemonset }}
 kind: DaemonSet
 metadata:
   name: {{ include "fluentd.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: {{ .Values.k8sApp }}
     version: v1
@@ -162,7 +162,7 @@ apiVersion: {{ .Values.apiVersions.daemonset }}
 kind: DaemonSet
 metadata:
   name: {{ include "fluentd.fullname" . }}-windows
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.namespace }}
   labels:
     k8s-app: {{ .Values.k8sApp }}
     version: v1

--- a/charts/fluentd/templates/fargate-logging-configmap.yaml
+++ b/charts/fluentd/templates/fargate-logging-configmap.yaml
@@ -19,6 +19,21 @@ data:
       Keep_Log Off
       K8S-Logging.Parser On
       K8S-Logging.Exclude On
+    [FILTER]
+      Name modify
+      Match *
+      Condition Key_value_matches message (?i)(error|failure|failed|exception|panic)
+      Add log_level ERROR
+    [FILTER]
+      Name modify
+      Match *
+      Condition Key_value_matches message (?i)(warn|warning)
+      Add log_level WARNING
+    [FILTER]
+      Name modify
+      Match *
+      Condition Key_value_does_not_match message (?i)(error|failure|failed|exception|panic|warn|warning)
+      Add log_level INFO
   output.conf: |
     [OUTPUT]
       Name  es

--- a/charts/fluentd/templates/secret.yaml
+++ b/charts/fluentd/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ .Values.apiVersions.secret }}
 kind: Secret
 metadata:
   name: {{ .Values.secretName }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
   logzio-log-shipping-token: {{ required "Logzio shipping token is required!" .Values.secrets.logzioShippingToken }}

--- a/charts/fluentd/templates/serviceaccount.yaml
+++ b/charts/fluentd/templates/serviceaccount.yaml
@@ -3,5 +3,5 @@ apiVersion: {{ .Values.apiVersions.serviceAccount }}
 kind: ServiceAccount
 metadata:
   name: {{ include "fluentd.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -16,7 +16,6 @@ apiVersions:
   configmap: v1
   secret: v1
 
-namespace: monitoring
 k8sApp: fluentd-logzio
 
 isRBAC: true


### PR DESCRIPTION
- Added filter for detecting `log_level`:
```
    [FILTER]
        Name modify
        Match *
        Condition Key_value_matches message (?i)(error|failure|failed|exception|panic)
        Add log_level ERROR
    [FILTER]
        Name modify
        Match *
        Condition Key_value_matches message (?i)(warn|warning)
        Add log_level WARNING
    [FILTER]
        Name modify
        Match *
        Condition Key_value_does_not_match message (?i)(error|failure|failed|exception|panic|warn|warning)
        Add log_level INFO
```
- Removed `namespace` value