### PR TITLE
Service graph & span metrics connectors

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 3.2.0
+version: 3.3.0
 
 sources:
   - https://github.com/logzio/logzio-helm
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "2.1.0"
+    version: "2.2.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -59,6 +59,7 @@ helm install -n monitoring \
 --set logzio-k8s-telemetry.spm.enabled=true \
 --set logzio-k8s-telemetry.secrets.env_id="<<ENV-ID>>" \
 --set logzio-k8s-telemetry.secrets.SpmToken=<<SPM-SHIPPING-TOKEN>> \
+--set logzio-k8s-telemetry.serviceGraph.enabled=true \
 --set securityReport.enabled=true \
 --set logzio-trivy.env_id="<<ENV-ID>>" \
 --set logzio-trivy.secrets.logzioShippingToken="<<LOG-SHIPPING-TOKEN>>" \
@@ -187,6 +188,13 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **3.3.0**:
+	- Upgrade `logzio-k8s-telemetry` to `2.2.0`:
+		- Upgraded SPM collector image to version `0.80.0`.
+		- Added service graph connector metrics.
+			- `serviceGraph.enabled` option.
+		- Refactored span metrics processor to a connector.
+			- Added metrics transform processor to modify the data for Logz.io backwards compatibility.
 - **3.2.0**:
 	- Upgrade `logzio-k8s-telemetry` to `2.1.0`:
 		- Update SPM labels

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -30,7 +30,6 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-
 version: 2.2.0
 
 

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -117,7 +117,23 @@ helm install  \
 --set secrets.env_id=<<ENV-ID>> \
 logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 ```
-
+#### Deploy both charts with span metrics and service graph
+**Note** `serviceGraph.enabled=true` will have no effect unless `traces.enabled` & `spm.enabled=true` is also set to `true`
+```
+helm install  \
+--set traces.enabled=true \
+--set spm.enabled=true \
+--set serviceGraph.enabled=true \
+--set secrets.TracesToken=<<TRACES-SHIPPING-TOKEN>> \
+--set secrets.SpmToken=<<SPM-SHIPPING-TOKEN>> \
+--set secrets.LogzioRegion=<<logzio-region>> \
+--set metrics.enabled=true \
+--set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
+--set secrets.ListenerHost=<<LISTENER-HOST>> \
+--set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
+--set secrets.env_id=<<ENV-ID>> \
+logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
+```
 #### Handling image pull rate limit
 In some cases (i.e spot clusters) where the pods/nodes are replaced frequently, the pull rate limit for images pulled from dockerhub might be reached, with an error:
 `You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limits`.

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -339,7 +339,11 @@ helm uninstall logzio-k8s-telemetry
 
 
 ## Change log
-
+* 1.3.0
+  - Upgraded SPM collector image to version `0.80.0`.
+  - Added service graph connector metrics.
+  - Refactored span metrics processor to a connector.
+    - Added metrics transform processor to modify the data for Logz.io backwards compatibility.
 * 1.2.0
   - Upgraded collector image to `0.80.0`.
   - Changed condition to filter duplicate metrics collected by daemonset collector.

--- a/charts/logzio-telemetry/templates/configmap-spm.yaml
+++ b/charts/logzio-telemetry/templates/configmap-spm.yaml
@@ -1,5 +1,14 @@
 {{- if and .Values.spm.enabled .Values.traces.enabled }}
 {{ $config := .Values.spanMetricsAgregator.config }}
+{{/* Handle serviceGraph config */}}
+{{- if .Values.serviceGraph.enabled -}}
+{{ $serviceGraphConfig := .Values.serviceGraph.config }}
+{{- $config := deepCopy $serviceGraphConfig | merge $config | mustMergeOverwrite -}}
+{{- $_ := set (index $config "service" "pipelines" "metrics/spm-logzio") "receivers" (concat (index $config "service" "pipelines" "metrics/spm-logzio" "receivers") (index $serviceGraphConfig "service" "pipelines" "metrics/spm-logzio" "receivers" )) -}}
+{{- $_ := set (index $config "service" "pipelines" "traces") "exporters" (concat (index $config "service" "pipelines" "traces" "exporters") (index $serviceGraphConfig "service" "pipelines" "traces" "exporters" )) -}}
+{{- end -}}
+{{- end -}}
+
 {{- $configYaml := toYaml $config }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -656,7 +656,7 @@ spanMetricsAgregator:
           - name: db.system
           - name: messaging.system          
           - name: env_id
-            default: ${ENV_ID}           
+            default: ${ENV_ID}
     receivers:
       # Dummy recivier 
       otlp/spm:

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -629,6 +629,8 @@ spanMetricsAgregator:
           - name: k8s.job.name
           - name: cloud.provider
           - name: cloud.region
+          - name: db.system
+          - name: messaging.system          
           - name: env_id
             default: ${ENV_ID}
       servicegraph:

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -585,6 +585,25 @@ ports:
     hostPort: 9411
     protocol: TCP
 
+# Span and service graph metrics
+serviceGraph:
+  enabled: true
+  config:
+    connectors:
+      servicegraph:
+        latency_histogram_buckets: [2ms, 8ms, 50ms, 100ms, 200ms, 500ms, 1s, 5s, 10s]
+        dimensions:
+          - env_id
+        store:
+          ttl: 5s
+          max_items: 100000
+    service:
+      pipelines:
+        traces:
+          exporters: [servicegraph]      
+        metrics/spm-logzio:
+          receivers: [servicegraph]
+
 spanMetricsAgregator:
   config:
     processors:
@@ -637,14 +656,7 @@ spanMetricsAgregator:
           - name: db.system
           - name: messaging.system          
           - name: env_id
-            default: ${ENV_ID}
-      servicegraph:
-        latency_histogram_buckets: [2ms, 8ms, 50ms, 100ms, 200ms, 500ms, 1s, 5s, 10s]
-        dimensions:
-          - env_id
-        store:
-          ttl: 5s
-          max_items: 100000            
+            default: ${ENV_ID}           
     receivers:
       # Dummy recivier 
       otlp/spm:
@@ -695,13 +707,13 @@ spanMetricsAgregator:
       pipelines:
         traces:
           receivers: [jaeger, zipkin, otlp]
-          exporters: [logging, spanmetrics, servicegraph]
+          exporters: [logging, spanmetrics]
         metrics/spm:
           # Dummy recivier 
           receivers: [otlp/spm]
           exporters: [prometheus/spm]
         metrics/spm-logzio:
-          receivers: [prometheus/spm-logzio, spanmetrics, servicegraph]
+          receivers: [prometheus/spm-logzio, spanmetrics]
           processors: [metricstransform]
           exporters: [prometheusremotewrite/spm-logzio]
   # service values        

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -508,7 +508,7 @@ windowsExporterInstallerImage:
 spmImage:
   repository: otel/opentelemetry-collector-contrib
   pullPolicy: IfNotPresent
-  tag: "0.73.0"
+  tag: "0.80.0"
 imagePullSecrets: []
 
 # OpenTelemetry Collector executable
@@ -584,9 +584,35 @@ ports:
 spanMetricsAgregator:
   config:
     processors:
+      # Modify the data to support Logz.io backwards compatibility
+      metricstransform:
+        transforms:
+          - include: '^duration.*'
+            action: update
+            match_type: regexp
+            new_name: 'latency.$1'
+          - include: calls
+            action: update
+            new_name: calls_total 
+          - include: ^latency
+            action: update
+            match_type: regexp            
+            operations:
+              - action: update_label
+                label: span.name
+                new_label: operation 
+          - include: ^calls
+            action: update
+            match_type: regexp            
+            operations:
+              - action: update_label
+                label: span.name
+                new_label: operation     
+    connectors:
       spanmetrics:
-        metrics_exporter: prometheus/spm
-        latency_histogram_buckets: [2ms, 8ms, 50ms, 100ms, 200ms, 500ms, 1s, 5s, 10s]
+        histogram:
+          explicit:
+            buckets: [2ms, 8ms, 50ms, 100ms, 200ms, 500ms, 1s, 5s, 10s]
         dimensions_cache_size: 100000
         aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
         dimensions:
@@ -605,6 +631,13 @@ spanMetricsAgregator:
           - name: cloud.region
           - name: env_id
             default: ${ENV_ID}
+      servicegraph:
+        latency_histogram_buckets: [2ms, 8ms, 50ms, 100ms, 200ms, 500ms, 1s, 5s, 10s]
+        dimensions:
+          - env_id
+        store:
+          ttl: 5s
+          max_items: 100000            
     receivers:
       # Dummy recivier 
       otlp/spm:
@@ -650,14 +683,14 @@ spanMetricsAgregator:
       pipelines:
         traces:
           receivers: [jaeger, zipkin, otlp]
-          processors: [spanmetrics]
-          exporters: [logging]
+          exporters: [logging, spanmetrics, servicegraph]
         metrics/spm:
           # Dummy recivier 
           receivers: [otlp/spm]
           exporters: [prometheus/spm]
         metrics/spm-logzio:
-          receivers: [prometheus/spm-logzio]
+          receivers: [prometheus/spm-logzio, spanmetrics, servicegraph]
+          processors: [metricstransform]
           exporters: [prometheusremotewrite/spm-logzio]
   # service values        
   service:


### PR DESCRIPTION
- Upgrade `logzio-monitoring` to v3.3.0
  - Upgrade `logzio-k8s-telemetry` to v2.2.0
    - Upgraded SPM collector image to version `0.80.0`.
    - Added service graph connector metrics.
      - `serviceGraph.enabled` option.
    - Refactored span metrics processor to a connector.
    - Added metrics transform processor to modify the data for Logz.io backwards compatibility.