### PR TITLE
logzio-monitoring v2.0.0 - Add Kubernetes deploy events integration

### DIFF
--- a/charts/logzio-k8s-events/Chart.yaml
+++ b/charts/logzio-k8s-events/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - k8s
   - kubernetes
 version: 0.0.3
-appVersion: 0.0.3
+appVersion: 0.0.2
 maintainers:
   - name: Raul Gurshumov
     email: raul.gurshumo@logz.io

--- a/charts/logzio-k8s-events/Chart.yaml
+++ b/charts/logzio-k8s-events/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
   - logging
   - k8s
   - kubernetes
-version: 0.0.2
-appVersion: 0.0.2
+version: 0.0.3
+appVersion: 0.0.3
 maintainers:
   - name: Raul Gurshumov
     email: raul.gurshumo@logz.io

--- a/charts/logzio-k8s-events/README.md
+++ b/charts/logzio-k8s-events/README.md
@@ -96,6 +96,8 @@ kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.tain
 
 
 ## Change log
+ - **0.0.3**:
+    - Rename listener template.
  - **0.0.2**:
     - Ignore internal event changes.
  - **0.0.1**:

--- a/charts/logzio-k8s-events/templates/_helpers.tpl
+++ b/charts/logzio-k8s-events/templates/_helpers.tpl
@@ -68,7 +68,7 @@ Create the name of the service account to use
 {{/*
 Builds the full logzio listener host
 */}}
-{{- define "logzio.listenerHost" }}
+{{- define "logzio-k8s-events.listenerHost" }}
 {{- if not (eq .Values.secrets.customListener "") -}}
 {{- printf "%s" .Values.secrets.customListener -}}
 {{- else -}}

--- a/charts/logzio-k8s-events/templates/secret.yaml
+++ b/charts/logzio-k8s-events/templates/secret.yaml
@@ -10,6 +10,6 @@ metadata:
 type: Opaque
 stringData:
   logzio-log-shipping-token: {{ required "Logzio shipping token is required!" .Values.secrets.logzioShippingToken }}
-  logzio-log-listener: {{ template "logzio.listenerHost" . }}
+  logzio-log-listener: {{ template "logzio-k8s-events.listenerHost" . }}
   env-id: {{ .Values.secrets.env_id }}
 {{- end }}

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "1.2.0"
+    version: "1.3.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 1.8.0
+version: 2.0.0
 
 sources:
   - https://github.com/logzio/logzio-helm
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "1.3.0"
+    version: "1.2.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy
@@ -23,6 +23,10 @@ dependencies:
     version: "1.3.0"
     repository: "https://opencost.github.io/opencost-helm-chart"
     condition: finops.enabled
+  - name: logzio-k8s-events
+    version: "0.0.2"
+    repository: "https://logzio.github.io/logzio-helm/"
+    condition: deployEvents.enabled
 
 maintainers:
 - name: tamirmich

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
     repository: "https://opencost.github.io/opencost-helm-chart"
     condition: finops.enabled
   - name: logzio-k8s-events
-    version: "0.0.2"
+    version: "0.0.3"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
 

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -56,6 +56,10 @@ helm install -n monitoring \
 --set logzio-trivy.env_id="<<ENV-ID>>" \
 --set logzio-trivy.secrets.logzioShippingToken="<<LOG-SHIPPING-TOKEN>>" \
 --set logzio-trivy.secrets.logzioListener="<<LISTENER-HOST>>" \
+--set deployEvents.enabled=true \
+--set logzio-k8s-events.secrets.env_id="<<ENV-ID>>" \
+--set logzio-k8s-events.secrets.logzioShippingToken="<<LOG-SHIPPING-TOKEN>>" \
+--set logzio-k8s-events.secrets.logzioListener="<<LISTENER-HOST>>" \
 logzio-monitoring logzio-helm/logzio-monitoring
 ```
 
@@ -80,7 +84,9 @@ However, you can modify the Chart by using the `--set` flag in your `helm instal
 | Parameter	| Description | Default |
 | --- | --- | --- |
 | `logs.enabled` | Enable to send k8s logs | `false` |
-| `metricsOrTraces` | Enable to send k8s metrics or traces | `false` |
+| `metricsOrTraces.enabled` | Enable to send k8s metrics or traces | `false` |
+| `securityReport.enabled` | Enable to send k8s security logs | `false` |
+| `deployEvents.enabled` | Enable to send k8s deploy events logs | `false` |
 
 #### To modify the logs Chart configuration:
 
@@ -165,6 +171,9 @@ Set logzio-k8s-telemetry `ListenerHost` value to send your metrics to a custom e
 ```
 
 ## Changelog
+- **2.0.0**:
+	- Add `logzio-k8s-events` sub chart version `0.0.2`:
+		- Sends Kubernetes deploy events logs.
 - **1.8.0**:
 	- Upgrade `logzio-k8s-telemetry` to `1.3.0`:
 		- Upgraded horizontal pod autoscaler API group version.

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -172,7 +172,7 @@ Set logzio-k8s-telemetry `ListenerHost` value to send your metrics to a custom e
 
 ## Changelog
 - **2.0.0**:
-	- Add `logzio-k8s-events` sub chart version `0.0.2`:
+	- Add `logzio-k8s-events` sub chart version `0.0.3`:
 		- Sends Kubernetes deploy events logs.
 - **1.8.0**:
 	- Upgrade `logzio-k8s-telemetry` to `1.3.0`:

--- a/charts/logzio-monitoring/values.yaml
+++ b/charts/logzio-monitoring/values.yaml
@@ -6,6 +6,8 @@ securityReport:
   enabled: false
 finops:
   enabled: false
+deployEvents:
+  enabled: false
 
 logzio-fluentd:
   daemonset:


### PR DESCRIPTION
- Upgraded logzio-monitoring chart to version to 2.0.0
- Added sub chart logzio-k8s-events v0.0.3
- Rename listener host template
  - Update secret template with new name
-  Updated readme file
- Added option to enable deploy events in the chart values