### PR TITLE
upgrade logzio-telemetry to 0.0.28

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 0.5.5
+version: 0.5.6
 
 sources:
   - https://github.com/logzio/logzio-helm
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "0.0.27"
+    version: "0.0.28"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -140,6 +140,11 @@ In these cases we can use the following `--set` commands to use an alternative i
 ```
 
 ## Changelog
+- **0.5.6**:
+	- Upgrade `logzio-k8s-telemetry` Chart to `0.0.28`:
+		- Change default metrics scrape and export values to handle more cases
+    - Reorder processors
+    - Remove the memory_limiter processor
 - **0.5.5**:
 	- Upgrade `logzio-fluentd` Chart to `0.20.2`:
 		- Use fluentd's retry instead of retry in code (raise exception on non-2xx response).


### PR DESCRIPTION
- Upgrade `logzio-k8s-telemetry` Chart to `0.0.28`:
  - Change default metrics scrape and export values to handle more cases
  - Reorder processors
  - Remove the memory_limiter processor