### PR TITLE
Logzio monitoring v3

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -35,3 +35,5 @@ maintainers:
   email: yotam.loewenbach@logz.io
 - name: miriig
   email: miri.ignatiev@logz.io
+- name: ralongit
+  email: raul.gurshumo@logz.io

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 2.0.0
+version: 3.0.0
 
 sources:
   - https://github.com/logzio/logzio-helm
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "1.3.0"
+    version: "2.0.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -11,6 +11,12 @@ This project packages 3 Helm Charts:
 - [logzio-telemetry](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-telemetry) for metrics and traces (via OpenTelemetry Collector).
 - [logzio-trivy](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-trivy) for security reports (via Trivy operator).
 
+### Kubernetes Versions Compatibility
+| Chart Version | Kubernetes Version |
+|---|---|
+| 3.0.0 | v1.22.0 - v1.28.0 |
+| < 2.0.0 | <= v1.22.0 |
+
 ## Instructions for standard deployment:
 
 ### Before installing the chart
@@ -171,6 +177,12 @@ Set logzio-k8s-telemetry `ListenerHost` value to send your metrics to a custom e
 ```
 
 ## Changelog
+- **3.0.0**:
+	- Upgrade `logzio-k8s-telemetry` to `2.0.0`:
+		- Upgrade its sub charts to latest versions.
+			- `kube-state-metrics` to `4.24.0`
+			- `prometheus-node-exporter` to `4.23.2`
+			- `prometheus-pushgateway` to `2.4.2`
 - **2.0.0**:
 	- Add `logzio-k8s-events` sub chart version `0.0.3`:
 		- Sends Kubernetes deploy events logs.

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -179,10 +179,14 @@ Set logzio-k8s-telemetry `ListenerHost` value to send your metrics to a custom e
 ## Changelog
 - **3.0.0**:
 	- Upgrade `logzio-k8s-telemetry` to `2.0.0`:
-		- Upgrade its sub charts to latest versions.
+		- Upgrade sub charts to their latest versions.
 			- `kube-state-metrics` to `4.24.0`
+			- Upgraded horizontal pod autoscaler API group version.
 			- `prometheus-node-exporter` to `4.23.2`
 			- `prometheus-pushgateway` to `2.4.2`
+		- Secrets resource name is now changeable via `secrets.name` in `values.yaml`.
+		- Fix sub charts conditional installation. 
+		- Add conditional creation of `CustomTracingEndpoint` secret key. 
 - **2.0.0**:
 	- Add `logzio-k8s-events` sub chart version `0.0.3`:
 		- Sends Kubernetes deploy events logs.

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -9,19 +9,19 @@ sources:
   - https://github.com/kubernetes/kube-state-metrics
 dependencies:
   - name: kube-state-metrics
-    version: "4.13.0"
+    version: "4.24.0"
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: kubeStateMetrics.enabled
     tags:
       - metrics.enabled
   - name: prometheus-node-exporter
-    version: "3.3.0"
+    version: "4.23.2"
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: nodeExporter.enabled
     tags:
       - metrics.enabled
   - name: prometheus-pushgateway
-    version: "1.18.2"
+    version: "2.4.2"
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: pushGateway.enabled
     tags:
@@ -29,7 +29,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 2.0.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -11,21 +11,22 @@ dependencies:
   - name: kube-state-metrics
     version: "4.24.0"
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: kubeStateMetrics.enabled
+    condition: metrics.enabled
     tags:
-      - metrics.enabled
+      - kubeStateMetrics.enabled
   - name: prometheus-node-exporter
     version: "4.23.2"
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: nodeExporter.enabled
+    condition: metrics.enabled
     tags:
-      - metrics.enabled
+      - nodeExporter.enabled
   - name: prometheus-pushgateway
     version: "2.4.2"
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: pushGateway.enabled
+    condition: metrics.enabled
     tags:
-      - metrics.enabled
+      - pushGateway.enabled
+
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -225,23 +225,23 @@ To enable applications metrics scraping set the `applicationMetrics.enabled` val
 This will enable the `metrics/applications` pipline and will scrape metrics from pods with the `prometheus.io/scrape=true` annotation
 ### Removing kube-state-metrics metrics
 
-To disable kube-state-metrics metrics scraping set the `tags.kubeStateMetrics.enabled` value to `true`
+To disable kube-state-metrics metrics scraping set the `tags.kubeStateMetrics.enabled` value to `false`
 ```bash
---set tags.kubeStateMetrics.enabled=true
+--set tags.kubeStateMetrics.enabled=false
 ```
 This will disable the `kube-state-metrics` sub chart installation so it won't scrape its metrics.
 ### Removing prometheus-pushgateway metrics
 
-To disable prometheus-pushgateway metrics scraping set the `tags.pushGateway.enabled` value to `true`
+To disable prometheus-pushgateway metrics scraping set the `tags.pushGateway.enabled` value to `false`
 ```bash
---set tags.pushGateway.enabled=true
+--set tags.pushGateway.enabled=false
 ```
 This will disable the `prometheus-pushgateway` sub chart installation so it won't scrape its metrics.
 ### Removing prometheus-node-exporter metrics
 
-To disable prometheus-node-exporter metrics scraping set the `tags.nodeExporter.enabled` value to `true`
+To disable prometheus-node-exporter metrics scraping set the `tags.nodeExporter.enabled` value to `false`
 ```bash
---set tags.nodeExporter.enabled=true
+--set tags.nodeExporter.enabled=false
 ```
 This will disable the `prometheus-node-exporter` sub chart installation so it won't scrape its metrics.
 ### Using Out of the box metrics filters for Logzio dashboards

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -14,6 +14,11 @@ It is also dependent on the [kube-state-metrics](https://github.com/kubernetes/k
 To disable the dependency during installation, set `kubeStateMetrics.enabled` and `nodeExporter` to `false`.
 
 
+### Kubernetes Versions Compatibility
+| Chart Version | Kubernetes Version |
+|---|---|
+| 2.0.0 | v1.22.0 - v1.28.0 |
+| < 1.3.0 | <= v1.22.0 |
 
 #### Before installing the chart
 * Check if you have any taints on your nodes:
@@ -339,6 +344,11 @@ helm uninstall logzio-k8s-telemetry
 
 
 ## Change log
+* 2.0.0
+  - Upgrade sub charts to their latest versions.
+    - `kube-state-metrics` to `4.24.0`
+    - `prometheus-node-exporter` to `4.23.2`
+    - `prometheus-pushgateway` to `2.4.2`
 * 1.3.0
   - Upgraded horizontal pod autoscaler API group version.
 * 1.2.0

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -11,7 +11,7 @@ The Helm tool is used to manage packages of pre-configured Kubernetes resources 
 
 **Note:** This chart is a fork of the [opentelemtry-collector](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) Helm chart. 
 It is also dependent on the [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) and [prometheus-node-exporter](https://github.com/helm/charts/tree/master/stable/prometheus-node-exporter) charts, which are installed by default. 
-To disable the dependency during installation, set `kubeStateMetrics.enabled` and `nodeExporter` to `false`.
+To disable the dependency during installation, set any of these values: `tags.kubeStateMetrics.enabled`, `tags.pushGateway.enabled` and `tags.nodeExporter.enabled` to `false`.
 
 
 ### Kubernetes Versions Compatibility

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -368,9 +368,12 @@ helm uninstall logzio-k8s-telemetry
 * 2.0.0
   - Upgrade sub charts to their latest versions.
     - `kube-state-metrics` to `4.24.0`
+      - Upgraded horizontal pod autoscaler API group version.
     - `prometheus-node-exporter` to `4.23.2`
     - `prometheus-pushgateway` to `2.4.2`
-    - Secrets resource name is now changeable via `secrets.name` in `values.yaml`.
+  - Secrets resource name is now changeable via `secrets.name` in `values.yaml`.
+  - Fix sub charts conditional installation. 
+  - Add conditional creation of `CustomTracingEndpoint` secret key. 
 * 1.3.0
   - Upgraded horizontal pod autoscaler API group version.
 * 1.2.0

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -349,6 +349,7 @@ helm uninstall logzio-k8s-telemetry
     - `kube-state-metrics` to `4.24.0`
     - `prometheus-node-exporter` to `4.23.2`
     - `prometheus-pushgateway` to `2.4.2`
+    - Secrets resource name is now changeable via `secrets.name` in `values.yaml`.
 * 1.3.0
   - Upgraded horizontal pod autoscaler API group version.
 * 1.2.0

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -223,6 +223,27 @@ To enable applications metrics scraping set the `applicationMetrics.enabled` val
 --set applicationMetrics.enabled=true
 ```
 This will enable the `metrics/applications` pipline and will scrape metrics from pods with the `prometheus.io/scrape=true` annotation
+### Removing kube-state-metrics metrics
+
+To disable kube-state-metrics metrics scraping set the `tags.kubeStateMetrics.enabled` value to `true`
+```bash
+--set tags.kubeStateMetrics.enabled=true
+```
+This will disable the `kube-state-metrics` sub chart installation so it won't scrape its metrics.
+### Removing prometheus-pushgateway metrics
+
+To disable prometheus-pushgateway metrics scraping set the `tags.pushGateway.enabled` value to `true`
+```bash
+--set tags.pushGateway.enabled=true
+```
+This will disable the `prometheus-pushgateway` sub chart installation so it won't scrape its metrics.
+### Removing prometheus-node-exporter metrics
+
+To disable prometheus-node-exporter metrics scraping set the `tags.nodeExporter.enabled` value to `true`
+```bash
+--set tags.nodeExporter.enabled=true
+```
+This will disable the `prometheus-node-exporter` sub chart installation so it won't scrape its metrics.
 ### Using Out of the box metrics filters for Logzio dashboards
 
 You can use predefined metrics filters to prevent unnecessary metrics being sent to Logz.io and reduce usage cost.

--- a/charts/logzio-telemetry/VALUES.md
+++ b/charts/logzio-telemetry/VALUES.md
@@ -1,6 +1,6 @@
 # logzio-k8s-telemetry
 
-![Version: 0.0.24](https://img.shields.io/badge/Version-0.0.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.70.0](https://img.shields.io/badge/AppVersion-0.70.0-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.70.0](https://img.shields.io/badge/AppVersion-0.80.0-informational?style=flat-square)
 
 logzio-k8s-telemetry allows you to ship metrics and traces from your Kubernetes cluster using the OpenTelemetry collector.
 
@@ -20,9 +20,9 @@ logzio-k8s-telemetry allows you to ship metrics and traces from your Kubernetes 
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://prometheus-community.github.io/helm-charts | kube-state-metrics | 4.13.0 |
-| https://prometheus-community.github.io/helm-charts | prometheus-node-exporter | 3.3.0 |
-| https://prometheus-community.github.io/helm-charts | prometheus-pushgateway | 1.18.2 |
+| https://prometheus-community.github.io/helm-charts | kube-state-metrics | 4.24.0 |
+| https://prometheus-community.github.io/helm-charts | prometheus-node-exporter | 4.23.2 |
+| https://prometheus-community.github.io/helm-charts | prometheus-pushgateway | 2.4.2 |
 
 ## Values
 

--- a/charts/logzio-telemetry/VALUES.md
+++ b/charts/logzio-telemetry/VALUES.md
@@ -44,13 +44,13 @@ logzio-k8s-telemetry allows you to ship metrics and traces from your Kubernetes 
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the opentelemetry collector image. |
 | image.repository | string | `"otel/opentelemetry-collector-contrib"` | Opentelemetry collector image repository. |
 | image.tag | string | `"0.78.0"` |  Opentelemetry collector image tag. |
-| kubeStateMetrics.enabled | bool | `true` | Controlles the deployment of the kube-state-metrics sub chart. |
+| tags.kubeStateMetrics.enabled | bool | `true` | Controlles the deployment of the kube-state-metrics sub chart. |
 | applicationMetrics.enabled | bool | `false` | wheter or not to enable `applications` scrape job. |
 | metrics.enabled | bool | `false` | Controlles the activation of metrics collection. |
 | traces.enabled | bool | `false` | Controlles the activation of traces collection. |
 | nameOverride | string | `"otel-collector"` | Name override for the opentelemetry collector. |
-| nodeExporter.enabled | bool | `true` | Controlles the deployment of the node-exporter sub chart. |
-| pushGateway.enabled | bool | `true` | Controlles the deployment of the prometheus-pushgateway sub chart. |
+| tags.nodeExporter.enabled | bool | `true` | Controlles the deployment of the node-exporter sub chart. |
+| tags.pushGateway.enabled | bool | `true` | Controlles the deployment of the prometheus-pushgateway sub chart. |
 | secrets.ListenerHost | string | `""` | Logzio listener host. |
 | secrets.LogzioRegion | string | `"us"` | Logzio listener region. |
 | secrets.MetricsToken | string | `""` | Logzio metrics token. |

--- a/charts/logzio-telemetry/templates/_daemonset-pod.tpl
+++ b/charts/logzio-telemetry/templates/_daemonset-pod.tpl
@@ -44,7 +44,7 @@ containers:
       - name: K8S_360_METRICS
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: kubernetes-360-metrics
       - name: LOGZIO_AGENT_VERSION
         value: {{.Chart.Version}}
@@ -55,28 +55,28 @@ containers:
       - name: METRICS_TOKEN
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: logzio-metrics-shipping-token
       - name: LISTENER_URL
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: logzio-metrics-listener
       - name: P8S_LOGZIO_NAME
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: p8s-logzio-name
       - name: ENV_ID
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: env_id
 {{- if .Values.opencost.enabled }}
       - name: OPENCOST_DUPLICATES
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: opencost-duplicates
 {{- end }}
 

--- a/charts/logzio-telemetry/templates/_pod-spm.tpl
+++ b/charts/logzio-telemetry/templates/_pod-spm.tpl
@@ -38,22 +38,22 @@ containers:
       - name: LISTENER_URL
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: logzio-metrics-listener
       - name: P8S_LOGZIO_NAME
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: p8s-logzio-name
       - name: SPM_TOKEN
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: logzio-spm-shipping-token
       - name: ENV_ID
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: env_id
     resources:
     {{- toYaml .Values.spanMetricsAgregator.resources | nindent 6 }}

--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -44,7 +44,7 @@ containers:
       - name: K8S_360_METRICS
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: kubernetes-360-metrics
       - name: LOGZIO_AGENT_VERSION
         value: {{.Chart.Version}}
@@ -59,65 +59,65 @@ containers:
       - name: METRICS_TOKEN
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: logzio-metrics-shipping-token
 {{- end }}
 {{- if or (eq .Values.metrics.enabled true) (eq .Values.spm.enabled true) }}
       - name: LISTENER_URL
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: logzio-metrics-listener
       - name: P8S_LOGZIO_NAME
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: p8s-logzio-name
 {{- end }}
 {{- if .Values.traces.enabled }}
       - name: TRACES_TOKEN
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: logzio-traces-shipping-token
       - name: LOGZIO_LISTENER_REGION
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: logzio-listener-region
       - name: CUSTOM_TRACING_ENDPOINT
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: custom-tracing-endpoint
       - name: SAMPLING_PROBABILITY
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: sampling-probability
       - name: SAMPLING_LATENCY
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: sampling-latency
 {{ if .Values.spm.enabled }}
       - name: SPM_TOKEN
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: logzio-spm-shipping-token
 {{ end }}
 {{- end }}
       - name: ENV_ID
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: env_id
 {{- if .Values.opencost.enabled }}
       - name: OPENCOST_DUPLICATES
         valueFrom:
           secretKeyRef:
-            name: logzio-secret
+            name: {{ .Values.secrets.name }}
             key: opencost-duplicates
 {{- end }}
       {{- with .Values.extraEnvs }}

--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -85,11 +85,13 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: logzio-listener-region
+      {{ if .Values.secrets.CustomTracingEndpoint}}
       - name: CUSTOM_TRACING_ENDPOINT
         valueFrom:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: custom-tracing-endpoint
+      {{ end }}
       - name: SAMPLING_PROBABILITY
         valueFrom:
           secretKeyRef:

--- a/charts/logzio-telemetry/templates/secrets.yaml
+++ b/charts/logzio-telemetry/templates/secrets.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: logzio-secret
+  name: {{ .Values.secrets.name }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:

--- a/charts/logzio-telemetry/templates/secrets.yaml
+++ b/charts/logzio-telemetry/templates/secrets.yaml
@@ -22,7 +22,9 @@ stringData:
 {{- if .Values.traces.enabled }}
   logzio-traces-shipping-token: {{ .Values.secrets.TracesToken }}
   logzio-listener-region: {{ .Values.secrets.LogzioRegion}}
+  {{ if .Values.secrets.CustomTracingEndpoint }}
   custom-tracing-endpoint: {{ .Values.secrets.CustomTracingEndpoint}}
+  {{ end }}
   sampling-latency: {{ .Values.secrets.SamplingLatency | quote }}
   sampling-probability: {{ .Values.secrets.SamplingProbability | quote}}
 {{ if .Values.spm.enabled }}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -16,6 +16,7 @@ nameOverride: "otel-collector"
 fullnameOverride: ""
 
 secrets:
+  name: logzio-secret
   enabled: true
   MetricsToken: ""
   TracesToken: ""
@@ -120,25 +121,27 @@ clusterRoleRules:
   - list
   - watch
 
-kubeStateMetrics:
-  ## If false, kube-state-metrics sub-chart will not be installed
-  ##
-  enabled: true
 
-pushGateway:
-  ## If false, pushGateway sub-chart will not be installed
-  ##
-  enabled: true
+tags:
+  kubeStateMetrics:
+    ## If false, kube-state-metrics sub-chart will not be installed
+    ##
+    enabled: true
+
+  pushGateway:
+    ## If false, pushGateway sub-chart will not be installed
+    ##
+    enabled: true
+  nodeExporter:
+    ## If false, node-exporter will not be installed
+    ##
+    enabled: true
+    
 prometheus-pushgateway:
   serviceAnnotations:
     prometheus.io/scrape: "true"
   nodeSelector:
     kubernetes.io/os: linux
-
-nodeExporter:
-  ## If false, node-exporter will not be installed
-  ##
-  enabled: true
 
 emptyConfig: {}
 
@@ -1002,6 +1005,7 @@ daemonsetConfig:
           - prometheus/infrastructure
           - prometheus/cadvisor
           - prometheus/collector
+
          
 opencost:
   enabled: false


### PR DESCRIPTION
- Upgrade `logzio-monitoring` to `3.0.0`:
  - Upgrade `logzio-k8s-telemetry` to `2.0.0`:
	  - Upgrade sub charts to their latest versions.
		  - `kube-state-metrics` to `4.24.0`
		    - Upgraded horizontal pod autoscaler API group version.  Solves #350 
		  - `prometheus-node-exporter` to `4.23.2`
		  - `prometheus-pushgateway` to `2.4.2`
	  - Secrets resource name is now changeable via `secrets.name` in `values.yaml`.
	  - Fix sub charts conditional installation. 
	  - Add conditional creation of `CustomTracingEndpoint` secret key.