### PR TITLE
Logzio monitoring 5.2.2

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.2.1
+version: 5.2.2
 
 sources:
   - https://github.com/logzio/logzio-helm
@@ -12,7 +12,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "4.1.1"
+    version: "4.1.2"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -206,6 +206,12 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **5.2.2**:
+  - Upgrade `logzio-k8s-telemetry` to `4.1.2`:
+    - Upgrade `.values.spmImage.tag` `0.80` -> `0.97`
+      - Add `metrics_expiration` to span metrics configuration, to prevent sending expired time series
+      - Add `resource_metrics_key_attributes` to span metrics configuration, to prevent value fluctuation of counter metrics when resource attributes change.
+    - Include collector log level configuration in individual components (standalone, daemonset, spanmetrics).
 - **5.2.1**:
 	- Upgrade `logzio-k8s-telemetry` to `4.1.1`:
   		- Fixed bug with cAdvisor metrics filter.


### PR DESCRIPTION
- **5.2.2**:
  - Upgrade `logzio-k8s-telemetry` to `4.1.2`:
    - Upgrade `.values.spmImage.tag` `0.80` -> `0.97`
      - Add `metrics_expiration` to span metrics configuration, to prevent sending expired time series
      - Add `resource_metrics_key_attributes` to span metrics configuration, to prevent value fluctuation of counter metrics when resource attributes change.
    - Include collector log level configuration in individual components (standalone, daemonset, spanmetrics).