### PR TITLE
logzio-monitoring 1.1.0

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 1.0.0
+version: 1.1.0
 
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: logzio-fluentd
-    version: "0.20.3"
+    version: "0.21.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -140,11 +140,22 @@ In these cases we can use the following `--set` commands to use an alternative i
 ```
 
 ## Changelog
-- **0.7.1**:
+
+- **1.1.0**:
+	- Upgrade `logzio-fluentd` to `0.21.0`:
+		- Upgrade fluentd to `1.16`.
+		- Upgrade gem `fluent-plugin-logzio` to `0.2.2`:
+			- Do not retry on 400 and 401. For 400 - try to fix log and resend.
+			- Generate a metric (`logzio_status_codes`) for response codes from Logz.io.
+- **1.0.0**:
   - Upgrade `logzio-k8s-telemetry` to `1.0.0`:
 	- Fixed an issue where when enabling `enableMetricsFilter.kubeSystem` installation failes.
   - **BREAKING CHANGES**:
     - Rename `enableMetricsFilter.kubeSystem` to `enableMetricsFilter.dropKubeSystem`, in order to avoid confusion between functionality of filters.
+
+<details>
+  <summary markdown="span"> Expand to check old versions </summary>
+
 - **0.7.1**:
 	- Upgrade `logzio-k8s-telemetry` to `0.2.1`:
 		- Rename k8s attributes for traces pipeline.
@@ -154,11 +165,6 @@ In these cases we can use the following `--set` commands to use an alternative i
 		- **BREAKING CHANGES**:
    			- Added `applicationMetrics.enabled` value (defaults to `false`)
 		- Added resourcedetection processor, span dimensions.
-
-
-<details>
-  <summary markdown="span"> Expand to check old versions </summary>
-
 - **0.6.0**:
 	- Upgrade `logzio-k8s-telemetry` to `0.1.0`:
 		- **BREAKING CHANGES**:


### PR DESCRIPTION
Upgrade `logzio-fluentd` to `0.21.0`:
- Upgrade fluentd to `1.16`.
- Upgrade gem `fluent-plugin-logzio` to `0.2.2`:
  - Do not retry on 400 and 401. For 400 - try to fix log and resend.
  - Generate a metric (`logzio_status_codes`) for response codes from Logz.io.