### PR TITLE
logzio-monitoring chart v5.0.0

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 4.0.0
+version: 5.0.0
 
 sources:
   - https://github.com/logzio/logzio-helm
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "3.0.0"
+    version: "4.0.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -189,6 +189,11 @@ There are two possible approaches to the upgrade you can choose from:
 
 ## Changelog
 - **4.0.0**:
+	- Upgrade `logzio-k8s-telemetry` to `4.0.0`:
+		- Removed the `kubernetes-360-metrics` key from the `logzio-secret`.
+			- Populate the pods containers `K8S_360_METRICS` environment variable directly using the opentelemetry-collector.k8s360 definition to inherit the list from values file instead.
+		- Added `logzio_app` label with `kubernetes360` value to cadvisor metrics pipeline to avoid dropping specific metrics by matching the k8s 360 filter.
+- **4.0.0**:
 	- Upgrade `logzio-k8s-telemetry` to `3.0.0`:
 		- Updated K360 metrics list in `secrets.yaml` - now created dynamically from OOB filters.
 		- Added `job_dummy` relabel and processor - Fixing an issue where duplicate metrics were being sent if the metrics were not in the `K8S_360_METRICS` environment variable.

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -188,10 +188,11 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
-- **4.0.0**:
+- **5.0.0**:
 	- Upgrade `logzio-k8s-telemetry` to `4.0.0`:
-		- Removed the `kubernetes-360-metrics` key from the `logzio-secret`.
-			- Populate the pods containers `K8S_360_METRICS` environment variable directly using the opentelemetry-collector.k8s360 definition to inherit the list from values file instead.
+		- **BREAKING CHANGES**:
+			- Removed the `kubernetes-360-metrics` key from the `logzio-secret`.
+				- Populate the pods containers `K8S_360_METRICS` environment variable directly using the opentelemetry-collector.k8s360 definition to inherit the list from values file instead.
 		- Added `logzio_app` label with `kubernetes360` value to cadvisor metrics pipeline to avoid dropping specific metrics by matching the k8s 360 filter.
 - **4.0.0**:
 	- Upgrade `logzio-k8s-telemetry` to `3.0.0`:


### PR DESCRIPTION
- Upgrade `logzio-k8s-telemetry` to `4.0.0`:
	- Removed the `kubernetes-360-metrics` key from the `logzio-secret`.
		- Populate the pods containers `K8S_360_METRICS` environment variable directly using the opentelemetry-collector.k8s360 definition to inherit the list from values file instead.
	- Added `logzio_app` label with `kubernetes360` value to cadvisor metrics pipeline to avoid dropping specific metrics by matching the k8s 360 filter.