### PR TITLE
Logzio monitoring 5.3.0

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,22 +2,22 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.2.5
+version: 5.3.0
 
 
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: logzio-fluentd
-    version: "0.29.1"
+    version: "0.29.2"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "4.1.3"
+    version: "4.2.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy
-    version: "0.3.0"
+    version: "0.3.1"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: securityReport.enabled
   - name: opencost
@@ -25,11 +25,11 @@ dependencies:
     repository: "https://opencost.github.io/opencost-helm-chart"
     condition: finops.enabled
   - name: logzio-k8s-events
-    version: "0.0.3"
+    version: "0.0.4"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
   - name: logzio-logs-collector
-    version: "1.0.0"
+    version: "1.0.1"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
 maintainers:

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.2.0
+version: 5.2.1
 
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: logzio-fluentd
-    version: "0.29.0"
+    version: "0.29.1"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
@@ -27,7 +27,10 @@ dependencies:
     version: "0.0.3"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
-
+  - name: logzio-logs-collector
+    version: "1.0.0"
+    repository: "https://logzio.github.io/logzio-helm/"
+    condition: logs.enabled
 maintainers:
 - name: tamirmich
   email: tamir.michaeli@logz.io

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -32,11 +32,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
 maintainers:
-- name: tamirmich
-  email: tamir.michaeli@logz.io
 - name: yotamloe
   email: yotam.loewenbach@logz.io
-- name: miriig
-  email: miri.ignatiev@logz.io
 - name: ralongit
   email: raul.gurshumo@logz.io

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.2.1
+version: 5.2.5
 
 sources:
   - https://github.com/logzio/logzio-helm

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -1,18 +1,20 @@
 # logzio-monitoring
 
-The logzio-monitoring Helm Chart ships your Kubernetes telemetry (logs, metrics, traces and security reports) to your Logz.io account.
+The `logzio-monitoring` Helm Chart facilitates the shipping of Kubernetes telemetry—including logs, metrics, traces, and security reports—to your Logz.io account.
 
-**Note:** this project is currently in *beta* and is prone to changes.
+**Note:** This project is currently in *beta* and may undergo changes.
 
 ## Overview
 
 This project packages the following Helm Charts:
-- [logzio-fluentd](https://github.com/logzio/logzio-helm/tree/master/charts/fluentd) for logs shipping (via Fluentd).
-- [logzio-telemetry](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-telemetry) for metrics and traces (via OpenTelemetry Collector).
-- [logzio-trivy](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-trivy) for security reports (via Trivy operator).
-- [logzio-k8s-events](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-k8s-events) for k8s deployment events.
+- [logzio-fluentd](https://github.com/logzio/logzio-helm/tree/master/charts/fluentd) for shipping logs via Fluentd.
+- [logzio-logs-collector](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-logs-collector) for shipping logs via opentelemetry.
+- [logzio-telemetry](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-telemetry) for metrics and traces via OpenTelemetry Collector.
+- [logzio-trivy](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-trivy) for security reports via Trivy operator.
+- [logzio-k8s-events](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-k8s-events) for Kubernetes deployment events.
 
 ### Kubernetes Versions Compatibility
+
 | Chart Version | Kubernetes Version |
 |---|---|
 | > 3.0.0 | v1.22.0 - v1.28.0 |
@@ -21,24 +23,25 @@ This project packages the following Helm Charts:
 ## Instructions for standard deployment:
 
 ### Before installing the chart
-* Check if you have any taints on your nodes:
 
-```sh
+* Verify if any taints are present on your nodes:
+
+```shell
 kubectl get nodes -o json | jq '"\(.items[].metadata.name) \(.items[].spec.taints)"'
 ```
 
-if you do, please add them as tolerations. For further explenation about modifying the chart, see the [further configuration section](#Further-configuration).
+If so, add them as tolerations. For further explanation on modifying the chart, see the [further configuration section](#Further-configuration).
 
-* You are using `Helm` client with version `v3.9.0` or above
+* You are using `Helm` client with version `v3.9.0` or above.
 
-### 1. Add the Helm Chart:
+### 1. Add the Helm chart:
 
-```sh
+```shell
 helm repo add logzio-helm https://logzio.github.io/logzio-helm
 helm repo update
 ```
 
-### 2. Deploy the Chart:
+### 2. Deploy the chart:
 
 Use the following command, and replace the placeholders with your parameters:
 
@@ -85,9 +88,9 @@ logzio-monitoring logzio-helm/logzio-monitoring
 
 ### Further configuration
 
-The above `helm install` command will deploy a standard configuration version of the Chart, for shipping logs, metrics and traces.
+The helm install command outlined above deploys a standard configuration of the chart for shipping logs, metrics, and traces.
 
-However, you can modify the Chart by using the `--set` flag in your `helm install` command:
+However, you can customize the chart using the --set flag in your helm install command:
 
 | Parameter	| Description | Default |
 | --- | --- | --- |
@@ -96,32 +99,20 @@ However, you can modify the Chart by using the `--set` flag in your `helm instal
 | `securityReport.enabled` | Enable to send k8s security logs | `false` |
 | `deployEvents.enabled` | Enable to send k8s deploy events logs | `false` |
 
-### To modify the logs Chart configuration:
+#### To modify the logs chart configuration:
 
 You can see a full list of the possible configuration values in the [logzio-fluentd Chart folder](https://github.com/logzio/logzio-helm/tree/master/charts/fluentd#configuration).
 
 If you want to modify one of the values mentioned in the `logzio-fluentd` folder, add it with the `--set` flag, and the `logzio-fluentd` prefix.
 
-For example, if in `logzio-fluentd`'s `values.yaml` file there's a parameter named `someField`, to set it we'll add the following to the `helm install` command:
+For example, to change a value named `someField` in `logzio-fluentd`'s `values.yaml` file, include the following in your `helm install` command:
 
-```sh
+```shell
 --set logzio-fluentd.someField="my new value"
 ```
+
 You can add `log_type` annotation with a custom value, which will be parsed into a `log_type` field with the same value.
 
-#### Migrate to OpenTelemetry for log collection
-
-The `logzio-fluentd` chart will be disabled by default in favor of the `logzio-logs-collector` for log collection in upcoming releases. To migrate to `logzio-logs-collector`, add the following `--set` flags:
-
-```sh
-helm install -n monitoring \
---set logs.enbled=true \
---set logzio-fluentd.enbled=false
---set logzio-logs-collector.enabled=true \
---set logzio-logs-collector.secrets.logzioShippingToken='<<LOG-SHIPPING-TOKEN>>' \
---set logzio-logs-collector.secrets.logzioListener='<<LISTENER-HOST>>' \
-logzio-monitoring logzio-helm/logzio-monitoring
-```
 
 ### To modify the metrics and traces Chart configuration:
 
@@ -129,16 +120,31 @@ You can see a full list of the possible configuration values in the [logzio-tele
 
 If you want to modify one of the values mentioned in the `logzio-telemetry` folder, add it with the `--set` flag, and the `logzio-k8s-telemetry` prefix.
 
-For example, if in `logzio-telemetry`'s `values.yaml` file there's a parameter named `someField`, to set it we'll add the following to the `helm install` command:
+For example, to change a value named `someField` in `logzio-telemetry`'s `values.yaml` file, include the following in your `helm install` command:
+
+```shell
+--set logzio-k8s-telemetry.someField="my new value"
+```
+
+### Migrate to OpenTelemetry for log collection
+
+The `logzio-fluentd` chart will be disabled by default in favor of the `logzio-logs-collector` for log collection in upcoming releases. To migrate to `logzio-logs-collector`, add the following `--set` flags:
 
 ```sh
---set logzio-k8s-telemetry.someField="my new value"
+helm install -n monitoring \
+--set logs.enabled=true \
+--set logzio-fluentd.enabled=false
+--set logzio-logs-collector.enabled=true \
+--set logzio-logs-collector.secrets.logzioShippingToken='<<LOG-SHIPPING-TOKEN>>' \
+--set logzio-logs-collector.secrets.logzioListener='<<LISTENER-HOST>>' \
+logzio-monitoring logzio-helm/logzio-monitoring
 ```
 
 ### Sending telemetry data from eks on fargate
 
-If you want to ship logs from pods that are running on fargate set the `fargateLogRouter.enabled` value to true, the follwing will deploy a dedicated `aws-observability` namespace and a `configmap` for fargate log router. More information about eks fargate logging can be found [here](https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html)
-```sh
+To ship logs from pods running on Fargate, set the `fargateLogRouter.enabled` value to `true`. This will deploy a dedicated `aws-observability` namespace and a `configmap` for the Fargate log router. More information about EKS Fargate logging can be found [here](https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html)
+
+```shell
 helm install -n monitoring \
 --set logs.enabled=true \
 --set logzio-fluentd.fargateLogRouter.enabled=true \
@@ -155,15 +161,22 @@ helm install -n monitoring \
 logzio-monitoring logzio-helm/logzio-monitoring
 ```
 
-Then use `kubectl port-forward` to accsess the user intefrace in your browser
-```
+Then use `kubectl port-forward` to accsess the user intefrace in your browser:
+
+```shell
 kubectl port-forward svc/ezkonnect-ui -n monitoring 31032:31032
 ```
 
 
 ### Handling image pull rate limit
-In some cases (i.e spot clusters) where the pods/nodes are replaced frequently, the pull rate limit for images pulled from dockerhub might be reached, with an error:
-`You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limits`.
+
+In scenarios (e.g., spot clusters) where pods/nodes are frequently replaced, you may encounter Dockerhub's pull rate limits. In these cases, use the following `--set` commands to use alternative image repositories:
+
+```
+You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limits.
+```
+
+
 In these cases we can use the following `--set` commands to use an alternative image repository:
 
 ```shell
@@ -174,19 +187,25 @@ In these cases we can use the following `--set` commands to use an alternative i
 ```
 
 ### Send logs to a custom endpoint
+
 Set fluetd `customEndpoint` value to send your logs to a custom endpoint
+
 ```shell
 --set logzio-fluentd.secrets.customEndpoint="<<CUSTOM_ENDPOINT>>" 
 ```
 
 ### Send Traces to a custom endpoint
+
 Set logzio-k8s-telemetry `CustomTracingEndpoint` value to send your spans to a custom endpoint
+
 ```shell
 --set logzio-k8s-telemetry.secrets.CustomTracingEndpoint="<<CUSTOM_TRACING_ENDPOINT>>" 
 ```
 
 ### Send metrics to a custom endpoint
+
 Set logzio-k8s-telemetry `ListenerHost` value to send your metrics to a custom endpoint (example: "https://endpoint.com:8080")
+
 ```shell
 --set logzio-k8s-telemetry.secrets.ListenerHost="<<CUSTOM_ENDPOINT>>"
 ```
@@ -196,12 +215,13 @@ Set logzio-k8s-telemetry `ListenerHost` value to send your metrics to a custom e
 Before upgrading your logzio-monitoring Chart to v3.0.0 with `helm upgrade`, note that you may encounter an error for some of the logzio-telemetry sub-charts.
 
 There are two possible approaches to the upgrade you can choose from:
+
 - Reinstall the chart.
 - Before running the `helm upgrade` command, delete the old subcharts resources: `logzio-monitoring-prometheus-pushgateway` deployment and the `logzio-monitoring-prometheus-node-exporter` daemonset.
 
 
 ## Changelog
-- **5.2.1**:
+- **5.2.5**:
   - **Depreciation notice** `logzio-fluentd` chart will be disabled by default in favour of `logzio-logs-collector` for log collection in upcoming releases.
 	- Added `logzio-logs-collector` version `1.0.0`:
     - otel collector daemonset designed and configured to function as log collection agent
@@ -211,6 +231,15 @@ There are two possible approaches to the upgrade you can choose from:
 	- Upgrade `logzio-fluentd` to `0.29.1`:
     - Added `enabled` value, to conditianly control the deployment of this chart by a parent chart.
     - Added `daemonset.LogFileRefreshInterval` and `windowsDaemonset.LogFileRefreshInterval` values, to control list of watched log files refresh interval.
+- **5.2.2**:
+  - Upgrade `logzio-k8s-telemetry` to `4.1.2`:
+    - Upgrade `.values.spmImage.tag` `0.80` -> `0.97`
+      - Add `metrics_expiration` to span metrics configuration, to prevent sending expired time series
+      - Add `resource_metrics_key_attributes` to span metrics configuration, to prevent value fluctuation of counter metrics when resource attributes change.
+    - Include collector log level configuration in individual components (standalone, daemonset, spanmetrics).
+- **5.2.1**:
+	- Upgrade `logzio-k8s-telemetry` to `4.1.1`:
+  		- Fixed bug with cAdvisor metrics filter.
 - **5.2.0**:
 	- Upgrade `logzio-k8s-telemetry` to `4.1.0`:
 		- Upgraded prometheus-node-exporter version to `4.29.0`

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -109,9 +109,10 @@ For example, if in `logzio-fluentd`'s `values.yaml` file there's a parameter nam
 ```
 You can add `log_type` annotation with a custom value, which will be parsed into a `log_type` field with the same value.
 
-#### Migrate to opentelemetry for log collection
-`logzio-fluentd` chart will be disabled by default in favour of `logzio-logs-collector` for log collection in upcoming releases.
-To migrate to `logzio-logs-collector` add the following `--set` flags:
+#### Migrate to OpenTelemetry for log collection
+
+The `logzio-fluentd` chart will be disabled by default in favor of the `logzio-logs-collector` for log collection in upcoming releases. To migrate to `logzio-logs-collector`, add the following `--set` flags:
+
 ```sh
 helm install -n monitoring \
 --set logs.enbled=true \

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -188,6 +188,15 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **5.2.1**:
+	- Added `logzio-logs-collector` version `1.0.0`:
+    - otel collector daemonset designed and configured to function as log collection agent
+    - eks fargate support
+    - adds logzio required fields (`log_level`, `type`, `env_id` and more)
+    - `enabled` value to enable/disable deployment from parent charts
+	- Upgrade `logzio-fluentd` to `0.29.1`:
+    - Added `enabled` value, to conditianly control the deployment of this chart by a parent chart.
+    - Added `daemonset.LogFileRefreshInterval` and `windowsDaemonset.LogFileRefreshInterval` values, to control list of watched log files refresh interval.
 - **5.2.0**:
 	- Upgrade `logzio-k8s-telemetry` to `4.1.0`:
 		- Upgraded prometheus-node-exporter version to `4.29.0`

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -96,7 +96,7 @@ However, you can modify the Chart by using the `--set` flag in your `helm instal
 | `securityReport.enabled` | Enable to send k8s security logs | `false` |
 | `deployEvents.enabled` | Enable to send k8s deploy events logs | `false` |
 
-#### To modify the logs Chart configuration:
+### To modify the logs Chart configuration:
 
 You can see a full list of the possible configuration values in the [logzio-fluentd Chart folder](https://github.com/logzio/logzio-helm/tree/master/charts/fluentd#configuration).
 
@@ -109,6 +109,18 @@ For example, if in `logzio-fluentd`'s `values.yaml` file there's a parameter nam
 ```
 You can add `log_type` annotation with a custom value, which will be parsed into a `log_type` field with the same value.
 
+#### Migrate to opentelemetry for log collection
+`logzio-fluentd` chart will be disabled by default in favour of `logzio-logs-collector` for log collection in upcoming releases.
+To migrate to `logzio-logs-collector` add the following `--set` flags:
+```sh
+helm install -n monitoring \
+--set logs.enbled=true \
+--set logzio-fluentd.enbled=false
+--set logzio-logs-collector.enabled=true \
+--set logzio-logs-collector.secrets.logzioShippingToken='<<LOG-SHIPPING-TOKEN>>' \
+--set logzio-logs-collector.secrets.logzioListener='<<LISTENER-HOST>>' \
+logzio-monitoring logzio-helm/logzio-monitoring
+```
 
 ### To modify the metrics and traces Chart configuration:
 
@@ -189,6 +201,7 @@ There are two possible approaches to the upgrade you can choose from:
 
 ## Changelog
 - **5.2.1**:
+  - **Depreciation notice** `logzio-fluentd` chart will be disabled by default in favour of `logzio-logs-collector` for log collection in upcoming releases.
 	- Added `logzio-logs-collector` version `1.0.0`:
     - otel collector daemonset designed and configured to function as log collection agent
     - eks fargate support

--- a/charts/logzio-monitoring/templates/NOTES.txt
+++ b/charts/logzio-monitoring/templates/NOTES.txt
@@ -1,0 +1,31 @@
+
+{{- if and (.Values.logs.enabled) (not (index .Values "logzio-logs-collector" "enabled")) (index .Values "logzio-fluentd" "enabled") }}
+[ DEPRICATION ] You are using fluetnd agent for log collection, this option will be disabled by default in upcoming releases.
+We reccomend to migrate to opentelemetry logzio-logs-collector by setting the following values:
+
+  --set logs.enbled=true \
+  --set logzio-logs-collector.enabled=true \
+  --set logzio-fluentd.enbled=false
+
+
+{{ end }}
+
+
+{{- if and (.Values.logs.enabled) (index .Values "logzio-logs-collector" "enabled") (index .Values "logzio-fluentd" "enabled") }}
+[ WARNING ] You enabled both fluetnd agent and opentelemetry logzio-logs-collector for log collection, you will probly have duplicated log data entries in logz.io
+We reccomend to migrate to opentelemetry logzio-logs-collector by setting the following values:
+
+  --set logs.enbled=true \
+  --set logzio-logs-collector.enabled=true \
+  --set logzio-fluentd.enbled=false
+
+{{ end }}
+
+
+{{- if and (.Values.logs.enabled) (index .Values "logzio-logs-collector" "enabled")}}
+[ INFO ] You enabled opentelemetry logzio-logs-collector for log collection, this option will be enabled the default in upcoming releases.
+
+{{ end }}
+
+
+

--- a/charts/logzio-monitoring/templates/NOTES.txt
+++ b/charts/logzio-monitoring/templates/NOTES.txt
@@ -3,22 +3,28 @@
 [ DEPRICATION ] You are using fluetnd agent for log collection, this option will be disabled by default in upcoming releases.
 You can change to opentelemetry logzio-logs-collector by setting the following values:
 
-  --set logs.enbled=true \
+  --set logs.enabled=true \
+  --set logzio-fluentd.enabled=false \
   --set logzio-logs-collector.enabled=true \
-  --set logzio-fluentd.enbled=false
-
+  --set logzio-logs-collector.secrets.logzioLogsToken=<<token>> \
+  --set logzio-logs-collector.secrets.logzioRegion=<<region>> \
+  --set logzio-logs-collector.secrets.env_id=<<env_id>> \
+  --set logzio-logs-collector.secrets.logType=<<log_type>> \
 
 {{ end }}
 
 
 {{- if and (.Values.logs.enabled) (index .Values "logzio-logs-collector" "enabled") (index .Values "logzio-fluentd" "enabled") }}
-[ WARNING ] You enabled both fluetnd agent and opentelemetry logzio-logs-collector for log collection, you will probly have duplicated log data entries in logz.io
+[ WARNING ] You enabled both fluetnd agent and opentelemetry logzio-logs-collector for log collection, you will have duplicated log data entries in logz.io
 You can change to opentelemetry logzio-logs-collector by setting the following values:
 
-  --set logs.enbled=true \
+  --set logs.enabled=true \
+  --set logzio-fluentd.enabled=false \
   --set logzio-logs-collector.enabled=true \
-  --set logzio-fluentd.enbled=false
-
+  --set logzio-logs-collector.secrets.logzioLogsToken=<<token>> \
+  --set logzio-logs-collector.secrets.logzioRegion=<<region>> \
+  --set logzio-logs-collector.secrets.env_id=<<env_id>> \
+  --set logzio-logs-collector.secrets.logType=<<log_type>> \
 {{ end }}
 
 

--- a/charts/logzio-monitoring/templates/NOTES.txt
+++ b/charts/logzio-monitoring/templates/NOTES.txt
@@ -1,7 +1,7 @@
 
 {{- if and (.Values.logs.enabled) (not (index .Values "logzio-logs-collector" "enabled")) (index .Values "logzio-fluentd" "enabled") }}
 [ DEPRICATION ] You are using fluetnd agent for log collection, this option will be disabled by default in upcoming releases.
-We reccomend to migrate to opentelemetry logzio-logs-collector by setting the following values:
+You can change to opentelemetry logzio-logs-collector by setting the following values:
 
   --set logs.enbled=true \
   --set logzio-logs-collector.enabled=true \
@@ -13,7 +13,7 @@ We reccomend to migrate to opentelemetry logzio-logs-collector by setting the fo
 
 {{- if and (.Values.logs.enabled) (index .Values "logzio-logs-collector" "enabled") (index .Values "logzio-fluentd" "enabled") }}
 [ WARNING ] You enabled both fluetnd agent and opentelemetry logzio-logs-collector for log collection, you will probly have duplicated log data entries in logz.io
-We reccomend to migrate to opentelemetry logzio-logs-collector by setting the following values:
+You can change to opentelemetry logzio-logs-collector by setting the following values:
 
   --set logs.enbled=true \
   --set logzio-logs-collector.enabled=true \
@@ -23,7 +23,7 @@ We reccomend to migrate to opentelemetry logzio-logs-collector by setting the fo
 
 
 {{- if and (.Values.logs.enabled) (index .Values "logzio-logs-collector" "enabled")}}
-[ INFO ] You enabled opentelemetry logzio-logs-collector for log collection, this option will be enabled the default in upcoming releases.
+[ INFO ] You enabled opentelemetry logzio-logs-collector for log collection.
 
 {{ end }}
 

--- a/charts/logzio-monitoring/values.yaml
+++ b/charts/logzio-monitoring/values.yaml
@@ -20,8 +20,12 @@ deployEvents:
 
 # Override values for the Fluentd sub-chart
 logzio-fluentd:
+  enabled: true
   daemonset:
     logType: "agent-k8s"
+
+logzio-logs-collector:
+  enabled: false
 
 # Override values for the opencost sub-chart
 opencost:


### PR DESCRIPTION
- Added `logzio-logs-collector` version `1.0.0`:
    - otel collector daemonset designed and configured to function as log collection agent
    - eks fargate support
    - adds logzio required fields (`log_level`, `type`, `env_id` and more)
    - `enabled` value to enable/disable deployment from parent charts
- Upgrade `logzio-fluentd` to `0.29.1`:
    - Added `enabled` value, to conditianly control the deployment of this chart by a parent chart.
    - Added `daemonset.LogFileRefreshInterval` and `windowsDaemonset.LogFileRefreshInterval` values, to control list of watched log files refresh interval.

**Still TODO:**
- [x] Add docs on how to enable `logzio-logs-collector` 
- [x] Edit and refine `notes.txt`
