### PR TITLE
Fluentbit image 0.4.1 & chart 0.0.5

### DIFF
--- a/charts/fluentbit/Chart.yaml
+++ b/charts/fluentbit/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - fluent-bit
   - fluentd
 type: application
-version: 0.0.4
-appVersion: 0.3.0
+version: 0.0.5
+appVersion: 0.4.1
 sources:
   - https://github.com/logzio/logzio-helm
   - https://github.com/fluent/fluent-bit/

--- a/charts/fluentbit/README.md
+++ b/charts/fluentbit/README.md
@@ -90,6 +90,10 @@ kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.tain
 
 
 ## Change log
+* 0.0.5 - Upgrade docker image to 0.4.1
+  * Trim the compiler build path from stack traces.
+  * Add timestamp decode support for new fluentbit versions.
+  * Update to fluent-bit 2.1.9 in docker image.
 * 0.0.4 - Upgrade docker image to 0.3.0, adding dedot filter
           in Logzio Output config, added memory and cpu requirements.
 * 0.0.3 - Upgrade docker image to 0.1.3.

--- a/charts/fluentbit/values.yaml
+++ b/charts/fluentbit/values.yaml
@@ -12,7 +12,7 @@ replicaCount: 1
 image:
   repository: logzio/fluent-bit-output
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
-  tag: "0.3.0"
+  tag: "0.4.1"
   pullPolicy: Always
 
 testFramework:


### PR DESCRIPTION
* Upgrade chart version to 0.0.5
* Upgrade docker image to 0.4.1
* Trim the compiler build path from stack traces.
* Add timestamp decode support for new fluentbit versions.
* Update to fluent-bit 2.1.9 in docker image.