### PR TITLE
Fluentbit image 0.4.1 & chart 0.0.5

### DIFF
--- a/charts/fluentbit/Chart.yaml
+++ b/charts/fluentbit/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - fluent-bit
   - fluentd
 type: application
-version: 0.0.4
-appVersion: 0.3.0
+version: 0.0.5
+appVersion: 0.4.1
 sources:
   - https://github.com/logzio/logzio-helm
   - https://github.com/fluent/fluent-bit/

--- a/charts/fluentbit/README.md
+++ b/charts/fluentbit/README.md
@@ -90,6 +90,10 @@ kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.tain
 
 
 ## Change log
+* 0.0.5 - Upgrade docker image to 0.4.1
+  * Trim the compiler build path from stack traces.
+  * Add timestamp decode support for new fluentbit versions.
+  * Update to fluent-bit 2.1.9 in docker image.
 * 0.0.4 - Upgrade docker image to 0.3.0, adding dedot filter
           in Logzio Output config, added memory and cpu requirements.
 * 0.0.3 - Upgrade docker image to 0.1.3.

--- a/charts/fluentbit/values.yaml
+++ b/charts/fluentbit/values.yaml
@@ -12,7 +12,7 @@ replicaCount: 1
 image:
   repository: logzio/fluent-bit-output
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
-  tag: "0.3.0"
+  tag: "0.4.1"
   pullPolicy: Always
 
 testFramework:

--- a/charts/logzio-k8s-events/Chart.yaml
+++ b/charts/logzio-k8s-events/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - k8s
   - kubernetes
-version: 0.0.1
-appVersion: 0.0.1
+version: 0.0.2
+appVersion: 0.0.2
 maintainers:
   - name: Raul Gurshumov
     email: raul.gurshumo@logz.io

--- a/charts/logzio-k8s-events/README.md
+++ b/charts/logzio-k8s-events/README.md
@@ -96,5 +96,7 @@ kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.tain
 
 
 ## Change log
+ - **0.0.2**:
+    - Ignore internal event changes.
  - **0.0.1**:
     - Initial release.

--- a/charts/logzio-k8s-events/values.yaml
+++ b/charts/logzio-k8s-events/values.yaml
@@ -6,7 +6,7 @@
 image:
   repository: logzio/logzio-k8s-events
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.0.1"
+  tag: "0.0.2"
 
 k8sApp: logzio-k8s-events
 


### PR DESCRIPTION
- Upgrade chart version to 0.0.5
- Upgrade docker image to 0.4.1
- Trim the compiler build path from stack traces.
- Add timestamp decode support for new fluentbit versions.
- Update to fluent-bit 2.1.9 in docker image.