### PR TITLE
Release logzio-telemetry v4.2.0

### DIFF
--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -24,14 +24,14 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.3
+version: 4.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.80.0
+appVersion: 0.97.0
 maintainers:
 - name: yotamloe
   email: yotam.loewenbach@logz.io
-- name: tamirmich
-  email: tamir.michaeli@logz.io
+- name: ralongit
+  email: raul.gurshumo@logz.io

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -58,7 +58,7 @@ Enable the traces configuration for this chart: --set traces.enabled=true
 
 Replace the Logz-io `<<TRACES-SHIPPING-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/manage-tokens/data-shipping) of the traces account to which you want to send your data.
 
-Replace `<<logzio-region>>` with the name of your Logz.io region e.g `us`,`eu`.
+Replace `<<LOGZIO-REGION>>` with the name of your Logz.io region e.g `us`,`eu`.
 
 
 
@@ -80,7 +80,7 @@ logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 helm install \
 --set traces.enabled=true \
 --set secrets.TracesToken=<<TRACES-SHIPPING-TOKEN>> \
---set secrets.LogzioRegion=<<logzio-region>> \
+--set secrets.LogzioRegion=<<LOGZIO-REGION>> \
 --set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
 --set secrets.env_id=<<ENV-ID>> \
 logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
@@ -94,7 +94,7 @@ helm install \
 --set spm.enabled=true \
 --set secrets.SpmToken=<<SPM-SHIPPING-TOKEN>> \
 --set secrets.TracesToken=<<TRACES-SHIPPING-TOKEN>> \
---set secrets.LogzioRegion=<<logzio-region>> \
+--set secrets.LogzioRegion=<<LOGZIO-REGION>> \
 --set secrets.ListenerHost=<<LISTENER-HOST>> \
 --set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
 --set secrets.env_id=<<ENV-ID>> \
@@ -109,7 +109,7 @@ helm install  \
 --set spm.enabled=true \
 --set secrets.TracesToken=<<TRACES-SHIPPING-TOKEN>> \
 --set secrets.SpmToken=<<SPM-SHIPPING-TOKEN>> \
---set secrets.LogzioRegion=<<logzio-region>> \
+--set secrets.LogzioRegion=<<LOGZIO-REGION>> \
 --set metrics.enabled=true \
 --set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
 --set secrets.ListenerHost=<<LISTENER-HOST>> \
@@ -117,6 +117,7 @@ helm install  \
 --set secrets.env_id=<<ENV-ID>> \
 logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 ```
+
 #### Deploy both charts with span metrics and service graph
 **Note** `serviceGraph.enabled=true` will have no effect unless `traces.enabled` & `spm.enabled=true` is also set to `true`
 ```
@@ -126,8 +127,23 @@ helm install  \
 --set serviceGraph.enabled=true \
 --set secrets.TracesToken=<<TRACES-SHIPPING-TOKEN>> \
 --set secrets.SpmToken=<<SPM-SHIPPING-TOKEN>> \
---set secrets.LogzioRegion=<<logzio-region>> \
+--set secrets.LogzioRegion=<<LOGZIO-REGION>> \
 --set metrics.enabled=true \
+--set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
+--set secrets.ListenerHost=<<LISTENER-HOST>> \
+--set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
+--set secrets.env_id=<<ENV-ID>> \
+logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
+```
+
+#### Deploy metrics chart with Kuberenetes object logs correlation
+**Note** `k8sObjectsConfig.enabled=true` will have no effect unless `metrics.enabled` is also set to `true`
+```
+helm install  \
+--set metrics.enabled=true \
+--set k8sObjectsConfig.enabled=true \
+--set secrets.LogzioRegion=<<LOGZIO-REGION>> \
+--set secrets.k8sObjectsLogsToken=<<LOGZIO-LOG-SHIPPING-TOKEN>> \
 --set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
 --set secrets.ListenerHost=<<LISTENER-HOST>> \
 --set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
@@ -394,6 +410,11 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 4.2.0
+  - Upgraded `opentelemetry-collector-contrib` image to `v0.97.0`
+  - Added Kubernetes objects receiver
+  - Removed servicegraph connector from span metrics configuration
+  - Allow `env_id` & `p8s_logzio_name` non string values
 * 4.1.3
   - Removed unused prometheus receiver
   - Divide metrics and labels renames to separate processors

--- a/charts/logzio-telemetry/templates/_daemonset-pod.tpl
+++ b/charts/logzio-telemetry/templates/_daemonset-pod.tpl
@@ -54,6 +54,18 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: logzio-metrics-shipping-token
+      {{ if .Values.k8sObjectsConfig.enabled }}
+      - name: OBJECTS_LOGS_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.secrets.name }}
+            key: logzio-k8s-objects-logs-token
+      - name: LOGZIO_LISTENER_REGION
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.secrets.name }}
+            key: logzio-listener-region            
+      {{ end }}            
       - name: LISTENER_URL
         valueFrom:
           secretKeyRef:

--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -58,6 +58,21 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: logzio-metrics-shipping-token
+      {{ if .Values.k8sObjectsConfig.enabled }}
+      - name: OBJECTS_LOGS_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.secrets.name }}
+            key: logzio-k8s-objects-logs-token
+      {{ end }} 
+         
+{{- end }}
+{{- if or (eq .Values.k8sObjectsConfig.enabled true) (eq .Values.traces.enabled true) }}  
+      - name: LOGZIO_LISTENER_REGION
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.secrets.name }}
+            key: logzio-listener-region            
 {{- end }}
 {{- if or (eq .Values.metrics.enabled true) (eq .Values.spm.enabled true) }}
       - name: LISTENER_URL
@@ -69,7 +84,7 @@ containers:
         valueFrom:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
-            key: p8s-logzio-name
+            key: p8s-logzio-name   
 {{- end }}
 {{- if .Values.traces.enabled }}
       - name: TRACES_TOKEN
@@ -77,11 +92,6 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: logzio-traces-shipping-token
-      - name: LOGZIO_LISTENER_REGION
-        valueFrom:
-          secretKeyRef:
-            name: {{ .Values.secrets.name }}
-            key: logzio-listener-region
       {{ if .Values.secrets.CustomTracingEndpoint}}
       - name: CUSTOM_TRACING_ENDPOINT
         valueFrom:
@@ -104,7 +114,7 @@ containers:
         valueFrom:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
-            key: logzio-spm-shipping-token
+            key: logzio-spm-shipping-token        
 {{ end }}
 {{- end }}
       - name: ENV_ID

--- a/charts/logzio-telemetry/templates/secrets.yaml
+++ b/charts/logzio-telemetry/templates/secrets.yaml
@@ -10,13 +10,13 @@ stringData:
 {{- if .Values.opencost.enabled -}}
   opencost-duplicates: container_memory_usage_bytes|container_fs_limit_bytes|container_fs_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total|container_cpu_usage_seconds_total|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_job_status_failed|kube_namespace_annotations|kube_namespace_labels|kube_node_labels|kube_node_status_allocatable|kube_node_status_allocatable_cpu_cores|kube_node_status_allocatable_memory_bytes|kube_node_status_capacity|kube_node_status_capacity_cpu_cores|kube_node_status_capacity_memory_bytes|kube_node_status_condition|kube_persistentvolume_capacity_bytes|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_annotations|kube_pod_container_resource_limits|kube_pod_container_resource_limits_cpu_cores|kube_pod_container_resource_limits_memory_bytes|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_running|kube_pod_container_status_terminated_reason|kube_pod_labels|kube_pod_owner|kube_pod_status_phase|kube_replicaset_owner|node_cpu_seconds_total|node_disk_reads_completed|node_disk_reads_completed_total|node_disk_writes_completed|node_disk_writes_completed_total|node_filesystem_device_error|node_memory_Buffers_bytes|node_memory_Cached_bytes|node_memory_MemAvailable_bytes|node_memory_MemFree_bytes|node_memory_MemTotal_bytes|node_network_transmit_bytes_total|
 {{- end }}  
-  env_id: {{.Values.secrets.env_id}}
+  env_id: {{.Values.secrets.env_id | quote }}
 {{- if .Values.metrics.enabled }}
   logzio-metrics-shipping-token: {{ .Values.secrets.MetricsToken }}
 {{- end }}
 {{- if or (eq .Values.metrics.enabled true) (eq .Values.spm.enabled true) }}
   logzio-metrics-listener: {{ .Values.secrets.ListenerHost }}
-  p8s-logzio-name: {{.Values.secrets.p8s_logzio_name}}
+  p8s-logzio-name: {{.Values.secrets.p8s_logzio_name | quote }}
 {{- end }}
 {{- if .Values.traces.enabled }}
   logzio-traces-shipping-token: {{ .Values.secrets.TracesToken }}
@@ -28,6 +28,10 @@ stringData:
   sampling-probability: {{ .Values.secrets.SamplingProbability | quote}}
 {{ if .Values.spm.enabled }}
   logzio-spm-shipping-token: {{ .Values.secrets.SpmToken }}
+{{ end }}
+{{ if .Values.k8sObjectsConfig.enabled }}
+  logzio-k8s-objects-logs-token: {{.Values.secrets.k8sObjectsLogsToken}}
+  logzio-listener-region: {{ .Values.secrets.LogzioRegion}}
 {{ end }}
 {{- end }}
 {{- if .Values.secrets.windowsNodeUsername }}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -5,34 +5,47 @@
 collector:
   mode: daemonset # possible values: standalone, daemonset
 traces:
-  enabled: false
+  enabled: false # Send traces telemetry
 metrics:
-  enabled: false
+  enabled: false # Send metrics telemetry 
 spm:
-  enabled: false
+  enabled: false # Send Span metrics, requires `traces.enabled`
+
 applicationMetrics:
-  enabled: false
-nameOverride: "otel-collector"
-fullnameOverride: ""
+  ## Send application metrics, requires `metrics.enabled` and the `prometheus.io/scrape: true` annotaion set.
+  enabled: false 
+kubeStateMetrics:
+  ## If false, kube-state-metrics sub-chart will not be installed
+  enabled: true
+pushGateway:
+  ## If false, prometheus-push-gateway sub-chart will not be installed
+  enabled: true
+nodeExporter:
+  ## If false, prometheus-node-exporter will not be installed
+  enabled: true
+
+nameOverride: "otel-collector" # The resources name prefix 
+fullnameOverride: "" # The resources name
 
 secrets:
-  name: logzio-secret
-  enabled: true
-  MetricsToken: ""
-  TracesToken: ""
-  SpmToken: ""
-  ListenerHost: ""
-  env_id: "my_environment"
-  LogzioRegion: "us"
-  CustomTracingEndpoint: ""
-  p8s_logzio_name: ""
-  windowsNodeUsername: ""
-  windowsNodePassword: ""
-  SamplingProbability: 10
-  SamplingLatency: 500
+  name: logzio-secret  # Secret name
+  enabled: true  # Create secret
+  MetricsToken: ""  # Metrics account shipping token
+  TracesToken: ""  # Tracing account shipping token
+  SpmToken: ""  # Span Metrics account shipping token
+  k8sObjectsLogsToken: ""  # Kubernetes objects Logs account shipping token
+  ListenerHost: ""  # Logz.io metrics listener address - https://docs.logz.io/docs/user-guide/admin/hosting-regions/account-region/
+  env_id: "my_environment"  # Environment name 
+  LogzioRegion: "us"  # Traces & Logs listener address region code - https://docs.logz.io/docs/user-guide/admin/hosting-regions/account-region/
+  CustomTracingEndpoint: ""  # Custom Traces listener endpoint
+  p8s_logzio_name: ""  # Metrics Environment name
+  windowsNodeUsername: ""  # Windows Node Username
+  windowsNodePassword: ""  # Windows Node Password
+  SamplingProbability: 10  # Traces Sampling Probability
+  SamplingLatency: 500  # Traces Sampling Latency
 
 
-managedServiceAccount: true
+managedServiceAccount: true 
 
 clusterRole:
   # Specifies whether a clusterRole should be created
@@ -121,27 +134,14 @@ clusterRoleRules:
   - list
   - watch
 
-
-kubeStateMetrics:
-  ## If false, kube-state-metrics sub-chart will not be installed
-  enabled: true
-
-pushGateway:
-  ## If false, prometheus-push-gateway sub-chart will not be installed
-  enabled: true
-
-nodeExporter:
-  ## If false, prometheus-node-exporter will not be installed
-  enabled: true
-
 prometheus-pushgateway:
   serviceAnnotations:
     prometheus.io/scrape: "true"
   nodeSelector:
     kubernetes.io/os: linux
-
+# Configuration merge from the colelctor configs
 emptyConfig: {}
-
+# Base configuration of the collector
 baseCollectorConfig:
   exporters:
     logging:
@@ -230,7 +230,7 @@ baseCollectorConfig:
     telemetry:
       logs:
         level: "info"
-
+# Traces configuration
 tracesConfig:
   exporters:
     logzio:
@@ -308,7 +308,7 @@ spmForwarderConfig:
         receivers: [jaeger, zipkin, otlp]
         processors: [resourcedetection/all, attributes/env_id, k8sattributes]
         exporters: [logging, otlp]
-
+# Metrics standalone collector configuration 
 metricsConfig:
   extensions:
     health_check: {}
@@ -494,7 +494,7 @@ image:
   repository: otel/opentelemetry-collector-contrib
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.80.0"
+  tag: "0.97.0"
 nginxWindowsImage:
   # Reverse proxy image to enable metrics scraping from windows nodes
   repository: logzio/logzio-windows-node-reverse-proxy
@@ -582,7 +582,89 @@ ports:
     hostPort: 9411
     protocol: TCP
 
-# Span and service graph metrics
+# Kubernetes Object logs
+k8sObjectsConfig:
+  enabled: true
+  config:
+    receivers:
+      # Watch for changes in Kubernetes objects
+      k8sobjects/watch:
+        objects:
+          - name: pods
+            mode: watch
+            exclude_watch_type: [ DELETED, BOOKMARK ]
+          - name: deployments
+            mode: watch
+            exclude_watch_type: [ DELETED, BOOKMARK ]
+          - name: daemonsets
+            mode: watch
+            exclude_watch_type: [ DELETED, BOOKMARK ]
+          - name: statefulsets
+            mode: watch
+            exclude_watch_type: [ DELETED, BOOKMARK ]
+          - name: jobs
+            mode: watch
+            exclude_watch_type: [ DELETED, BOOKMARK ]
+          - name: nodes
+            mode: watch
+            exclude_watch_type: [ DELETED, BOOKMARK ]
+      # Pull Kubernetes objects every 3 hours(default)
+      k8sobjects/pull:
+        objects:
+          - name: pods
+            mode: pull
+            interval: 180m
+          - name: deployments
+            mode: pull
+            interval: 180m
+          - name: daemonsets
+            mode: pull
+            interval: 180m
+          - name: statefulsets
+            mode: pull
+            interval: 180m
+          - name: jobs
+            mode: pull
+            interval: 180m
+          - name: nodes
+            mode: pull
+            interval: 180m
+    processors:
+      # Adds eventType key with value of type key, then sets type to k8s_object
+      transform/log_type:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - set(body["eventType"],body["type"]) where body["type"] != "k8s_object"
+              - set(body["type"], "k8s_object")
+      # For pulled objects, copy the log into object key       
+      transform/pulled_object:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - set(body["object"],body) where body["object"] == nil
+              - keep_keys(body, ["object", "type", "eventType"])
+      # Remove managed fields metadata key              
+      transform/remove_managedfields:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - delete_key(body["object"]["metadata"], "managedFields")
+    exporters:
+      logzio/logs:
+        account_token: "${OBJECTS_LOGS_TOKEN}"
+        region: "${LOGZIO_LISTENER_REGION}"
+
+    service:
+      pipelines:
+        logs/k8sobjects:
+          receivers: [k8sobjects/pull,k8sobjects/watch]
+          processors: [transform/pulled_object,transform/remove-managedfields,transform/log_type]
+          exporters: [logzio/logs]
+# Service graph metrics configuration
 serviceGraph:
   enabled: true
   config:
@@ -600,7 +682,7 @@ serviceGraph:
           exporters: [servicegraph]      
         metrics/spm-logzio:
           receivers: [servicegraph]
-
+# Span metrics configuration
 spanMetricsAgregator:
   config:
     processors:
@@ -630,22 +712,6 @@ spanMetricsAgregator:
             label: span.name
             new_label: operation  
     connectors:
-      servicegraph:
-        dimensions:
-        - env_id
-        latency_histogram_buckets:
-        - 2ms
-        - 8ms
-        - 50ms
-        - 100ms
-        - 200ms
-        - 500ms
-        - 1s
-        - 5s
-        - 10s
-        store:
-          max_items: 100000
-          ttl: 5s
       spanmetrics:
         aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
         dimensions:
@@ -726,12 +792,10 @@ spanMetricsAgregator:
           - metricstransform/labels-rename
           receivers:
           - spanmetrics
-          - servicegraph
         traces:
           exporters:
           - logging
           - spanmetrics
-          - servicegraph
           receivers:
           - jaeger
           - zipkin
@@ -799,9 +863,12 @@ standaloneCollector:
       memory: 512Mi
     requests:
       cpu: 200m
+      
+  podLabels:  {}
 
   podAnnotations: {}
-  # Configuration override that will be merged into the colelctor default config
+  
+  # Configuration override that will be merged into the collector default config
   configOverride: {}
 
 daemonsetCollector:
@@ -825,7 +892,10 @@ daemonsetCollector:
     requests:
       cpu: 150m
 
+  podLabels:  {}
+
   podAnnotations: {}
+  
   # Configuration override that will be merged into the daemonset default config
   configOverride: {}
 
@@ -880,15 +950,16 @@ prometheus-node-exporter:
                 operator: DoesNotExist
   rbac:
     pspEnabled: false
-
+# Filter only metrics relevant for prebuilt content
 enableMetricsFilter:
-  gke: false
-  eks: false
-  aks: false
-  dropKubeSystem: false
+  gke: false  # Google Kubernetes Engine
+  eks: false  # Amazon Elastic Kubernetes Service
+  aks: false  # Azure Kubernetes Service
+  dropKubeSystem: false  # Drop kube-system metrics
 
-disableKubeDnsScraping: false
+disableKubeDnsScraping: false  # Kube DNS metrics scraping
 
+# Metrics Daemonset collector configuration
 daemonsetConfig:
   extensions:
     health_check: {}


### PR DESCRIPTION
- Upgraded `opentelemetry-collector-contrib` image to `v0.97.0`
- Added Kubernetes objects receiver
- Removed servicegraph connector from span metrics configuration
- Allow `env_id` & `p8s_logzio_name` non string values