### PR TITLE
Fluentd - filter by log level

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.22.0
+version: 0.23.0
 appVersion: 1.5.0
 maintainers:
   - name: Miri Bar

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -151,6 +151,7 @@ helm install -n monitoring \
 | `configmap.envId` | Config snippet for adding `env_id` field to logs | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 | `configmap.customSources` | Add sources to the Fluentd configuration | `""` |
 | `configmap.customFilters` | Add filters to the Fluentd configuration | `""` |
+| `logLevelFilter` | Add log level filter. Regex of the log level(s) you want to ship. For example, if you want to ship warning and error logs, use `WARNING|ERROR`. Possible levels are: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `TRACE`. | `""` |
 
 **Note:** If you're adding your own configuration file via `configmap.extraConfig`:
 - Add a `--set-file` flag to your `helm install` command, as seen in the [example above](https://github.com/logzio/logzio-helm/tree/master/charts/fluentd#configuration).
@@ -277,6 +278,8 @@ When enabling promehteus configuration, the pod collects and exposes fluentd met
 
 ## Change log
 
+ - **0.23.0**:
+   - Allow filtering logs by log level with `logLevelFilter`.
  - **0.22.0**:
    - Add custom endpoint option with `secrets.customEndpoint`.
  - **0.21.0**:
@@ -285,14 +288,12 @@ When enabling promehteus configuration, the pod collects and exposes fluentd met
     - Upgrade gem `fluent-plugin-logzio` to `0.2.2`:
       - Do not retry on 400 and 401. For 400 - try to fix log and resend.
       - Generate a metric (`logzio_status_codes`) for response codes from Logz.io.
- - **0.20.3**:
-   - ezKonnect support: Added `logz.io/application_type` to type annotation check .
-
-
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>
 
+ - **0.20.3**:
+   - ezKonnect support: Added `logz.io/application_type` to type annotation check .
  - **0.20.2**:
    - Upgrade docker image `logzio/logzio-fluentd` to `1.4.0`:
      - Use fluentd's retry instead of retry in code (raise exception on non-2xx response).

--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -77,3 +77,13 @@ Builds the list for exclude paths in the tail for the containers - windows
 {{- print .Values.windowsDaemonset.excludeFluentdPath }}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Builds a filter based on log levels
+*/}}
+{{- define "logzio.logLevelFilter" }}
+{{- if .Values.logLevelFilter }}
+{{- cat "<filter **>\n    @type grep\n    regexp1 log_level" .Values.logLevelFilter "\n</filter>" | replace "\"" "" }}
+{{- end -}}
+{{- end -}}

--- a/charts/fluentd/templates/configmap.yaml
+++ b/charts/fluentd/templates/configmap.yaml
@@ -26,6 +26,10 @@ data:
 
   custom-filters.conf : {{ toYaml .Values.configmap.customFilters | indent 2 }}
 
+  {{- if .Values.logLevelFilter }}
+  log-level-filter.conf : {{ include "logzio.logLevelFilter" . | toYaml }}
+  {{- end }}
+
   {{- if .Values.env_id }}
   env-id.conf : {{ toYaml .Values.configmap.envId | indent 2 }}
   {{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -407,6 +407,8 @@ configmap:
       de_dot_nested     true
     </filter>
 
+    @include log-level-filter.conf
+
   system: |
     <system>
       log_level "#{ENV['LOGZIO_LOG_LEVEL']}"
@@ -559,3 +561,4 @@ configmap:
     
   customSources: ""
   customFilters: ""
+logLevelFilter: ""


### PR DESCRIPTION
This PR allows users to filter for logs with the desired log level. The default behaviour still remains that all logs are collected.