### PR TITLE
v1.0.4

### DIFF
--- a/charts/easy-connect/Chart.yaml
+++ b/charts/easy-connect/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: easy-connect
 description: Easily add otel auto instrumentation and log types to your Kubernetes applications
 type: application
-version: 1.0.3
+version: 1.0.4
 
 maintainers:
 - name: yotamloe

--- a/charts/easy-connect/README.md
+++ b/charts/easy-connect/README.md
@@ -96,6 +96,7 @@ Here, `my_values.yaml` is your custom configuration file.
 Change log
 -------------
 * 1.0.4
+  - Use images from `public.aws.ecr`
   - Update `dotnet` agent:
     - use `otlp` exporter instead of `zipkin`
     - upgrade version `v0.5.0` -> `v1.2.0`

--- a/charts/easy-connect/README.md
+++ b/charts/easy-connect/README.md
@@ -48,17 +48,17 @@ serviceAccount
 | Parameter | Description | Default |
 | --- | --- | --- |
 | `kubernetesInstrumentor.serviceAccount` | Service account name of the instrumentor deployment | `"kubernetes-instrumentor"` |
-| `kubernetesInstrumentor.image.repository` | Repository of the instrumentor image | `"public.ecr.aws/logzio/instrumentor"` |
+| `kubernetesInstrumentor.image.repository` | Repository of the instrumentor image | `"logzio/instrumentor"` |
 | `kubernetesInstrumentor.image.tag` | Tag of the instrumentor image | `"v1.0.8"` |
-| `kubernetesInstrumentor.instrumentationDetectorImage.repository` | Repository of the instrumentation detector image | `"public.ecr.aws/logzio/instrumentation-detector"` |
+| `kubernetesInstrumentor.instrumentationDetectorImage.repository` | Repository of the instrumentation detector image | `"logzio/instrumentation-detector"` |
 | `kubernetesInstrumentor.instrumentationDetectorImage.tag` | Tag of the instrumentation detector image | `"v1.0.8"` |
-| `kubernetesInstrumentor.javaAgentImage.repository` | Repository of the Java agent image | `"public.ecr.aws/logzio/otel-agent-java"` |
+| `kubernetesInstrumentor.javaAgentImage.repository` | Repository of the Java agent image | `"logzio/otel-agent-java"` |
 | `kubernetesInstrumentor.javaAgentImage.tag` | Tag of the Java agent image | `"v1.0.8"` |
-| `kubernetesInstrumentor.dotnetAgentImage.repository` | Repository of the .Net agent image | `"public.ecr.aws/logzio/otel-agent-dotnet"` |
+| `kubernetesInstrumentor.dotnetAgentImage.repository` | Repository of the .Net agent image | `"logzio/otel-agent-dotnet"` |
 | `kubernetesInstrumentor.dotnetAgentImage.tag` | Tag of the .Net agent image | `"v1.0.8"` |
-| `kubernetesInstrumentor.nodejsAgentImage.repository` | Repository of the Node.js agent image | `"public.ecr.aws/logzio/otel-agent-nodejs"` |
+| `kubernetesInstrumentor.nodejsAgentImage.repository` | Repository of the Node.js agent image | `"logzio/otel-agent-nodejs"` |
 | `kubernetesInstrumentor.nodejsAgentImage.tag` | Tag of the Node.js agent image | `"v1.0.8"` |
-| `kubernetesInstrumentor.pythonAgentImage.repository` | Repository of the Python agent image | `"public.ecr.aws/logzio/otel-agent-python"` |
+| `kubernetesInstrumentor.pythonAgentImage.repository` | Repository of the Python agent image | `"logzio/otel-agent-python"` |
 | `kubernetesInstrumentor.pythonAgentImage.tag` | Tag of the Python agent image | `"v1.0.8"` |
 | `kubernetesInstrumentor.ports.metricsPort` | Metrics port for the instrumentor | `8080` |
 | `kubernetesInstrumentor.ports.healthProbePort` | Health probe port for the instrumentor | `8081` |
@@ -92,11 +92,14 @@ You can override the default values by creating your own `values.yaml` file and 
 
 Here, `my_values.yaml` is your custom configuration file.
 
+Alternative images
+-------------
+you can find alternative to `dockerhub` images in `public.ecr.aws/logzio/` with the same image name (example: `public.ecr.aws/logzio/instrumentor`)
 
 Change log
 -------------
 * 1.0.4
-  - Use images from `public.aws.ecr`
+  - add images to `public.aws.ecr`
   - Update `dotnet` agent:
     - use `otlp` exporter instead of `zipkin`
     - upgrade version `v0.5.0` -> `v1.2.0`

--- a/charts/easy-connect/README.md
+++ b/charts/easy-connect/README.md
@@ -48,18 +48,18 @@ serviceAccount
 | Parameter | Description | Default |
 | --- | --- | --- |
 | `kubernetesInstrumentor.serviceAccount` | Service account name of the instrumentor deployment | `"kubernetes-instrumentor"` |
-| `kubernetesInstrumentor.image.repository` | Repository of the instrumentor image | `"logzio/instrumentor"` |
-| `kubernetesInstrumentor.image.tag` | Tag of the instrumentor image | `"v1.0.6"` |
-| `kubernetesInstrumentor.instrumentationDetectorImage.repository` | Repository of the instrumentation detector image | `"logzio/instrumentation-detector"` |
-| `kubernetesInstrumentor.instrumentationDetectorImage.tag` | Tag of the instrumentation detector image | `"v1.0.6"` |
-| `kubernetesInstrumentor.javaAgentImage.repository` | Repository of the Java agent image | `"logzio/otel-agent-java"` |
-| `kubernetesInstrumentor.javaAgentImage.tag` | Tag of the Java agent image | `"v1.0.6"` |
-| `kubernetesInstrumentor.dotnetAgentImage.repository` | Repository of the .Net agent image | `"logzio/otel-agent-dotnet"` |
-| `kubernetesInstrumentor.dotnetAgentImage.tag` | Tag of the .Net agent image | `"v1.0.6"` |
-| `kubernetesInstrumentor.nodejsAgentImage.repository` | Repository of the Node.js agent image | `"logzio/otel-agent-nodejs"` |
-| `kubernetesInstrumentor.nodejsAgentImage.tag` | Tag of the Node.js agent image | `"v1.0.6"` |
-| `kubernetesInstrumentor.pythonAgentImage.repository` | Repository of the Python agent image | `"logzio/otel-agent-python"` |
-| `kubernetesInstrumentor.pythonAgentImage.tag` | Tag of the Python agent image | `"v1.0.6"` |
+| `kubernetesInstrumentor.image.repository` | Repository of the instrumentor image | `"public.ecr.aws/logzio/instrumentor"` |
+| `kubernetesInstrumentor.image.tag` | Tag of the instrumentor image | `"v1.0.8"` |
+| `kubernetesInstrumentor.instrumentationDetectorImage.repository` | Repository of the instrumentation detector image | `"public.ecr.aws/logzio/instrumentation-detector"` |
+| `kubernetesInstrumentor.instrumentationDetectorImage.tag` | Tag of the instrumentation detector image | `"v1.0.8"` |
+| `kubernetesInstrumentor.javaAgentImage.repository` | Repository of the Java agent image | `"public.ecr.aws/logzio/otel-agent-java"` |
+| `kubernetesInstrumentor.javaAgentImage.tag` | Tag of the Java agent image | `"v1.0.8"` |
+| `kubernetesInstrumentor.dotnetAgentImage.repository` | Repository of the .Net agent image | `"public.ecr.aws/logzio/otel-agent-dotnet"` |
+| `kubernetesInstrumentor.dotnetAgentImage.tag` | Tag of the .Net agent image | `"v1.0.8"` |
+| `kubernetesInstrumentor.nodejsAgentImage.repository` | Repository of the Node.js agent image | `"public.ecr.aws/logzio/otel-agent-nodejs"` |
+| `kubernetesInstrumentor.nodejsAgentImage.tag` | Tag of the Node.js agent image | `"v1.0.8"` |
+| `kubernetesInstrumentor.pythonAgentImage.repository` | Repository of the Python agent image | `"public.ecr.aws/logzio/otel-agent-python"` |
+| `kubernetesInstrumentor.pythonAgentImage.tag` | Tag of the Python agent image | `"v1.0.8"` |
 | `kubernetesInstrumentor.ports.metricsPort` | Metrics port for the instrumentor | `8080` |
 | `kubernetesInstrumentor.ports.healthProbePort` | Health probe port for the instrumentor | `8081` |
 | `kubernetesInstrumentor.resources.limits.cpu` | CPU limit for the instrumentor | `"500m"` |
@@ -95,6 +95,20 @@ Here, `my_values.yaml` is your custom configuration file.
 
 Change log
 -------------
+* 1.0.4
+  - Update `dotnet` agent:
+    - use `otlp` exporter instead of `zipkin`
+    - upgrade version `v0.5.0` -> `v1.2.0`
+    - Add env variables: 
+      - `OTEL_EXPORTER_OTLP_PROTOCOL`
+      - `DOTNET_STARTUP_HOOKS` 
+      - `OTEL_METRICS_EXPORTER`
+      - `OTEL_LOGS_EXPORTER`
+      - `OTEL_EXPORTER_OTLP_PROTOCOL`
+      - `OTEL_DOTNET_AUTO_HOME`
+      - `OTEL_RESOURCE_ATTRIBUTES`
+  - update `python` agent:
+    - update deps
 * 1.0.3
   - Refactor `ezkonnect` -> `easy-connect`
 * 1.0.2

--- a/charts/easy-connect/values.yaml
+++ b/charts/easy-connect/values.yaml
@@ -3,23 +3,23 @@
 kubernetesInstrumentor:
   serviceAccount: "kubernetes-instrumentor"
   image:
-    repository: "logzio/instrumentor"
-    tag: "v1.0.6"
+    repository: "public.ecr.aws/logzio/instrumentor"
+    tag: "v1.0.8"
   instrumentationDetectorImage:
-    repository: "logzio/instrumentation-detector"
-    tag: "v1.0.6"
+    repository: "public.ecr.aws/logzio/instrumentation-detector"
+    tag: "v1.0.8"
   javaAgentImage:
-    repository: "logzio/otel-agent-java"
-    tag: "v1.0.6"
+    repository: "public.ecr.aws/logzio/otel-agent-java"
+    tag: "v1.0.8"
   dotnetAgentImage:
-    repository: "logzio/otel-agent-dotnet"
-    tag: "v1.0.6"
+    repository: "public.ecr.aws/logzio/otel-agent-dotnet"
+    tag: "v1.0.8"
   nodejsAgentImage:
-    repository: "logzio/otel-agent-nodejs"
-    tag: "v1.0.6"
+    repository: "public.ecr.aws/logzio/otel-agent-nodejs"
+    tag: "v1.0.8"
   pythonAgentImage:
-    repository: "logzio/otel-agent-python"
-    tag: "v1.0.6"
+    repository: "public.ecr.aws/logzio/otel-agent-python"
+    tag: "v1.0.8"
   ports:
     metricsPort: 8080
     healthProbePort: 8081

--- a/charts/easy-connect/values.yaml
+++ b/charts/easy-connect/values.yaml
@@ -3,22 +3,22 @@
 kubernetesInstrumentor:
   serviceAccount: "kubernetes-instrumentor"
   image:
-    repository: "public.ecr.aws/logzio/instrumentor"
+    repository: "logzio/instrumentor"
     tag: "v1.0.8"
   instrumentationDetectorImage:
-    repository: "public.ecr.aws/logzio/instrumentation-detector"
+    repository: "logzio/instrumentation-detector"
     tag: "v1.0.8"
   javaAgentImage:
-    repository: "public.ecr.aws/logzio/otel-agent-java"
+    repository: "logzio/otel-agent-java"
     tag: "v1.0.8"
   dotnetAgentImage:
-    repository: "public.ecr.aws/logzio/otel-agent-dotnet"
+    repository: "logzio/otel-agent-dotnet"
     tag: "v1.0.8"
   nodejsAgentImage:
-    repository: "public.ecr.aws/logzio/otel-agent-nodejs"
+    repository: "logzio/otel-agent-nodejs"
     tag: "v1.0.8"
   pythonAgentImage:
-    repository: "public.ecr.aws/logzio/otel-agent-python"
+    repository: "logzio/otel-agent-python"
     tag: "v1.0.8"
   ports:
     metricsPort: 8080


### PR DESCRIPTION
- Use images from `public.aws.ecr`  
- Update `dotnet` agent:
    - use `otlp` exporter instead of `zipkin`
    - upgrade version `v0.5.0` -> `v1.2.0`
    - Add env variables: 
      - `OTEL_EXPORTER_OTLP_PROTOCOL`
      - `DOTNET_STARTUP_HOOKS` 
      - `OTEL_METRICS_EXPORTER`
      - `OTEL_LOGS_EXPORTER`
      - `OTEL_EXPORTER_OTLP_PROTOCOL`
      - `OTEL_DOTNET_AUTO_HOME`
      - `OTEL_RESOURCE_ATTRIBUTES`
- update `python` agent:
    - update deps