### PR TITLE
prometheus-alerts-migrator 1.0.0

### DIFF
--- a/charts/prometheus-alerts-migrator/.helmignore
+++ b/charts/prometheus-alerts-migrator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/prometheus-alerts-migrator/Chart.yaml
+++ b/charts/prometheus-alerts-migrator/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: prometheus-alerts-migrator
+description: This Helm chart serves as a Kubernetes controller that automates the migration of Prometheus alert rules to Logz.io's alert format, facilitating monitoring and alert management in a Logz.io integrated environment.
+
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"

--- a/charts/prometheus-alerts-migrator/Chart.yaml
+++ b/charts/prometheus-alerts-migrator/Chart.yaml
@@ -2,24 +2,12 @@ apiVersion: v2
 name: prometheus-alerts-migrator
 description: This Helm chart serves as a Kubernetes controller that automates the migration of Prometheus alert rules to Logz.io's alert format, facilitating monitoring and alert management in a Logz.io integrated environment.
 
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.0.0
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
 appVersion: "1.0.0"
+
+maintainers:
+- name: yotamloe
+  email: yotam.loewenbach@logz.io

--- a/charts/prometheus-alerts-migrator/README.md
+++ b/charts/prometheus-alerts-migrator/README.md
@@ -14,12 +14,12 @@ To install the chart with the release name `logzio-prometheus-alerts-migrator`:
 
 ```sh
 helm install \
-  --set applicationConfig.annotation="prometheus.io/kube-rules" \
-  --set applicationConfig.logzioAPIToken="your-logzio-api-token" \
-  --set applicationConfig.logzioAPIURL="https://api.logz.io/" \
-  --set applicationConfig.rulesDS="<<logzio_metrics_data_source_name>>" \
-  --set applicationConfig.envID="<<env_id>>" \
-  --set applicationConfig.workerCount=2 \
+  --set config.configMapAnnotation="prometheus.io/kube-rules" \
+  --set config.logzioAPIToken="your-logzio-api-token" \
+  --set config.logzioAPIURL="https://api.logz.io/" \
+  --set config.rulesDS="<<logzio_metrics_data_source_name>>" \
+  --set config.env_id="<<env_id>>" \
+  --set config.workerCount=2 \
   logzio-prometheus-alerts-migrator logzio-helm/prometheus-alerts-migrator
 ```
 
@@ -34,12 +34,12 @@ The following table lists the configurable parameters of the Prometheus Alerts M
 | image.tag | Container image tag | v1.0.0-test |
 | serviceAccount.create | Specifies whether a service account should be created | true |
 | serviceAccount.name | The name of the service account to use | "" |
-| applicationConfig.annotation | ConfigMap annotation for rules | prometheus.io/kube-rules |
-| applicationConfig.logzioAPIToken | Logz.io API token | "" |
-| applicationConfig.logzioAPIURL | Logz.io API URL | https://api.logz.io/ |
-| applicationConfig.rulesDS | Data source for rules | IntegrationsTeamTesting_metrics |
-| applicationConfig.envID | Environment ID | my-env-yotam |
-| applicationConfig.workerCount | Number of workers | 2 |
+| config.configMapAnnotation | ConfigMap annotation for rules | prometheus.io/kube-rules |
+| config.logzioAPIToken | Logz.io API token | "" |
+| config.logzioAPIURL | Logz.io API URL | https://api.logz.io/ |
+| config.rulesDS | Data source for rules | IntegrationsTeamTesting_metrics |
+| config.env_id | Environment ID | my-env-yotam |
+| config.workerCount | Number of workers | 2 |
 | rbac.rules | Custom rules for the Kubernetes cluster role | [{apiGroups: [""], resources: ["configmaps"], verbs: ["get", "list", "watch"]}] |
 
 ### ConfigMap Format

--- a/charts/prometheus-alerts-migrator/README.md
+++ b/charts/prometheus-alerts-migrator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the Prometheus Alerts M
 | `replicaCount` | Number of controller replicas | 1 |
 | `image.repository` | Container image repository | logzio/prometheus-alerts-migrator |
 | `image.pullPolicy` | Container image pull policy | IfNotPresent |
-| `image.tag`| Container image tag | v1.0.0-test |
+| `image.tag`| Container image tag | v1.0.0 |
 | `serviceAccount.create` | Specifies whether a service account should be created | true |
 | `serviceAccount.name` | The name of the service account to use | "" |
 | `config.configMapAnnotation` | ConfigMap annotation for rules | prometheus.io/kube-rules |

--- a/charts/prometheus-alerts-migrator/README.md
+++ b/charts/prometheus-alerts-migrator/README.md
@@ -28,19 +28,50 @@ The following table lists the configurable parameters of the Prometheus Alerts M
 
 | Parameter | Description | Default |
 |---|---|---|
-| replicaCount | Number of controller replicas | 1 |
-| image.repository | Container image repository | logzio/prometheus-alerts-migrator |
-| image.pullPolicy | Container image pull policy | IfNotPresent |
-| image.tag | Container image tag | v1.0.0-test |
-| serviceAccount.create | Specifies whether a service account should be created | true |
-| serviceAccount.name | The name of the service account to use | "" |
-| config.configMapAnnotation | ConfigMap annotation for rules | prometheus.io/kube-rules |
-| config.logzioAPIToken | Logz.io API token | "" |
-| config.logzioAPIURL | Logz.io API URL | https://api.logz.io/ |
-| config.rulesDS | Data source for rules | IntegrationsTeamTesting_metrics |
-| config.env_id | Environment ID | my-env-yotam |
-| config.workerCount | Number of workers | 2 |
-| rbac.rules | Custom rules for the Kubernetes cluster role | [{apiGroups: [""], resources: ["configmaps"], verbs: ["get", "list", "watch"]}] |
+| `replicaCount` | Number of controller replicas | 1 |
+| `image.repository` | Container image repository | logzio/prometheus-alerts-migrator |
+| `image.pullPolicy` | Container image pull policy | IfNotPresent |
+| `image.tag`| Container image tag | v1.0.0-test |
+| `serviceAccount.create` | Specifies whether a service account should be created | true |
+| `serviceAccount.name` | The name of the service account to use | "" |
+| `config.configMapAnnotation` | ConfigMap annotation for rules | prometheus.io/kube-rules |
+| `config.logzioAPIToken` | Logz.io API token | "" |
+| `config.logzioAPIURL` | Logz.io API URL | https://api.logz.io/ |
+| `config.rulesDS` | Data source for rules | IntegrationsTeamTesting_metrics |
+| `config.env_id` | Environment ID | my-env-yotam |
+| `config.workerCount` | Number of workers | 2 |
+| `rbac.rules` | Custom rules for the Kubernetes cluster role | [{apiGroups: [""], resources: ["configmaps"], verbs: ["get", "list", "watch"]}] |
+
+## Secret Management
+
+The chart can optionally create a Kubernetes Secret to store sensitive information like the Logz.io API token. You can control the creation and naming of this Secret through the following configurations in the `values.yaml` file.
+
+| Parameter       | Description                                                        | Default             |
+| --------------- | ------------------------------------------------------------------ | ------------------- |
+| `secret.enabled` | Determines whether a Secret should be created by the Helm chart.  | `true`              |
+| `secret.name`    | Specifies the name of the Secret to be used.                      | `logzio-api-token`  |
+
+
+### Using an Existing Secret
+By default, the chart will create a Secret named `logzio-api-token`. You can change the name by setting `secret.name` to your preferred name. If you enable Secret creation, make sure to provide the actual token value in the `values.yaml` or via the `--set` flag:
+```sh
+helm install \
+  --set logzioAPIToken=your-logzio-api-token \
+  logzio-prometheus-alerts-migrator logzio-helm/prometheus-alerts-migrator
+```
+
+If you prefer to manage the Secret outside of the Helm chart (e.g., for security reasons or to use an existing Secret), set `secret.enabled` to `false` and provide the name of your existing Secret in `secret.name`.
+
+Example of disabling Secret creation and using an existing Secret:
+
+```sh
+helm install \
+  --set secret.enabled=false \
+  --set secret.name=my-existing-secret \
+  logzio-prometheus-alerts-migrator logzio-helm/prometheus-alerts-migrator
+```
+In this case, ensure that your existing Secret my-existing-secret contains the necessary key (`token` in this context) with the appropriate value (Logz.io API token).
+
 
 ### ConfigMap Format
 The controller is designed to process ConfigMaps containing Prometheus alert rules. These ConfigMaps must be annotated with a specific key that matches the value of the `ANNOTATION` environment variable for the controller to process them.

--- a/charts/prometheus-alerts-migrator/README.md
+++ b/charts/prometheus-alerts-migrator/README.md
@@ -48,8 +48,8 @@ The chart can optionally create a Kubernetes Secret to store sensitive informati
 
 | Parameter       | Description                                                        | Default             |
 | --------------- | ------------------------------------------------------------------ | ------------------- |
-| `secret.enabled` | Determines whether a Secret should be created by the Helm chart.  | `true`              |
-| `secret.name`    | Specifies the name of the Secret to be used.                      | `logzio-api-token`  |
+| `secret.create` | Determines whether a Secret should be created by the Helm chart.  | `true`              |
+| `secret.name`   | Specifies the name of the Secret to be used.                      | `logzio-api-token`  |
 
 
 ### Using an Existing Secret

--- a/charts/prometheus-alerts-migrator/README.md
+++ b/charts/prometheus-alerts-migrator/README.md
@@ -1,0 +1,78 @@
+# Prometheus Alerts Migrator Helm Chart
+
+This Helm chart deploys the Prometheus Alerts Migrator as a Kubernetes controller, which automates the migration of Prometheus alert rules to Logz.io's alert format, facilitating monitoring and alert management in a Logz.io integrated environment.
+
+## Prerequisites
+
+- Helm 3+
+- Kubernetes 1.19+
+- Logz.io account with API access
+
+## Installing the Chart
+
+To install the chart with the release name `logzio-prometheus-alerts-migrator`:
+
+```sh
+helm install \
+  --set applicationConfig.annotation="prometheus.io/kube-rules" \
+  --set applicationConfig.logzioAPIToken="your-logzio-api-token" \
+  --set applicationConfig.logzioAPIURL="https://api.logz.io/" \
+  --set applicationConfig.rulesDS="<<logzio_metrics_data_source_name>>" \
+  --set applicationConfig.envID="<<env_id>>" \
+  --set applicationConfig.workerCount=2 \
+  logzio-prometheus-alerts-migrator logzio-helm/prometheus-alerts-migrator
+```
+
+## Configuration
+The following table lists the configurable parameters of the Prometheus Alerts Migrator chart and their default values.
+
+| Parameter | Description | Default |
+|---|---|---|
+| replicaCount | Number of controller replicas | 1 |
+| image.repository | Container image repository | logzio/prometheus-alerts-migrator |
+| image.pullPolicy | Container image pull policy | IfNotPresent |
+| image.tag | Container image tag | v1.0.0-test |
+| serviceAccount.create | Specifies whether a service account should be created | true |
+| serviceAccount.name | The name of the service account to use | "" |
+| applicationConfig.annotation | ConfigMap annotation for rules | prometheus.io/kube-rules |
+| applicationConfig.logzioAPIToken | Logz.io API token | "" |
+| applicationConfig.logzioAPIURL | Logz.io API URL | https://api.logz.io/ |
+| applicationConfig.rulesDS | Data source for rules | IntegrationsTeamTesting_metrics |
+| applicationConfig.envID | Environment ID | my-env-yotam |
+| applicationConfig.workerCount | Number of workers | 2 |
+| rbac.rules | Custom rules for the Kubernetes cluster role | [{apiGroups: [""], resources: ["configmaps"], verbs: ["get", "list", "watch"]}] |
+
+### ConfigMap Format
+The controller is designed to process ConfigMaps containing Prometheus alert rules. These ConfigMaps must be annotated with a specific key that matches the value of the `ANNOTATION` environment variable for the controller to process them.
+
+### Example ConfigMap
+
+Below is an example of how a ConfigMap should be structured:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logzio-rules
+  namespace: monitoring
+  annotations:
+    prometheus.io/kube-rules: "true"
+data:
+  all_instances_down_otel_collector: |
+    alert: Opentelemetry_Collector_Down
+    expr: sum(up{app="opentelemetry-collector", job="kubernetes-pods"}) == 0
+    for: 5m
+    labels:
+      team: sre
+      severity: major
+    annotations:
+      description: "The OpenTelemetry collector has been down for more than 5 minutes."
+      summary: "Instance down"
+```
+- Replace `prometheus.io/kube-rules` with the actual annotation you use to identify relevant ConfigMaps. The data section should contain your Prometheus alert rules in YAML format.
+- Deploy the configmap to your cluster `kubectl apply -f <configmap-file>.yml`
+
+
+## Changelog
+- 1.0.0
+  - initial release

--- a/charts/prometheus-alerts-migrator/README.md
+++ b/charts/prometheus-alerts-migrator/README.md
@@ -100,6 +100,7 @@ data:
       description: "The OpenTelemetry collector has been down for more than 5 minutes."
       summary: "Instance down"
 ```
+
 - Replace `prometheus.io/kube-rules` with the actual annotation you use to identify relevant ConfigMaps. The data section should contain your Prometheus alert rules in YAML format.
 - Deploy the configmap to your cluster `kubectl apply -f <configmap-file>.yml`
 

--- a/charts/prometheus-alerts-migrator/templates/_helpers.tpl
+++ b/charts/prometheus-alerts-migrator/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-alerts-migrator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "prometheus-alerts-migrator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-alerts-migrator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "prometheus-alerts-migrator.labels" -}}
+helm.sh/chart: {{ include "prometheus-alerts-migrator.chart" . }}
+{{ include "prometheus-alerts-migrator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prometheus-alerts-migrator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prometheus-alerts-migrator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prometheus-alerts-migrator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "prometheus-alerts-migrator.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus-alerts-migrator/templates/clusterrole.yaml
+++ b/charts/prometheus-alerts-migrator/templates/clusterrole.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ include "prometheus-alerts-migrator.fullname" . }}
   namespace: {{ .Release.Namespace }}
 rules:
-# You need to fill these rules with actual permissions required by your application
 - apiGroups: [""]
   resources: ["pods", "pods/log"]
   verbs: ["get", "list"]

--- a/charts/prometheus-alerts-migrator/templates/clusterrole.yaml
+++ b/charts/prometheus-alerts-migrator/templates/clusterrole.yaml
@@ -2,8 +2,5 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "prometheus-alerts-migrator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
-rules:
-- apiGroups: [""]
-  resources: ["pods", "pods/log"]
-  verbs: ["get", "list"]
+rules: 
+{{ toYaml .Values.rbac.rules | nindent 2 }}

--- a/charts/prometheus-alerts-migrator/templates/clusterrole.yaml
+++ b/charts/prometheus-alerts-migrator/templates/clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "prometheus-alerts-migrator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+# You need to fill these rules with actual permissions required by your application
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list"]

--- a/charts/prometheus-alerts-migrator/templates/clusterrolebinding.yaml
+++ b/charts/prometheus-alerts-migrator/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "prometheus-alerts-migrator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "prometheus-alerts-migrator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "prometheus-alerts-migrator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/prometheus-alerts-migrator/templates/clusterrolebinding.yaml
+++ b/charts/prometheus-alerts-migrator/templates/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "prometheus-alerts-migrator.fullname" . }}
   namespace: {{ .Release.Namespace }}
-
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/prometheus-alerts-migrator/templates/deployment.yaml
+++ b/charts/prometheus-alerts-migrator/templates/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "prometheus-alerts-migrator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "prometheus-alerts-migrator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "prometheus-alerts-migrator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "prometheus-alerts-migrator.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "prometheus-alerts-migrator.serviceAccountName" . }}
+      containers:
+        - name: prometheus-alerts-migrator
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: ANNOTATION
+              value: "{{ .Values.config.annotation }}"
+            - name: LOGZIO_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: logzio-api-token
+                  key: token
+            - name: LOGZIO_API_URL
+              value: "{{ .Values.config.logzioAPIURL }}"
+            - name: RULES_DS
+              value: "{{ .Values.config.rulesDS }}"
+            - name: ENV_ID
+              value: "{{ .Values.config.envID }}"
+            - name: WORKER_COUNT
+              value: "{{ .Values.config.workerCount }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/prometheus-alerts-migrator/templates/deployment.yaml
+++ b/charts/prometheus-alerts-migrator/templates/deployment.yaml
@@ -23,8 +23,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: ANNOTATION
-              value: "{{ .Values.config.annotation }}"
+            - name: CONFIGMAP_ANNOTATION
+              value: "{{ .Values.config.configMapAnnotation }}"
             - name: LOGZIO_API_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -35,7 +35,7 @@ spec:
             - name: RULES_DS
               value: "{{ .Values.config.rulesDS }}"
             - name: ENV_ID
-              value: "{{ .Values.config.envID }}"
+              value: "{{ .Values.config.env_id }}"
             - name: WORKER_COUNT
               value: "{{ .Values.config.workerCount }}"
           resources:

--- a/charts/prometheus-alerts-migrator/templates/deployment.yaml
+++ b/charts/prometheus-alerts-migrator/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
             - name: LOGZIO_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: logzio-api-token
+                  name:  {{ .Values.secret.name }}
                   key: token
             - name: LOGZIO_API_URL
               value: "{{ .Values.config.logzioAPIURL }}"

--- a/charts/prometheus-alerts-migrator/templates/secret.yaml
+++ b/charts/prometheus-alerts-migrator/templates/secret.yaml
@@ -8,5 +8,5 @@ metadata:
     {{- include "prometheus-alerts-migrator.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  token: {{ .Values.logzioAPIToken }}
+  token: {{ .Values.config.logzioAPIToken }}
 {{- end }}

--- a/charts/prometheus-alerts-migrator/templates/secret.yaml
+++ b/charts/prometheus-alerts-migrator/templates/secret.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.config.logzioAPIToken }}
+{{- if and .Values.secret.enabled .Values.config.logzioAPIToken }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: logzio-api-token
+  name: {{ .Values.secret.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "prometheus-alerts-migrator.labels" . | nindent 4 }}

--- a/charts/prometheus-alerts-migrator/templates/secret.yaml
+++ b/charts/prometheus-alerts-migrator/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.logzioAPIToken }}
+{{- if .Values.config.logzioAPIToken }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/prometheus-alerts-migrator/templates/secret.yaml
+++ b/charts/prometheus-alerts-migrator/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.logzioAPIToken }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: logzio-api-token
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "prometheus-alerts-migrator.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  token: {{ .Values.logzioAPIToken }}
+{{- end }}

--- a/charts/prometheus-alerts-migrator/templates/secret.yaml
+++ b/charts/prometheus-alerts-migrator/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.secret.enabled .Values.config.logzioAPIToken }}
+{{- if and .Values.secret.create .Values.config.logzioAPIToken }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/prometheus-alerts-migrator/templates/serviceaccount.yaml
+++ b/charts/prometheus-alerts-migrator/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prometheus-alerts-migrator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "prometheus-alerts-migrator.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}

--- a/charts/prometheus-alerts-migrator/values.yaml
+++ b/charts/prometheus-alerts-migrator/values.yaml
@@ -18,11 +18,11 @@ serviceAccount:
   name: ""
 
 config:
-  annotation: "prometheus.io/kube-rules"
+  configMapAnnotation: "prometheus.io/kube-rules"
   logzioAPIToken: ""
   logzioAPIURL: "https://api.logz.io/"
   rulesDS: ""
-  envID: "my-env"
+  env_id: "my-env"
   workerCount: 2
 
 rbac:

--- a/charts/prometheus-alerts-migrator/values.yaml
+++ b/charts/prometheus-alerts-migrator/values.yaml
@@ -17,6 +17,10 @@ serviceAccount:
   annotations: {}
   name: ""
 
+secret:
+  create: true
+  name: logzio-api-token
+
 config:
   configMapAnnotation: "prometheus.io/kube-rules"
   logzioAPIToken: ""

--- a/charts/prometheus-alerts-migrator/values.yaml
+++ b/charts/prometheus-alerts-migrator/values.yaml
@@ -10,8 +10,7 @@ replicaCount: 1
 image:
   repository: logzio/prometheus-alerts-migrator
   pullPolicy: IfNotPresent
-  # still not official release
-  tag: "v1.0.0-test"
+  tag: "v1.0.0"
 
 serviceAccount:
   create: true
@@ -25,6 +24,12 @@ config:
   rulesDS: ""
   envID: "my-env"
   workerCount: 2
+
+rbac:
+  rules:
+    - apiGroups: [""]
+      resources: ["configmaps"]
+      verbs: ["get", "list", "watch"]
 
 resources:
   limits:

--- a/charts/prometheus-alerts-migrator/values.yaml
+++ b/charts/prometheus-alerts-migrator/values.yaml
@@ -1,0 +1,41 @@
+# Default values for prometheus-alerts-migrator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+fullnameOverride: ""
+nameOverride: ""
+
+replicaCount: 1
+
+image:
+  repository: logzio/prometheus-alerts-migrator
+  pullPolicy: IfNotPresent
+  # still not official release
+  tag: "v1.0.0-test"
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+config:
+  annotation: "prometheus.io/kube-rules"
+  logzioAPIToken: ""
+  logzioAPIURL: "https://api.logz.io/"
+  rulesDS: ""
+  envID: "my-env"
+  workerCount: 2
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This chart serves as a Kubernetes controller that automates the migration of Prometheus alert rules to Logz.io's alert format, facilitating monitoring and alert management in a Logz.io-integrated environment.
