### PR TITLE
`5.1.0`

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.0.1
+version: 5.1.0
 
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: logzio-fluentd
-    version: "0.28.1"
+    version: "0.29.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -188,7 +188,9 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
-
+- **5.1.0**
+  - Upgrade `logzio-fluentd` -> `0.29.0``:
+    - EKS Fargate logging: Send logs to port `8070` in logzio listener (instead of port `5050`)
 - **5.0.1**:
 	- Upgrade `logzio-fluentd` to `0.28.1`:
 		- Added `windowsDaemonset.enabled` customization.

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -189,7 +189,7 @@ There are two possible approaches to the upgrade you can choose from:
 
 ## Changelog
 - **5.1.0**
-  - Upgrade `logzio-fluentd` -> `0.29.0``:
+  - Upgrade `logzio-fluentd` -> `0.29.0`:
     - EKS Fargate logging: Send logs to port `8070` in logzio listener (instead of port `5050`)
 - **5.0.1**:
 	- Upgrade `logzio-fluentd` to `0.28.1`:


### PR DESCRIPTION
- **5.1.0**
  - Upgrade `logzio-fluentd` -> `0.29.0`:
    - EKS Fargate logging: Send logs to port `8070` in logzio listener (instead of port `5050`)