### PR TITLE
Grcp unified status code dimensions

### DIFF
--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -10,6 +10,7 @@ This project packages 3 Helm Charts:
 - [logzio-fluentd](https://github.com/logzio/logzio-helm/tree/master/charts/fluentd) for logs shipping (via Fluentd).
 - [logzio-telemetry](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-telemetry) for metrics and traces (via OpenTelemetry Collector).
 - [logzio-trivy](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-trivy) for security reports (via Trivy operator).
+- [logzio-k8s-events](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-k8s-events) for k8s deployment events.
 
 ### Kubernetes Versions Compatibility
 | Chart Version | Kubernetes Version |

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -6,7 +6,7 @@ The logzio-monitoring Helm Chart ships your Kubernetes telemetry (logs, metrics,
 
 ## Overview
 
-This project packages 3 Helm Charts:
+This project packages the following Helm Charts:
 - [logzio-fluentd](https://github.com/logzio/logzio-helm/tree/master/charts/fluentd) for logs shipping (via Fluentd).
 - [logzio-telemetry](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-telemetry) for metrics and traces (via OpenTelemetry Collector).
 - [logzio-trivy](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-trivy) for security reports (via Trivy operator).

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -593,6 +593,7 @@ spanMetricsAgregator:
         dimensions_cache_size: 100000
         aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
         dimensions:
+          - name: rpc.grpc.status_code
           - name: http.method
           - name: http.status_code
           - name: k8s.pod.name
@@ -621,6 +622,11 @@ spanMetricsAgregator:
             scrape_interval: 30s
             static_configs:
             - targets: [ "0.0.0.0:8889" ]
+            metric_relabel_configs:
+            - source_labels: [http_status_code]
+              target_label: unified_status_code
+            - source_labels: [rpc_grpc_status_code]
+              target_label: unified_status_code              
       jaeger:
         protocols:
           thrift_compact:


### PR DESCRIPTION
  - Update SPM labels
    - Add `rpc_grpc_status_code` dimension
    - Add `unified_status_code` dimension
      - Takes value of `rpc_grpc_status_code` / `http_status_code`
  - Add missing sub chart reference in readme