### PR TITLE
Upgrade logzio-monitoring chart to v5.2.0

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.1.0
+version: 5.2.0
 
 sources:
   - https://github.com/logzio/logzio-helm
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "4.0.0"
+    version: "4.1.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -188,6 +188,11 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **5.2.0**:
+	- Upgrade `logzio-k8s-telemetry` to `4.1.0`:
+		- Upgraded prometheus-node-exporter version to `4.29.0`
+		- Fixed bug with AKS metrics filter
+		- Remove unified_status_code label from SPM
 - **5.1.0**
   - Upgrade `logzio-fluentd` -> `0.29.0`:
     - EKS Fargate logging: Send logs to port `8070` in logzio listener (instead of port `5050`)


### PR DESCRIPTION
- Upgrade logzio-telemetry chart to v4.1.0 - Fix bug with AKS K8S 360 metrics filter
    - Remove unified_status_code label from SPM
    - Updated `prometheus-node-exporter` sub chart to `4.29.0`
    - Update changelog