### PR TITLE
feature/add logz.io token from env-var

### DIFF
--- a/charts/fluentbit/templates/daemonset.yaml
+++ b/charts/fluentbit/templates/daemonset.yaml
@@ -35,4 +35,9 @@ spec:
         {{- end }}
     spec:
       {{- include "fluent-bit.pod" . | nindent 6 }}
+      containers:
+        - name: fluent-bit
+          env:
+            - name: LOGZIO_TOKEN
+              value: {{ .Values.env.LOGZIO_TOKEN }}
 {{- end }}


### PR DESCRIPTION
There is a need to specify the logz.io token from a env var injected from a k8s secret created by terraform code from, e.g. aws secret manager - in my example.

This issue describes it way good => https://github.com/fluent/fluent-bit/issues/7011#issuecomment-1472880366

The only need is to have it in the helm chart.