### PR TITLE
Upgrade logzio-k8s-telemetry to 2.0.0

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "1.3.0"
+    version: "2.0.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 2.0.0
+version: 3.0.0
 
 sources:
   - https://github.com/logzio/logzio-helm

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -11,6 +11,13 @@ This project packages 3 Helm Charts:
 - [logzio-telemetry](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-telemetry) for metrics and traces (via OpenTelemetry Collector).
 - [logzio-trivy](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-trivy) for security reports (via Trivy operator).
 
+### Kubernetes Versions
+
+| Cluster Version | Chart Version |
+|---|---|
+| v1.22.0 - v1.28.0 | 3.0.0 |
+| Up to v1.22.0 | 2.0.0 |
+
 ## Instructions for standard deployment:
 
 ### Before installing the chart

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -171,6 +171,12 @@ Set logzio-k8s-telemetry `ListenerHost` value to send your metrics to a custom e
 ```
 
 ## Changelog
+- **3.0.0**:
+	- Upgrade `logzio-k8s-telemetry` to `2.0.0`:
+		- Upgrade its sub charts to latest versions.
+			- `kube-state-metrics` to `4.24.0`
+			- `prometheus-node-exporter` to `4.23.2`
+			- `prometheus-pushgateway` to `2.4.2`
 - **2.0.0**:
 	- Add `logzio-k8s-events` sub chart version `0.0.3`:
 		- Sends Kubernetes deploy events logs.

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -11,12 +11,11 @@ This project packages 3 Helm Charts:
 - [logzio-telemetry](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-telemetry) for metrics and traces (via OpenTelemetry Collector).
 - [logzio-trivy](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-trivy) for security reports (via Trivy operator).
 
-### Kubernetes Versions
-
-| Cluster Version | Chart Version |
+### Kubernetes Versions Compatibility
+| Chart Version | Kubernetes Version |
 |---|---|
-| v1.22.0 - v1.28.0 | 3.0.0 |
-| Up to v1.22.0 | 2.0.0 |
+| 3.0.0 | v1.22.0 - v1.28.0 |
+| < 2.0.0 | <= v1.22.0 |
 
 ## Instructions for standard deployment:
 

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -9,19 +9,19 @@ sources:
   - https://github.com/kubernetes/kube-state-metrics
 dependencies:
   - name: kube-state-metrics
-    version: "4.13.0"
+    version: "4.24.0"
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: kubeStateMetrics.enabled
     tags:
       - metrics.enabled
   - name: prometheus-node-exporter
-    version: "3.3.0"
+    version: "4.23.2"
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: nodeExporter.enabled
     tags:
       - metrics.enabled
   - name: prometheus-pushgateway
-    version: "1.18.2"
+    version: "2.4.2"
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: pushGateway.enabled
     tags:
@@ -29,7 +29,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 2.0.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -14,6 +14,12 @@ It is also dependent on the [kube-state-metrics](https://github.com/kubernetes/k
 To disable the dependency during installation, set `kubeStateMetrics.enabled` and `nodeExporter` to `false`.
 
 
+### Kubernetes Versions
+
+| Cluster Version | Chart Version |
+|---|---|
+| v1.22.0 - v1.28.0 | 2.0.0 |
+| Up to v1.22.0 | 1.3.0 |
 
 #### Before installing the chart
 * Check if you have any taints on your nodes:

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -14,12 +14,11 @@ It is also dependent on the [kube-state-metrics](https://github.com/kubernetes/k
 To disable the dependency during installation, set `kubeStateMetrics.enabled` and `nodeExporter` to `false`.
 
 
-### Kubernetes Versions
-
-| Cluster Version | Chart Version |
+### Kubernetes Versions Compatibility
+| Chart Version | Kubernetes Version |
 |---|---|
-| v1.22.0 - v1.28.0 | 2.0.0 |
-| Up to v1.22.0 | 1.3.0 |
+| 2.0.0 | v1.22.0 - v1.28.0 |
+| < 1.3.0 | <= v1.22.0 |
 
 #### Before installing the chart
 * Check if you have any taints on your nodes:

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -339,6 +339,11 @@ helm uninstall logzio-k8s-telemetry
 
 
 ## Change log
+* 2.0.0
+  - Upgrade sub charts to their latest versions.
+    - `kube-state-metrics` to `4.24.0`
+    - `prometheus-node-exporter` to `4.23.2`
+    - `prometheus-pushgateway` to `2.4.2`
 * 1.3.0
   - Upgraded horizontal pod autoscaler API group version.
 * 1.2.0


### PR DESCRIPTION
- Upgrade 'logzio-k8s-telemetry' to v2.0.0
  - Upgrade the sub charts to latest versions.
    - 'kube-state-metrics' to v 4.24.0 
    - 'prometheus-node-exporter' to v4.23.2 
    - 'prometheus-pushgateway' to v2.4.2