### PR TITLE
Change logzio-telemetry sub chart conditioning

### DIFF
--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -11,26 +11,22 @@ dependencies:
   - name: kube-state-metrics
     version: "4.24.0"
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: metrics.enabled
-    tags:
-      - kubeStateMetrics.enabled
+    condition: kubeStateMetrics.enabled
+
   - name: prometheus-node-exporter
     version: "4.23.2"
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: metrics.enabled
-    tags:
-      - nodeExporter.enabled
+    condition: nodeExporter.enabled
+
   - name: prometheus-pushgateway
     version: "2.4.2"
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: metrics.enabled
-    tags:
-      - pushGateway.enabled
+    condition: pushGateway.enabled 
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/VALUES.md
+++ b/charts/logzio-telemetry/VALUES.md
@@ -43,14 +43,14 @@ logzio-k8s-telemetry allows you to ship metrics and traces from your Kubernetes 
 | enableMetricsFilter.dropKubeSystem | bool | `false` | Enable metric filtering for kube system metrics. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the opentelemetry collector image. |
 | image.repository | string | `"otel/opentelemetry-collector-contrib"` | Opentelemetry collector image repository. |
-| image.tag | string | `"0.78.0"` |  Opentelemetry collector image tag. |
-| tags.kubeStateMetrics.enabled | bool | `true` | Controlles the deployment of the kube-state-metrics sub chart. |
+| image.tag | string | `"0.80.0"` |  Opentelemetry collector image tag. |
+| kubeStateMetrics.enabled | bool | `true` | Controlles the deployment of the kube-state-metrics sub chart. |
 | applicationMetrics.enabled | bool | `false` | wheter or not to enable `applications` scrape job. |
 | metrics.enabled | bool | `false` | Controlles the activation of metrics collection. |
 | traces.enabled | bool | `false` | Controlles the activation of traces collection. |
 | nameOverride | string | `"otel-collector"` | Name override for the opentelemetry collector. |
-| tags.nodeExporter.enabled | bool | `true` | Controlles the deployment of the node-exporter sub chart. |
-| tags.pushGateway.enabled | bool | `true` | Controlles the deployment of the prometheus-pushgateway sub chart. |
+| nodeExporter.enabled | bool | `true` | Controlles the deployment of the node-exporter sub chart. |
+| pushGateway.enabled | bool | `true` | Controlles the deployment of the prometheus-pushgateway sub chart. |
 | secrets.ListenerHost | string | `""` | Logzio listener host. |
 | secrets.LogzioRegion | string | `"us"` | Logzio listener region. |
 | secrets.MetricsToken | string | `""` | Logzio metrics token. |

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -122,21 +122,18 @@ clusterRoleRules:
   - watch
 
 
-tags:
-  kubeStateMetrics:
-    ## If false, kube-state-metrics sub-chart will not be installed
-    ##
-    enabled: true
+kubeStateMetrics:
+  ## If false, kube-state-metrics sub-chart will not be installed
+  enabled: true
 
-  pushGateway:
-    ## If false, pushGateway sub-chart will not be installed
-    ##
-    enabled: true
-  nodeExporter:
-    ## If false, node-exporter will not be installed
-    ##
-    enabled: true
-    
+pushGateway:
+  ## If false, prometheus-push-gateway sub-chart will not be installed
+  enabled: true
+
+nodeExporter:
+  ## If false, prometheus-node-exporter will not be installed
+  enabled: true
+
 prometheus-pushgateway:
   serviceAnnotations:
     prometheus.io/scrape: "true"


### PR DESCRIPTION
Instead of having the global `metrics.enabled` option of disabling installation of all logzio-telemetry sub charts, each sub chart has its own flag and by default will be installed.