### PR TITLE
logzio-k8s-telemetry 0.0.27

### DIFF
--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -318,7 +318,7 @@ helm uninstall logzio-k8s-telemetry
 
 ## Change log
 * 0.0.27
-  - Removed duplicate `prometheus.io/scrape` annotation from `kube-state-metrics`
+  - Removed duplicate `prometheus.io/scrape` annotation from `kube-state-metrics` (@dlip)
 * 0.0.26
   - Added `applications` scrape job for `daemonset` collector mode.
   - Added `secrets.enabled` value.

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -317,6 +317,8 @@ helm uninstall logzio-k8s-telemetry
 
 
 ## Change log
+* 0.0.27
+  - Removed duplicate `prometheus.io/scrape` annotation from `kube-state-metrics`
 * 0.0.26
   - Added `applications` scrape job for `daemonset` collector mode.
   - Added `secrets.enabled` value.


### PR DESCRIPTION
  - Removed duplicate `prometheus.io/scrape` annotation from `kube-state-metrics`