### PR TITLE
Allow Windows Daemonset resource to be created conditionally

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.28.0
+version: 0.28.1
 appVersion: 1.5.1
 maintainers:
   - name: Miri Bar

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -115,6 +115,7 @@ helm install -n monitoring \
 | `daemonset.init.containerImage` | Init container image for the fluentd daemonset. | `busybox` |
 | `daemonset.priorityClassName` | Set [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) for all DaemonSet pods. | `""` |
 | `daemonset.updateStrategy` | Strategy to use when updating the Daemonset. | `{}` |
+| `windowsDaemonset.enabled` | Enables Fluentd Daemonset for Windows. | `true` |
 | `windowsDaemonset.kubernetesVerifySsl` | Enables to validate SSL certificates (windows). | `true` |
 | `windowsDaemonset.auditLogFormat` | Match Fluentd's format for kube-apiserver audit logs. Set to `audit-json` if your audit logs are in json format. (windows) | `audit` |
 | `windowsDaemonset.containerdRuntime` | **Deprecated from chart version 0.1.0.** Determines whether to use a configuration for a Containerd runtime. Set to `false` if your cluster doesn't use Containerd as CRI. (windows) | `true` |
@@ -300,7 +301,8 @@ If needed, the fluentd image can be changed to support windows server 2022 with 
 
 
 ## Change log
-
+ - **0.28.1**:
+   - Added `windowsDaemonset.enabled` customization.
  - **0.28.0**:
    - Added `daemonset.initContainerSecurityContext` customization.
    - Added `daemonset.updateStrategy` customization.

--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -67,11 +67,11 @@ Builds the list for exclude paths in the tail for the containers
 {{- end -}}
 {{- end -}}
 
-{{- if .Values.windowsDaemonset.enabled }}
 {{/*
 Builds the list for exclude paths in the tail for the containers - windows
 */}}
 {{- define "logzio.windowsExcludePath" }}
+{{- if .Values.windowsDaemonset.enabled }}
 {{- if .Values.windowsDaemonset.extraExclude }}
 {{- cat .Values.windowsDaemonset.excludeFluentdPath "," .Values.windowsDaemonset.extraExclude | nospace }}
 {{- else }}

--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -67,6 +67,7 @@ Builds the list for exclude paths in the tail for the containers
 {{- end -}}
 {{- end -}}
 
+{{- if .Values.windowsDaemonset.enabled }}
 {{/*
 Builds the list for exclude paths in the tail for the containers - windows
 */}}
@@ -75,6 +76,7 @@ Builds the list for exclude paths in the tail for the containers - windows
 {{- cat .Values.windowsDaemonset.excludeFluentdPath "," .Values.windowsDaemonset.extraExclude | nospace }}
 {{- else }}
 {{- print .Values.windowsDaemonset.excludeFluentdPath }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -175,6 +175,7 @@ spec:
   updateStrategy: {{ toYaml .Values.daemonset.updateStrategy | nindent 4 }}
   {{- end }}
 
+{{- if .Values.windowsDaemonset.enabled }}
 ---
 apiVersion: {{ .Values.apiVersions.daemonset }}
 kind: DaemonSet
@@ -314,3 +315,4 @@ spec:
   {{- if .Values.windowsDaemonset.updateStrategy }}
   updateStrategy: {{ toYaml .Values.windowsDaemonset.updateStrategy | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -145,6 +145,8 @@ daemonset:
   updateStrategy: {}
 
 windowsDaemonset:
+  # Controls whether the Daemonset is enabled for Windows
+  enabled: true
   # Tolerations for the Daemonset for Windows nodes
   tolerations:
   - key: node-role.kubernetes.io/master


### PR DESCRIPTION
#250 was raised as we don't have any need for the Windows Daemonset in our cluster and we would like the option to disable it. 

This PR allows it to be disabled via a new customisation option - `windowsDaemonset.enabled` - defaulting to `true` for backwards compatibility. In our use case, we can set this to `false` and not have support for Windows enabled as we don't use it.

The exclude paths helper for Windows is also wrapped in this to allow this to be optional.

I proposed this change to be a patch change as it doesn't change any behaviour unless you explicitly choose to turn off the daemonset, but I am happy to make it a minor change if that is deemed more appropriate. 