### PR TITLE
Logzio telemetry 4.1.2

### DIFF
--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.1
+version: 4.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -397,7 +397,8 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 * 4.1.2
   - Upgrade `.values.spmImage.tag` `0.80` -> `0.97`
     - Add `metrics_expiration` to span metrics configuration, to prevent sending expired time series
-    - Add `resource_metrics_key_attributes` to span metrics configuration, to prevent value fluctuation of counter metrics when resource attributes change
+    - Add `resource_metrics_key_attributes` to span metrics configuration, to prevent value fluctuation of counter metrics when resource attributes change.
+  - Include collector log level configuration in individual components (standalone, daemonset, spanmetrics).
 * 4.1.1
   - Fixed bug with cAdvisor metrics filter for standalone collector mode.
 * 4.1.0

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -394,6 +394,10 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 4.1.2
+  - Upgrade `.values.spmImage.tag` `0.80` -> `0.97`
+    - Add `metrics_expiration` to span metrics configuration, to prevent sending expired time series
+    - Add `resource_metrics_key_attributes` to span metrics configuration, to prevent value fluctuation of counter metrics when resource attributes change
 * 4.1.1
   - Fixed bug with cAdvisor metrics filter for standalone collector mode.
 * 4.1.0

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -295,9 +295,6 @@ tracesConfig:
         receivers: [jaeger, zipkin, otlp]
         processors: [resourcedetection/all,attributes/env_id, k8sattributes, resource/k8s, tail_sampling, batch]
         exporters: [logzio]
-    telemetry:
-      logs:
-        level: "info"  
 
 spmForwarderConfig:
   exporters:
@@ -716,6 +713,9 @@ spanMetricsAgregator:
           receivers: [prometheus/spm-logzio, spanmetrics]
           processors: [metricstransform]
           exporters: [prometheusremotewrite/spm-logzio]
+      telemetry:
+        logs:
+          level: "info"  
   # service values        
   service:
     type: ClusterIP
@@ -1075,6 +1075,9 @@ daemonsetConfig:
           - prometheus/infrastructure
           - prometheus/cadvisor
           - prometheus/collector
+    telemetry:
+      logs:
+        level: "info" 
 
          
 opencost:

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -511,7 +511,7 @@ windowsExporterInstallerImage:
 spmImage:
   repository: otel/opentelemetry-collector-contrib
   pullPolicy: IfNotPresent
-  tag: "0.80.0"
+  tag: "0.97.0"
 imagePullSecrets: []
 
 # OpenTelemetry Collector executable
@@ -638,6 +638,11 @@ spanMetricsAgregator:
             buckets: [2ms, 8ms, 50ms, 100ms, 200ms, 500ms, 1s, 5s, 10s]
         dimensions_cache_size: 100000
         aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
+        metrics_expiration: 5m
+        resource_metrics_key_attributes:
+          - service.name
+          - telemetry.sdk.language
+          - telemetry.sdk.name
         dimensions:
           - name: rpc.grpc.status_code
           - name: http.method


### PR DESCRIPTION
* 4.1.2
  - Upgrade `.values.spmImage.tag` `0.80` -> `0.97`
    - Add `metrics_expiration` to span metrics configuration, to prevent sending expired time series
    - Add `resource_metrics_key_attributes` to span metrics configuration, to prevent value fluctuation of counter metrics when resource attributes change
   - Include collector log level configuration in individual components (standalone, daemonset, spanmetrics) for a more strait forward way to configure the collector log level