### PR TITLE
Fix custom tracing endpoint

### DIFF
--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -85,11 +85,13 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: logzio-listener-region
+      {{ if .Values.secrets.CustomTracingEndpoint}}
       - name: CUSTOM_TRACING_ENDPOINT
         valueFrom:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: custom-tracing-endpoint
+      {{ end }}
       - name: SAMPLING_PROBABILITY
         valueFrom:
           secretKeyRef:

--- a/charts/logzio-telemetry/templates/secrets.yaml
+++ b/charts/logzio-telemetry/templates/secrets.yaml
@@ -22,7 +22,9 @@ stringData:
 {{- if .Values.traces.enabled }}
   logzio-traces-shipping-token: {{ .Values.secrets.TracesToken }}
   logzio-listener-region: {{ .Values.secrets.LogzioRegion}}
+  {{ if .Values.secrets.CustomTracingEndpoint }}
   custom-tracing-endpoint: {{ .Values.secrets.CustomTracingEndpoint}}
+  {{ end }}
   sampling-latency: {{ .Values.secrets.SamplingLatency | quote }}
   sampling-probability: {{ .Values.secrets.SamplingProbability | quote}}
 {{ if .Values.spm.enabled }}


### PR DESCRIPTION
- Conditional creation of `CUSTOM_TRACING_ENDPOINT` to prevent errors on various helm client version
