### PR TITLE
0.5.2

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 0.5.1
+version: 0.5.2
 
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: logzio-fluentd
-    version: "0.20.0"
+    version: "0.20.1"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "0.0.25"
+    version: "0.0.26"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -140,7 +140,14 @@ In these cases we can use the following `--set` commands to use an alternative i
 ```
 
 ## Changelog
-
+- **0.5.2**:
+	- Upgrade `logzio-k8s-telemetry` Chart to `0.0.26`:
+		- Added `applications` scrape job for `daemonset` collector mode.
+    - Added `secrets.enabled` value.
+	- Upgrade `logzio-fluentd` Chart to `0.20.1`:
+		- Added log level detection for fargate log router.
+    - Remove `namespace` value, replaced by `Realese.namespace` in all templates
+.
 - **0.5.1**:
 	- Upgrade `logzio-trivy` Chart to `0.2.0`:
 		- Watch for creation/modification of reports.


### PR DESCRIPTION
- **0.5.2**:
	- Upgrade `logzio-k8s-telemetry` Chart to `0.0.26`:
		- Added `applications` scrape job for `daemonset` collector mode.
    - Added `secrets.enabled` value.
	- Upgrade `logzio-fluentd` Chart to `0.20.1`:
		- Added log level detection for fargate log router.
    - Remove `namespace` value, replaced by `Realese.namespace` in all templates