### PR TITLE
Temporary version revert for monitoring chart

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.2.1
+version: 5.2.0
 
 sources:
   - https://github.com/logzio/logzio-helm
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "4.1.1"
+    version: "4.1.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -206,7 +206,7 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
-- **5.2.0**:
+- **5.2.1**:
 	- Upgrade `logzio-k8s-telemetry` to `4.1.1`:
   		- Fixed bug with cAdvisor metrics filter.
 - **5.2.0**:


### PR DESCRIPTION
- Sub charts in the auto-release workflow should be created before main chart.
- Fix readme