### PR TITLE
0.29.0

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.28.1
+version: 0.29.0
 appVersion: 1.5.1
 maintainers:
   - name: Miri Bar

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -301,6 +301,9 @@ If needed, the fluentd image can be changed to support windows server 2022 with 
 
 
 ## Change log
+ - **0.29.0**:
+   - EKS Fargate logging:
+    - Send logs to port `8070` in logzio listener (instead of port `5050`)
  - **0.28.1**:
    - Added `windowsDaemonset.enabled` customization.
  - **0.28.0**:

--- a/charts/fluentd/templates/fargate-logging-configmap.yaml
+++ b/charts/fluentd/templates/fargate-logging-configmap.yaml
@@ -39,6 +39,9 @@ data:
       Name  es
       Match *
       Host  {{ .Values.secrets.logzioListener }}
-      Port  5050
+      HTTP_User token
+      HTTP_Passwd {{ .Values.secrets.logzioShippingToken }}
+      Port  8070
+      Retry_Limit no_retries
       Index logzioCustomerIndex
 {{ end }}


### PR DESCRIPTION
 **0.29.0**:
  - EKS Fargate logging:
    - Send logs to port `8070` in logzio listener (instead of port `5050`)