### PR TITLE
Upgrade logzio-monitoring v5.2.3

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.2.2
+version: 5.2.3
 
 sources:
   - https://github.com/logzio/logzio-helm

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -206,6 +206,12 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **5.2.3**:
+  - Upgrade `logzio-k8s-telemetry` to `4.1.3`:
+	- Removed unused prometheus receiver
+	- Divide metrics and labels renames to separate processors
+	- Disable metric suffix from prometheus exporter
+		- Resolves latency metric rename
 - **5.2.2**:
   - Upgrade `logzio-k8s-telemetry` to `4.1.2`:
     - Upgrade `.values.spmImage.tag` `0.80` -> `0.97`


### PR DESCRIPTION
  - Upgrade `logzio-k8s-telemetry` to `4.1.3`:
	- Removed unused prometheus receiver
	- Divide metrics and labels renames to separate processors
	- Disable metric suffix from prometheus exporter
		- Resolves latency metric rename