### PR TITLE
Fix Kubernetes360 filter for cAdvisor metrics in standalone

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.2.0
+version: 5.2.1
 
 sources:
   - https://github.com/logzio/logzio-helm
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "4.1.0"
+    version: "4.1.1"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy
@@ -29,11 +29,7 @@ dependencies:
     condition: deployEvents.enabled
 
 maintainers:
-- name: tamirmich
-  email: tamir.michaeli@logz.io
 - name: yotamloe
   email: yotam.loewenbach@logz.io
-- name: miriig
-  email: miri.ignatiev@logz.io
 - name: ralongit
   email: raul.gurshumo@logz.io

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -207,6 +207,9 @@ There are two possible approaches to the upgrade you can choose from:
 
 ## Changelog
 - **5.2.0**:
+	- Upgrade `logzio-k8s-telemetry` to `4.1.1`:
+  		- Fixed bug with cAdvisor metrics filter.
+- **5.2.0**:
 	- Upgrade `logzio-k8s-telemetry` to `4.1.0`:
 		- Upgraded prometheus-node-exporter version to `4.29.0`
 		- Fixed bug with AKS metrics filter

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.0
+version: 4.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -394,6 +394,8 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 4.1.1
+  - Fixed bug with cAdvisor metrics filter.
 * 4.1.0
   - Upgraded prometheus-node-exporter version to `4.29.0`
   - Fixed bug with AKS metrics filter

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -399,6 +399,9 @@ metricsConfig:
           relabel_configs:
           - action: labelmap
             regex: __meta_kubernetes_node_label_(.+)  
+          - action: replace
+            replacement: kubernetes360
+            target_label: logzio_app                   
           metric_relabel_configs: []
     prometheus/collector:
       config:


### PR DESCRIPTION
- Added the `logzio_app` label to standalone collector so filter won't drop the cAdvisor metrics.