### PR TITLE
Logzio k8s telemetry 0.0.28

### DIFF
--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.27
+version: 0.0.28
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -317,6 +317,10 @@ helm uninstall logzio-k8s-telemetry
 
 
 ## Change log
+* 0.0.28
+  - Change default metrics scrape and export values to handle more cases
+  - Reorder processors
+  - Remove the `memory_limiter` processor
 * 0.0.27
   - Removed duplicate `prometheus.io/scrape` annotation from `kube-state-metrics` (@dlip)
 * 0.0.26

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -274,7 +274,7 @@ spmForwarderConfig:
     pipelines:
       traces/spm:
         receivers: [jaeger, zipkin, otlp]
-        processors: [attributes/env_id, attributes/env_id, k8sattributes, batch]
+        processors: [attributes/env_id, k8sattributes, batch]
         exporters: [logging, otlp]
 
 metricsConfig:

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -259,7 +259,7 @@ tracesConfig:
     pipelines:
       traces:
         receivers: [jaeger, zipkin, otlp]
-        processors: [tail_sampling, attributes/env_id, k8sattributes, resource/k8s, memory_limiter, batch]
+        processors: [attributes/env_id, k8sattributes, resource/k8s, tail_sampling, memory_limiter, batch]
         exporters: [logging, logzio]
     telemetry:
       logs:
@@ -275,7 +275,7 @@ spmForwarderConfig:
     pipelines:
       traces/spm:
         receivers: [jaeger, zipkin, otlp]
-        processors: [attributes/env_id, memory_limiter, batch]
+        processors: [attributes/env_id, attributes/env_id, k8sattributes, memory_limiter, batch]
         exporters: [logging, otlp]
 
 metricsConfig:

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -297,8 +297,8 @@ metricsConfig:
     prometheus:
       config:
         global:
-          scrape_interval: 30s
-          scrape_timeout: 30s
+          scrape_interval: 60s
+          scrape_timeout: 60s
         scrape_configs:
         # Job to collect opentelemetry collector metrics
         - job_name: 'collector-metrics'

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -288,6 +288,7 @@ metricsConfig:
           - 'IsMatch(metric.name, "(${K8S_360_METRICS})") == true and attributes["logzio_app"] != "kubernetes360"'
   exporters:
     prometheusremotewrite:
+      timeout: 30s
       endpoint: ${LISTENER_URL}
       external_labels:
         p8s_logzio_name: ${P8S_LOGZIO_NAME}
@@ -297,13 +298,12 @@ metricsConfig:
     prometheus:
       config:
         global:
-          scrape_interval: 15s
-          scrape_timeout: 10s
-          evaluation_interval: 10s
+          scrape_interval: 30s
+          scrape_timeout: 30s
         scrape_configs:
         # Job to collect opentelemetry collector metrics
         - job_name: 'collector-metrics'
-          scrape_interval: 15s
+          scrape_interval: 30s
           static_configs:
           - targets: [ "0.0.0.0:8888" ]
         - job_name: windows-metrics
@@ -542,7 +542,7 @@ spanMetricsAgregator:
         config:
           scrape_configs:
           - job_name: 'spm'
-            scrape_interval: 15s
+            scrape_interval: 30s
             static_configs:
             - targets: [ "0.0.0.0:8889" ]
       jaeger:
@@ -568,6 +568,7 @@ spanMetricsAgregator:
       prometheus/spm:
         endpoint: "0.0.0.0:8889"
       prometheusremotewrite/spm-logzio:
+        timeout: 30s
         endpoint: ${LISTENER_URL}
         headers:
           Authorization: "Bearer ${SPM_TOKEN}"
@@ -775,6 +776,7 @@ daemonsetConfig:
         datapoint:
   exporters:
     prometheusremotewrite:
+      timeout: 30s
       endpoint: ${LISTENER_URL}
       external_labels:
         p8s_logzio_name: ${P8S_LOGZIO_NAME}
@@ -784,13 +786,12 @@ daemonsetConfig:
     prometheus:
       config:
         global:
-          scrape_interval: 15s
-          scrape_timeout: 10s
-          evaluation_interval: 10s
+          scrape_interval: 30s
+          scrape_timeout: 30s
         scrape_configs:
         # Job to collect opentelemetry collector metrics
         - job_name: 'collector-metrics'
-          scrape_interval: 15s
+          scrape_interval: 30s
           static_configs:
           - targets: [ "0.0.0.0:8888" ]
         - job_name: windows-metrics

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -192,7 +192,6 @@ baseCollectorConfig:
         - key: logzio_agent_version
           value: ${LOGZIO_AGENT_VERSION}
           action: insert
-    memory_limiter: null
   service:
     extensions:
       - health_check
@@ -259,7 +258,7 @@ tracesConfig:
     pipelines:
       traces:
         receivers: [jaeger, zipkin, otlp]
-        processors: [attributes/env_id, k8sattributes, resource/k8s, tail_sampling, memory_limiter, batch]
+        processors: [attributes/env_id, k8sattributes, resource/k8s, tail_sampling, batch]
         exporters: [logging, logzio]
     telemetry:
       logs:
@@ -275,7 +274,7 @@ spmForwarderConfig:
     pipelines:
       traces/spm:
         receivers: [jaeger, zipkin, otlp]
-        processors: [attributes/env_id, attributes/env_id, k8sattributes, memory_limiter, batch]
+        processors: [attributes/env_id, attributes/env_id, k8sattributes, batch]
         exporters: [logging, otlp]
 
 metricsConfig:
@@ -424,7 +423,6 @@ metricsConfig:
           - prometheusremotewrite
         processors:
           - attributes/env_id
-          - memory_limiter
           - filter/kubernetes360
         receivers:
           - prometheus
@@ -927,7 +925,6 @@ daemonsetConfig:
           - prometheusremotewrite
         processors:
           - attributes/env_id
-          - memory_limiter
           - filter/kubernetes360
         receivers:
           - prometheus


### PR DESCRIPTION
- Change default metrics scrape and export values to handle more cases
- Reorder processors
- Remove `memory_limiter` processor