### PR TITLE
logzio-monitoring-0.5.7

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 0.5.6
+version: 0.5.7
 
 sources:
   - https://github.com/logzio/logzio-helm
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "0.0.28"
+    version: "0.0.29"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -144,7 +144,7 @@ In these cases we can use the following `--set` commands to use an alternative i
 	- Upgrade `logzio-k8s-telemetry` Chart to `0.0.29`:
     - Upgrade traces and metrics otel image `0.70.0` -> `0.78.0`
     - Upgrade spm image `0.70.0` -> `0.73.0`
-    - Added values for seprate spm iamge
+    - Added values for seprate spm image
 - **0.5.6**:
 	- Upgrade `logzio-k8s-telemetry` Chart to `0.0.28`:
 		- Change default metrics scrape and export values to handle more cases

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -140,6 +140,11 @@ In these cases we can use the following `--set` commands to use an alternative i
 ```
 
 ## Changelog
+- **0.5.7**:
+	- Upgrade `logzio-k8s-telemetry` Chart to `0.0.29`:
+    - Upgrade traces and metrics otel image `0.70.0` -> `0.78.0`
+    - Upgrade spm image `0.70.0` -> `0.73.0`
+    - Added values for seprate spm iamge
 - **0.5.6**:
 	- Upgrade `logzio-k8s-telemetry` Chart to `0.0.28`:
 		- Change default metrics scrape and export values to handle more cases


### PR DESCRIPTION
- **0.5.7**:
	- Upgrade `logzio-k8s-telemetry` Chart to `0.0.29`:
    - Upgrade traces and metrics otel image `0.70.0` -> `0.78.0`
    - Upgrade spm image `0.70.0` -> `0.73.0`
    - Added values for seprate spm iamge