### PR TITLE
Fluentd - fix service account template bug, allow privileged security context

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.24.0
+version: 0.25.0
 appVersion: 1.5.0
 maintainers:
   - name: Miri Bar

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -76,6 +76,7 @@ helm install -n monitoring \
 | `fargateLogRouter.enabled` | Boolen to decide if to configure fargate log router | `false` |
 | `env_id` | Add to your logs field `env_id` with identification of the environment you're shipping logs from. | `""` |
 | `isRBAC` | Specifies whether the Chart should be compatible to a RBAC cluster. If you're running on a non-RBAC cluster, set to `false`.  | `true` |
+| `isPrivileged` | Specifies whether to run the Damonset with priviliged security context | `false` |
 | `serviceAccount.name` | Name of the service account. | `""` |
 | `daemonset.tolerations` | Set [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. | See [values.yaml](https://github.com/logzio/logzio-helm/blob/master/charts/fluentd/values.yaml). |
 | `daemonset.nodeSelector` | Set [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for all DaemonSet pods. | `{}` |
@@ -293,19 +294,22 @@ If needed, the fluentd image can be changed to support windows server 2022 with 
 
 
 ## Change log
-
+ - **0.25.0*:
+   - Add parameter `isPrivileged` to allow running Daemonset with priviliged security context.
+   - **Bug fix**: Fix template for `fluentd.serviceAccount`, and fix use of template in service account.
  - **0.24.0**:
    - Add parameter `configmap.customFilterAfter` that allows adding filters AFTER built-in filter configuration.
    - Added `daemonset.init.containerImage` customization.
    - Added fluentd image for windows server 2022.
  - **0.23.0**:
    - Allow filtering logs by log level with `logLevelFilter`.
- - **0.22.0**:
-   - Add custom endpoint option with `secrets.customEndpoint`.
+
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>
 
+ - **0.22.0**:
+   - Add custom endpoint option with `secrets.customEndpoint`.
  - **0.21.0**:
   - Bump docker image to `1.5.0`:
     - Upgrade fluentd to `1.16`.

--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -21,7 +21,7 @@ If release name contains chart name it will be used as a full name.
 Create the name of the service account to use
 */}}
 {{- define "fluentd.serviceAccount" -}}
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.isRBAC -}}
     {{ default (include "fluentd.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -56,6 +56,10 @@ spec:
       containers:
       - name: fluentd
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{- if .Values.isPrivileged }}
+        securityContext:
+          privileged: true
+{{- end}}
 {{- if .Values.daemonset.fluentdPrometheusConf }}
         ports:
         - name: metrics

--- a/charts/fluentd/templates/serviceaccount.yaml
+++ b/charts/fluentd/templates/serviceaccount.yaml
@@ -2,6 +2,6 @@
 apiVersion: {{ .Values.apiVersions.serviceAccount }}
 kind: ServiceAccount
 metadata:
-  name: {{ include "fluentd.fullname" . }}
+  name: {{ template "fluentd.serviceAccount" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -19,6 +19,7 @@ apiVersions:
 k8sApp: fluentd-logzio
 
 isRBAC: true
+isPrivileged: false
 
 serviceAccount:
   name: ""


### PR DESCRIPTION
In this PR:
* **Bug fix**- service account that's being created does not match the service account references in other resources.
* Add parameter that allows setting pods to have privileged security context.