### PR TITLE
Use attributes processor to add unified_status_code

### DIFF
--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -630,7 +630,15 @@ spanMetricsAgregator:
             operations:
               - action: update_label
                 label: span.name
-                new_label: operation     
+                new_label: operation
+      attributes/spm:
+        actions:
+        - key: unified_status_code
+          action: update
+          from_attribute: http.status_code
+        - key: unified_status_code
+          action: update
+          from_attribute: rpc.grpc.status_code          
     connectors:
       spanmetrics:
         histogram:
@@ -669,12 +677,7 @@ spanMetricsAgregator:
           - job_name: 'spm'
             scrape_interval: 30s
             static_configs:
-            - targets: [ "0.0.0.0:8889" ]
-            metric_relabel_configs:
-            - source_labels: [http_status_code]
-              target_label: unified_status_code
-            - source_labels: [rpc_grpc_status_code]
-              target_label: unified_status_code              
+            - targets: [ "0.0.0.0:8889" ] 
       jaeger:
         protocols:
           thrift_compact:
@@ -714,7 +717,7 @@ spanMetricsAgregator:
           exporters: [prometheus/spm]
         metrics/spm-logzio:
           receivers: [prometheus/spm-logzio, spanmetrics]
-          processors: [metricstransform]
+          processors: [metricstransform,attributes/spm]
           exporters: [prometheusremotewrite/spm-logzio]
   # service values        
   service:


### PR DESCRIPTION
Since spansmetrics is now a connector it wont go trough the relabel pipeline, instead I added attributes processor to add unified_status_code.