### PR TITLE
Add proxy support INT-703

### DIFF
--- a/charts/fluentbit/Chart.yaml
+++ b/charts/fluentbit/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - fluent-bit
   - fluentd
 type: application
-version: 0.0.4
-appVersion: 0.3.0
+version: 0.0.5
+appVersion: 0.4.0
 sources:
   - https://github.com/logzio/logzio-helm
   - https://github.com/fluent/fluent-bit/

--- a/charts/fluentbit/README.md
+++ b/charts/fluentbit/README.md
@@ -1,4 +1,4 @@
-# Logzio fluentbit helm chart
+# Logz.io FluentBit Helm Chart
 
 ##  Overview
 

--- a/charts/fluentbit/README.md
+++ b/charts/fluentbit/README.md
@@ -35,6 +35,30 @@ helm install  \
 logzio-fluent-bit logzio-helm/logzio-fluent-bit
 ```
 
+
+#### Sending logs using HTTP Proxy server
+
+*Note that HTTPS is not currently supported. It is recommended not to set this and to configure the [HTTP_PROXY environment variables](https://docs.fluentbit.io/manual/administration/http-proxy) instead as they support both HTTP and HTTPS.* 
+
+If you want to ship logs and route them through a Proxy HTTP server please set the following Helm chart parameters:
+
+Replace the parameter `<<PROXY_HOST>>` (optional) with your HTTP Proxy server host address. # `<<IP_OR_HOST>>:<<PORT>>`
+
+If you'd like to use basic authentication please replace the parameter `<<PROXY_USERNAME>>` (optional) with the Proxy server username and replace the parameter `<<PROXY_PASSWORD>>` (optional) with the user's password.
+
+###### Run the Helm deployment code with Proxy configuration
+```sh
+helm install  \
+--set logzio.token=<<LOGZIO_TOKEN>> \
+--set logzio.listenerHost=<<LISTENER_HOST>> \
+--set logzio.logType=<<LOG_TYPE>> \
+--set logzio.proxyHost=<<PROXY_HOST>> \
+--set logzio.proxyUser=<<PROXY_USERNAME>> \
+--set logzio.proxyPass=<<PROXY_PASSWORD>> \
+logzio-fluent-bit logzio-helm/logzio-fluent-bit
+```
+
+
 ##### Check Logz.io for your logs
 
 Give your logs some time to get from your system to ours, then open [Logz.io](https://app.logz.io/).
@@ -87,7 +111,6 @@ To determine if a node uses taints as well as to display the taint keys, run:
 ```sh
 kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.taints}"
 ```
-
 
 ## Change log
 * 0.0.4 - Upgrade docker image to 0.3.0, adding dedot filter

--- a/charts/fluentbit/README.md
+++ b/charts/fluentbit/README.md
@@ -36,29 +36,6 @@ logzio-fluent-bit logzio-helm/logzio-fluent-bit
 ```
 
 
-#### Sending logs using HTTP Proxy server
-
-*Note that HTTPS is not currently supported. It is recommended not to set this and to configure the [HTTP_PROXY environment variables](https://docs.fluentbit.io/manual/administration/http-proxy) instead as they support both HTTP and HTTPS.* 
-
-If you want to ship logs and route them through a Proxy HTTP server please set the following Helm chart parameters:
-
-Replace the parameter `<<PROXY_HOST>>` (optional) with your HTTP Proxy server host address. # `<<IP_OR_HOST>>:<<PORT>>`
-
-If you'd like to use basic authentication please replace the parameter `<<PROXY_USERNAME>>` (optional) with the Proxy server username and replace the parameter `<<PROXY_PASSWORD>>` (optional) with the user's password.
-
-###### Run the Helm deployment code with Proxy configuration
-```sh
-helm install  \
---set logzio.token=<<LOGZIO_TOKEN>> \
---set logzio.listenerHost=<<LISTENER_HOST>> \
---set logzio.logType=<<LOG_TYPE>> \
---set logzio.proxyHost=<<PROXY_HOST>> \
---set logzio.proxyUser=<<PROXY_USERNAME>> \
---set logzio.proxyPass=<<PROXY_PASSWORD>> \
-logzio-fluent-bit logzio-helm/logzio-fluent-bit
-```
-
-
 ##### Check Logz.io for your logs
 
 Give your logs some time to get from your system to ours, then open [Logz.io](https://app.logz.io/).
@@ -94,6 +71,30 @@ To uninstall the `logzio-fluent-bit` deployment, use the following command:
 helm uninstall logzio-fluent-bit
 ```
 
+#### Sending logs using HTTP Proxy server
+
+If you want to ship logs and route them through a Proxy HTTP server please set the following Helm chart parameters:
+
+Replace the parameter `<<PROXY_HOST>>` (optional) with your HTTP Proxy server host address. # `<<IP_OR_HOST>>:<<PORT>>`
+
+If you'd like to use basic authentication please replace the parameter `<<PROXY_USERNAME>>` (optional) with the Proxy server username and replace the parameter `<<PROXY_PASSWORD>>` (optional) with the user's password.
+
+
+**Note that HTTPS is not currently supported. It is recommended not to set this and to configure the [HTTP_PROXY environment variables](https://docs.fluentbit.io/manual/administration/http-proxy) instead as they support both HTTP and HTTPS.** 
+
+
+###### Run the Helm deployment code with Proxy configuration
+```sh
+helm install  \
+--set logzio.token=<<LOGZIO_TOKEN>> \
+--set logzio.listenerHost=<<LISTENER_HOST>> \
+--set logzio.logType=<<LOG_TYPE>> \
+--set logzio.proxyHost=<<PROXY_HOST>> \
+--set logzio.proxyUser=<<PROXY_USERNAME>> \
+--set logzio.proxyPass=<<PROXY_PASSWORD>> \
+logzio-fluent-bit logzio-helm/logzio-fluent-bit
+```
+
 ## Sending logs from nodes with taints
 
 If you want to ship logs from any of the nodes that have a taint, make sure that the taint key values are listed in your in your daemonset/deployment configuration as follows:
@@ -113,8 +114,8 @@ kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.tain
 ```
 
 ## Change log
-* 0.0.4 - Upgrade docker image to 0.3.0, adding dedot filter
-          in Logzio Output config, added memory and cpu requirements.
+* 0.0.5 - Upgrade docker image to 0.4.0, adding HTTP proxy support in Logzio Output config.
+* 0.0.4 - Upgrade docker image to 0.3.0, adding dedot filter in Logzio Output config, added memory and cpu requirements.
 * 0.0.3 - Upgrade docker image to 0.1.3.
 * 0.0.2 - Upgrade docker image to v0.1.2.
 * 0.0.1 - Initial realese

--- a/charts/fluentbit/README.md
+++ b/charts/fluentbit/README.md
@@ -75,7 +75,7 @@ helm uninstall logzio-fluent-bit
 
 If you want to ship logs and route them through a Proxy HTTP server please set the following Helm chart parameters:
 
-Replace the parameter `<<PROXY_HOST>>` (optional) with your HTTP Proxy server host address. # `<<IP_OR_HOST>>:<<PORT>>`
+Replace the parameter `<<PROXY_HOST>>` with your HTTP Proxy server host address. # `<<IP_OR_HOST>>:<<PORT>>`
 
 If you'd like to use basic authentication please replace the parameter `<<PROXY_USERNAME>>` (optional) with the Proxy server username and replace the parameter `<<PROXY_PASSWORD>>` (optional) with the user's password.
 

--- a/charts/fluentbit/values.yaml
+++ b/charts/fluentbit/values.yaml
@@ -225,7 +225,7 @@ config:
         dedot_enabled true
         dedot_nested true
         dedot_new_seperator _
-        proxy_url http://{{ .Values.logzio.proxyUrl }}
+        proxy_host  {{ .Values.logzio.proxyHost }}
         proxy_user {{ .Values.logzio.proxyUser }}
         proxy_pass {{ .Values.logzio.proxyPass }}
         

--- a/charts/fluentbit/values.yaml
+++ b/charts/fluentbit/values.yaml
@@ -12,7 +12,7 @@ replicaCount: 1
 image:
   repository: logzio/fluent-bit-output
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
-  tag: "0.3.0"
+  tag: "0.4.0"
   pullPolicy: Always
 
 testFramework:
@@ -225,6 +225,10 @@ config:
         dedot_enabled true
         dedot_nested true
         dedot_new_seperator _
+        proxy_url http://{{ .Values.logzio.proxyUrl }}
+        proxy_user {{ .Values.logzio.proxyUser }}
+        proxy_pass {{ .Values.logzio.proxyPass }}
+        
   ## https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |
     [PARSER]

--- a/charts/fluentbit/values.yaml
+++ b/charts/fluentbit/values.yaml
@@ -89,7 +89,7 @@ serviceMonitor:
 prometheusRule:
   enabled: false
 #   namespace: ""
-#   additionnalLabels: {}
+#   additionalLabels: {}
 #   rules:
 #   - alert: NoOutputBytesProcessed
 #     expr: rate(fluentbit_output_proc_bytes_total[5m]) == 0


### PR DESCRIPTION

In this PR:
- Add option to use proxy server parameters in order to route data through it using logz.io Fluentbit output plugin.
- Fix typo in values.yaml file.
- Update configured Logz.io Fluentbit output plugin image version.
- Update Readme.
- Bump version.