### PR TITLE
Upgrade logzio-telemetry chart to v4.1.0

### DIFF
--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     condition: kubeStateMetrics.enabled
 
   - name: prometheus-node-exporter
-    version: "4.23.2"
+    version: "4.29.0"
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: nodeExporter.enabled
 
@@ -24,7 +24,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.0
+version: 4.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -394,6 +394,10 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 4.1.0
+  - Upgraded prometheus-node-exporter version to `4.29.0`
+  - Fixed bug with AKS metrics filter
+  - Remove unified_status_code label from SPM
 * 4.0.0
   - **BREAKING CHANGES**:
     - Removed the `kubernetes-360-metrics` key from the `logzio-secret`.

--- a/charts/logzio-telemetry/templates/_helpers.tpl
+++ b/charts/logzio-telemetry/templates/_helpers.tpl
@@ -137,7 +137,7 @@ If any OOB filters is being used the function return the OOB filter concatenated
 {{- define "opentelemetry-collector.k360Metrics" -}}
 {{- $metrics := "" }}
 {{- if .Values.enableMetricsFilter.aks }}
-    {{ $metrics = .Values.prometheusFilters.metrics.infrastructure.keep.aks  }}
+    {{- $metrics = .Values.prometheusFilters.metrics.infrastructure.keep.aks }}
 {{- else if .Values.enableMetricsFilter.gke}}
     {{- $metrics = .Values.prometheusFilters.metrics.infrastructure.keep.gke }}
 {{- else }}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -627,15 +627,7 @@ spanMetricsAgregator:
             operations:
               - action: update_label
                 label: span.name
-                new_label: operation
-      attributes/spm:
-        actions:
-        - action: upsert
-          from_attribute: rpc.grpc.status_code
-          key: unified_status_code
-        - action: upsert
-          from_attribute: http.status_code
-          key: unified_status_code           
+                new_label: operation    
     connectors:
       spanmetrics:
         histogram:
@@ -714,7 +706,7 @@ spanMetricsAgregator:
           exporters: [prometheus/spm]
         metrics/spm-logzio:
           receivers: [prometheus/spm-logzio, spanmetrics]
-          processors: [metricstransform,attributes/spm]
+          processors: [metricstransform]
           exporters: [prometheusremotewrite/spm-logzio]
   # service values        
   service:


### PR DESCRIPTION
- Upgraded prometheus-node-exporter version to `4.29.0`
- Fixed bug with AKS K8S 360 metrics filter
- Remove unified_status_code label from SPM