### PR TITLE
v1.3.0 - Upgrade autoscaling api group version

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "1.2.0"
+    version: "1.2.1"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 1.7.0
+version: 1.7.1
 
 sources:
   - https://github.com/logzio/logzio-helm

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 1.7.1
+version: 1.8.0
 
 sources:
   - https://github.com/logzio/logzio-helm

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "1.2.1"
+    version: "1.3.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -165,6 +165,9 @@ Set logzio-k8s-telemetry `ListenerHost` value to send your metrics to a custom e
 ```
 
 ## Changelog
+- **1.7.1**:
+	- Upgrade `logzio-k8s-telemetry` to `1.2.1`:
+		- Upgraded horizontal pod autoscaler API group version.
 - **1.7.0**:
 	- Upgrade `logzio-fluentd` to `0.25.0`:
    - Add parameter `isPrivileged` to allow running Daemonset with priviliged security context.

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -165,7 +165,7 @@ Set logzio-k8s-telemetry `ListenerHost` value to send your metrics to a custom e
 ```
 
 ## Changelog
-- **1.7.1**:
+- **1.8.0**:
 	- Upgrade `logzio-k8s-telemetry` to `1.3.0`:
 		- Upgraded horizontal pod autoscaler API group version.
 	- Remove replicasCount from daemonset.

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -168,6 +168,7 @@ Set logzio-k8s-telemetry `ListenerHost` value to send your metrics to a custom e
 - **1.7.1**:
 	- Upgrade `logzio-k8s-telemetry` to `1.3.0`:
 		- Upgraded horizontal pod autoscaler API group version.
+	- Remove replicasCount from daemonset.
 - **1.7.0**:
 	- Upgrade `logzio-fluentd` to `0.25.0`:
    - Add parameter `isPrivileged` to allow running Daemonset with priviliged security context.

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -166,7 +166,7 @@ Set logzio-k8s-telemetry `ListenerHost` value to send your metrics to a custom e
 
 ## Changelog
 - **1.7.1**:
-	- Upgrade `logzio-k8s-telemetry` to `1.2.1`:
+	- Upgrade `logzio-k8s-telemetry` to `1.3.0`:
 		- Upgraded horizontal pod autoscaler API group version.
 - **1.7.0**:
 	- Upgrade `logzio-fluentd` to `0.25.0`:

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.3.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -339,7 +339,7 @@ helm uninstall logzio-k8s-telemetry
 
 
 ## Change log
-* 1.2.1
+* 1.3.0
   - Upgraded horizontal pod autoscaler API group version.
 * 1.2.0
   - Upgraded collector image to `0.80.0`.

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -339,7 +339,8 @@ helm uninstall logzio-k8s-telemetry
 
 
 ## Change log
-
+* 1.2.1
+  - Upgraded horizontal pod autoscaler API group version.
 * 1.2.0
   - Upgraded collector image to `0.80.0`.
   - Changed condition to filter duplicate metrics collected by daemonset collector.

--- a/charts/logzio-telemetry/templates/daemonset-collector.yaml
+++ b/charts/logzio-telemetry/templates/daemonset-collector.yaml
@@ -6,9 +6,6 @@ metadata:
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 spec:
-{{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.standaloneCollector.replicaCount }}
-{{- end }}
   selector:
     matchLabels:
       {{- include "opentelemetry-collector.selectorLabels" . | nindent 6 }}

--- a/charts/logzio-telemetry/templates/hpa.yaml
+++ b/charts/logzio-telemetry/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.autoscaling.enabled .Values.standaloneCollector.enabled }}
-apiVersion: {{ if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}autoscaling/v2{{ else }}autoscaling/v2beta2{{ end }}
+apiVersion: {{ if semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version }}autoscaling/v2{{ else }}autoscaling/v2beta1{{ end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
@@ -17,7 +17,7 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
+        {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
@@ -29,7 +29,7 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
+        {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}

--- a/charts/logzio-telemetry/templates/hpa.yaml
+++ b/charts/logzio-telemetry/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.autoscaling.enabled .Values.standaloneCollector.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}autoscaling/v2{{ else }}autoscaling/v2beta2{{ end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
@@ -17,12 +17,24 @@ spec:
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- end }}
   {{- end }}
   {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
- Added a condition to the horizontal pod autoscaler to upgrade the api group version if the Kubernetes version is 1.23+ as the previous one was deprecated in newer versions.
- Updated logzio-monitoring chart dependency version.
- Upgraded chart versions to logzio-monitoring & logzio-telemetry charts