### PR TITLE
logzio-k8s-telemetry-0.0.29

### DIFF
--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -29,12 +29,12 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.28
+version: 0.0.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.70.0
+appVersion: 0.78.0
 
 maintainers:
 - name: yotamloe

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -317,6 +317,10 @@ helm uninstall logzio-k8s-telemetry
 
 
 ## Change log
+* 0.0.29
+  - Upgrade traces and metrics otel image `0.70.0` -> `0.78.0`
+  - Upgrade spm image `0.70.0` -> `0.73.0`
+  - Added values for seprate spm iamge
 * 0.0.28
   - Change default metrics scrape and export values to handle more cases
   - Reorder processors
@@ -333,6 +337,11 @@ helm uninstall logzio-k8s-telemetry
   - Improved naming of the collector deployments:
     - Daemonset pods now have the "ds" suffix.
     - Standalone pod now have the "standalone" suffix.
+
+
+<details>
+  <summary markdown="span"> Expand to check old versions </summary>
+
 * 0.0.24
   - Added `collector.mode` flag - now supports `standalone` and `daemonset`, default is `daemonset`.
   - Fixed subchart conditions.
@@ -340,12 +349,6 @@ helm uninstall logzio-k8s-telemetry
   - Increased minimum memory (`1024Mi`) and cpu (`512m`) requiremts for the collector pods.
 * 0.0.23
   - Updated metrics filter (#219)
-
-
-
-<details>
-  <summary markdown="span"> Expand to check old versions </summary>
-
 * 0.0.22
   - **breaking changes:** Add separate span metrics component that includes the following resources:
     - `deployment-spm.yaml`

--- a/charts/logzio-telemetry/templates/_pod-spm.tpl
+++ b/charts/logzio-telemetry/templates/_pod-spm.tpl
@@ -13,8 +13,8 @@ containers:
       {{- range .Values.command.extraArgs }}
       - {{ . }}
       {{- end }}
-    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-    imagePullPolicy: {{ .Values.image.pullPolicy }}
+    image: "{{ .Values.spmImage.repository }}:{{ .Values.spmImage.tag | default .Chart.AppVersion }}"
+    imagePullPolicy: {{ .Values.spmImage.pullPolicy }}
     ports:
       {{- range $key, $port := .Values.spanMetricsAgregator.ports }}
       {{- if $port.enabled }}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -435,7 +435,7 @@ image:
   repository: otel/opentelemetry-collector-contrib
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.70.0"
+  tag: "0.78.0"
 nginxWindowsImage:
   # Reverse proxy image to enable metrics scraping from windows nodes
   repository: logzio/logzio-windows-node-reverse-proxy
@@ -446,6 +446,11 @@ windowsExporterInstallerImage:
   repository: logzio/logzio-windows-exporter-installer
   pullPolicy: IfNotPresent
   tag: "0.0.1"
+spmImage:
+  # Job image to install windows exporter on windows nodes
+  repository: otel/opentelemetry-collector-contrib
+  pullPolicy: IfNotPresent
+  tag: "0.73.0"
 imagePullSecrets: []
 
 # OpenTelemetry Collector executable

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -447,7 +447,6 @@ windowsExporterInstallerImage:
   pullPolicy: IfNotPresent
   tag: "0.0.1"
 spmImage:
-  # Job image to install windows exporter on windows nodes
   repository: otel/opentelemetry-collector-contrib
   pullPolicy: IfNotPresent
   tag: "0.73.0"


### PR DESCRIPTION
## Change log
* 0.0.29
  - Upgrade traces and metrics otel image `0.70.0` -> `0.78.0`
  - Upgrade spm image `0.70.0` -> `0.73.0`
  - Added values for seprate spm iamge