### PR TITLE
Release `logzio-monitoring` Helm chart v5.3.0

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.29.1
+version: 0.29.2
 appVersion: 1.5.1
 maintainers:
   - name: Yotam loewenbach

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -303,6 +303,8 @@ If needed, the fluentd image can be changed to support windows server 2022 with 
 
 
 ## Change log
+ - **0.29.2**:
+  - Enhanced env_id handling to support both numeric and string formats.
  - **0.29.1**:
    - Added `enabled` value, to conditianly control the deployment of this chart by a parent chart.
    - Added `daemonset.LogFileRefreshInterval` and `windowsDaemonset.LogFileRefreshInterval` values, to control list of watched log files refresh interval.

--- a/charts/fluentd/templates/configmap.yaml
+++ b/charts/fluentd/templates/configmap.yaml
@@ -36,7 +36,7 @@ data:
   {{- end }}
 
   {{- if .Values.env_id }}
-  env-id.conf : {{ toYaml .Values.configmap.envId | indent 2 }}
+  env-id.conf : {{ toYaml .Values.configmap.envId | quote | indent 2 }}
   {{- end }}
 {{- if .Values.configmap.extraConfig }}
 {{- range $key, $value := fromYaml .Values.configmap.extraConfig }}

--- a/charts/fluentd/templates/daemonset.yaml
+++ b/charts/fluentd/templates/daemonset.yaml
@@ -277,7 +277,7 @@ spec:
           value: {{ .Values.windowsDaemonset.containersPath | quote }}
         {{- if .Values.env_id }}
         - name: ENV_ID
-          value: {{ .Values.env_id }}
+          value: {{ .Values.env_id | quote}}
         {{- end }}
         {{- if .Values.windowsDaemonset.extraEnv }}
 {{ toYaml .Values.windowsDaemonset.extraEnv | indent 8 }}

--- a/charts/logzio-k8s-events/Chart.yaml
+++ b/charts/logzio-k8s-events/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - k8s
   - kubernetes
-version: 0.0.3
+version: 0.0.4
 appVersion: 0.0.2
 maintainers:
   - name: Raul Gurshumov

--- a/charts/logzio-k8s-events/README.md
+++ b/charts/logzio-k8s-events/README.md
@@ -98,6 +98,8 @@ kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.tain
 
 
 ## Change log
+ - **0.0.4**:
+    - Enhanced env_id handling to support both numeric and string formats.
  - **0.0.3**:
     - Rename listener template.
  - **0.0.2**:

--- a/charts/logzio-k8s-events/templates/secret.yaml
+++ b/charts/logzio-k8s-events/templates/secret.yaml
@@ -11,5 +11,5 @@ type: Opaque
 stringData:
   logzio-log-shipping-token: {{ required "Logzio shipping token is required!" .Values.secrets.logzioShippingToken }}
   logzio-log-listener: {{ template "logzio-k8s-events.listenerHost" . }}
-  env-id: {{ .Values.secrets.env_id }}
+  env-id: {{ .Values.secrets.env_id | quote }}
 {{- end }}

--- a/charts/logzio-logs-collector/Chart.yaml
+++ b/charts/logzio-logs-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: logzio-logs-collector
-version: 1.0.0
+version: 1.0.1
 description: kubernetes logs collection agent for logz.io based on opentelemetry collector
 type: application
 home: https://logz.io/

--- a/charts/logzio-logs-collector/README.md
+++ b/charts/logzio-logs-collector/README.md
@@ -145,5 +145,6 @@ The collector supports by default various log formats (including multiline logs)
 * 1.0.1
   - Update multiline parsing
   - Update error detection in logs
+  - Change default log type
 * 1.0.0
   - kubernetes logs collection agent for logz.io based on opentelemetry collector

--- a/charts/logzio-logs-collector/README.md
+++ b/charts/logzio-logs-collector/README.md
@@ -146,5 +146,6 @@ The collector supports by default various log formats (including multiline logs)
   - Update multiline parsing
   - Update error detection in logs
   - Change default log type
+  - Enhanced env_id handling to support both numeric and string formats.
 * 1.0.0
   - kubernetes logs collection agent for logz.io based on opentelemetry collector

--- a/charts/logzio-logs-collector/README.md
+++ b/charts/logzio-logs-collector/README.md
@@ -142,5 +142,8 @@ Multi line logs configuration
 The collector supports by default various log formats (including multiline logs) such as `CRI-O` `CRI-Containerd` `Docker` formats. You can configure the chart to parse custom multiline logs pattern according to your needs, please read [Customizing Multiline Log Handling](./examples/multiline.md) guide for more details.
 
 ## Change log
+* 1.0.1
+  - Update multiline parsing
+  - Update error detection in logs
 * 1.0.0
   - kubernetes logs collection agent for logz.io based on opentelemetry collector

--- a/charts/logzio-logs-collector/templates/secret.yaml
+++ b/charts/logzio-logs-collector/templates/secret.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
-  env-id: {{.Values.secrets.env_id}}
+  env-id: {{.Values.secrets.env_id | quote}}
   log-type: {{ .Values.secrets.logType}}
   logzio-listener-region: {{ .Values.secrets.LogzioRegion}}
   {{ if .Values.secrets.logzioLogsToken}}

--- a/charts/logzio-logs-collector/values.yaml
+++ b/charts/logzio-logs-collector/values.yaml
@@ -25,7 +25,7 @@ secrets:
   # environment indentifier attribute that will be added to all logs
   env_id: "my_env"
   # defualt log type field
-  logType: "k8s"
+  logType: "test"
   # Secret with your logzio logs shipping token
   logzioLogsToken: "token"
   # Secret with your logzio region
@@ -61,7 +61,7 @@ config:
             - set(attributes["log.level"], "INFO")
             - set(attributes["log.level"], "DEBUG") where (IsMatch(body, ".*\\b(?i:debug)\\b.*"))
             - set(attributes["log.level"], "WARNING") where (IsMatch(body, ".*\\b(?i:warning|warn)\\b.*"))
-            - set(attributes["log.level"], "ERROR") where (IsMatch(body, ".*\\b(?i:error|failure|failed|exception|panic)\\b.*"))
+            - set(attributes["log.level"], "ERROR") where (IsMatch(body, ".*(?i:(?:error|fail|failure|exception|panic)).*"))
     transform/log_type:
       error_mode: ignore
       log_statements:
@@ -132,7 +132,7 @@ config:
       # Find out which format is used by kubernetes
       - id: get-format
         routes:
-        - expr: body matches "^\\{"
+        - expr: body matches "^{.*"
           output: parser-docker
         - expr: body matches "^[^ Z]+ "
           output: parser-crio
@@ -201,6 +201,15 @@ config:
       - from: attributes.uid
         to: resource["k8s.pod.uid"]
         type: move
+      # Update body field after finishing all parsing
+      - from: attributes.log
+        to: body
+        type: move
+      # conditional json parser
+      - type: json_parser
+        id: json
+        parse_from: body
+        if: 'body matches "^{.*}$"'
       # multiline parsers. add more `type: recombine` operators for custom multiline formats
       # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/stanza/docs/operators/recombine.md
       - type: recombine
@@ -208,10 +217,6 @@ config:
         combine_field: body
         is_first_entry: body matches "^[^\\s]"
         source_identifier: attributes["log.file.path"]
-      # Update body field after finishing all parsing
-      - from: attributes.log
-        to: body
-        type: move
     otlp:
       protocols:
         grpc:

--- a/charts/logzio-logs-collector/values.yaml
+++ b/charts/logzio-logs-collector/values.yaml
@@ -25,7 +25,7 @@ secrets:
   # environment indentifier attribute that will be added to all logs
   env_id: "my_env"
   # defualt log type field
-  logType: "test"
+  logType: "agent-k8s"
   # Secret with your logzio logs shipping token
   logzioLogsToken: "token"
   # Secret with your logzio region

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,21 +2,22 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.2.4
+version: 5.3.0
+
 
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: logzio-fluentd
-    version: "0.29.0"
+    version: "0.29.2"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "4.1.3"
+    version: "4.2.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy
-    version: "0.3.0"
+    version: "0.3.1"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: securityReport.enabled
   - name: opencost
@@ -24,10 +25,13 @@ dependencies:
     repository: "https://opencost.github.io/opencost-helm-chart"
     condition: finops.enabled
   - name: logzio-k8s-events
-    version: "0.0.3"
+    version: "0.0.4"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
-
+  - name: logzio-logs-collector
+    version: "1.0.1"
+    repository: "https://logzio.github.io/logzio-helm/"
+    condition: logs.enabled
 maintainers:
 - name: yotamloe
   email: yotam.loewenbach@logz.io

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -8,6 +8,7 @@ The `logzio-monitoring` Helm Chart facilitates the shipping of Kubernetes teleme
 
 This project packages the following Helm Charts:
 - [logzio-fluentd](https://github.com/logzio/logzio-helm/tree/master/charts/fluentd) for shipping logs via Fluentd.
+- [logzio-logs-collector](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-logs-collector) for shipping logs via opentelemetry.
 - [logzio-telemetry](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-telemetry) for metrics and traces via OpenTelemetry Collector.
 - [logzio-trivy](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-trivy) for security reports via Trivy operator.
 - [logzio-k8s-events](https://github.com/logzio/logzio-helm/tree/master/charts/logzio-k8s-events) for Kubernetes deployment events.
@@ -125,6 +126,20 @@ For example, to change a value named `someField` in `logzio-telemetry`'s `values
 --set logzio-k8s-telemetry.someField="my new value"
 ```
 
+### Migrate to OpenTelemetry for log collection
+
+The `logzio-fluentd` chart will be disabled by default in favor of the `logzio-logs-collector` for log collection in upcoming releases. To migrate to `logzio-logs-collector`, add the following `--set` flags:
+
+```sh
+helm install -n monitoring \
+--set logs.enabled=true \
+--set logzio-fluentd.enabled=false
+--set logzio-logs-collector.enabled=true \
+--set logzio-logs-collector.secrets.logzioShippingToken='<<LOG-SHIPPING-TOKEN>>' \
+--set logzio-logs-collector.secrets.logzioListener='<<LISTENER-HOST>>' \
+logzio-monitoring logzio-helm/logzio-monitoring
+```
+
 ### Sending telemetry data from eks on fargate
 
 To ship logs from pods running on Fargate, set the `fargateLogRouter.enabled` value to `true`. This will deploy a dedicated `aws-observability` namespace and a `configmap` for the Fargate log router. More information about EKS Fargate logging can be found [here](https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html)
@@ -206,6 +221,16 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **5.2.5**:
+  - **Depreciation notice** `logzio-fluentd` chart will be disabled by default in favour of `logzio-logs-collector` for log collection in upcoming releases.
+	- Added `logzio-logs-collector` version `1.0.0`:
+    - otel collector daemonset designed and configured to function as log collection agent
+    - eks fargate support
+    - adds logzio required fields (`log_level`, `type`, `env_id` and more)
+    - `enabled` value to enable/disable deployment from parent charts
+	- Upgrade `logzio-fluentd` to `0.29.1`:
+    - Added `enabled` value, to conditianly control the deployment of this chart by a parent chart.
+    - Added `daemonset.LogFileRefreshInterval` and `windowsDaemonset.LogFileRefreshInterval` values, to control list of watched log files refresh interval.
 - **5.2.4**:
   - Update `logzio-k8s-telemetry` sub chart version to `4.1.3`
 - **5.2.3**:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -221,6 +221,25 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **5.3.0**:
+  - Add `logzio-logs-collector.enabled` + `fluentd.enabled` values
+  - Upgrade `logzio-k8s-telemetry` to `4.2.0`:
+    - Upgraded opentelemetry-collector-contrib image to v0.97.0
+    - Added Kubernetes objects receiver
+    - Removed servicegraph connector from span metrics configuration
+    - Allow env_id & p8s_logzio_name non string values
+  - Upgrade `logzio-logs-collector` version to `1.0.1`:
+    - Create NOTES.txt for Helm install notes
+	- Enhanced env_id handling to support both numeric and string formats
+    - Change default log type
+	- Update multiline parsing and error detection
+	- Update error detection in logs
+  - Upgrade `logzio-fluentd` to `0.29.2`:
+    - Enhanced env_id handling to support both numeric and string formats
+  - Upgrade `logzio-trivy` to `0.4.0`:
+    - Enhanced env_id handling to support both numeric and string formats
+  - Upgrade `logzio-k8s-events` to `0.0.4`:
+    - Enhanced env_id handling to support both numeric and string formats
 - **5.2.5**:
   - **Depreciation notice** `logzio-fluentd` chart will be disabled by default in favour of `logzio-logs-collector` for log collection in upcoming releases.
 	- Added `logzio-logs-collector` version `1.0.0`:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -132,11 +132,13 @@ The `logzio-fluentd` chart will be disabled by default in favor of the `logzio-l
 
 ```sh
 helm install -n monitoring \
---set logs.enabled=true \
---set logzio-fluentd.enabled=false
---set logzio-logs-collector.enabled=true \
---set logzio-logs-collector.secrets.logzioShippingToken='<<LOG-SHIPPING-TOKEN>>' \
---set logzio-logs-collector.secrets.logzioListener='<<LISTENER-HOST>>' \
+--set logs.enabled=true \  
+--set logzio-fluentd.enabled=false \  
+--set logzio-logs-collector.enabled=true \  
+--set logzio-logs-collector.secrets.logzioLogsToken=<<token>> \  
+--set logzio-logs-collector.secrets.logzioRegion=<<region>> \  
+--set logzio-logs-collector.secrets.env_id=<<env_id>> \  
+--set logzio-logs-collector.secrets.logType=<<log_type>> \
 logzio-monitoring logzio-helm/logzio-monitoring
 ```
 

--- a/charts/logzio-monitoring/templates/NOTES.txt
+++ b/charts/logzio-monitoring/templates/NOTES.txt
@@ -1,0 +1,37 @@
+
+{{- if and (.Values.logs.enabled) (not (index .Values "logzio-logs-collector" "enabled")) (index .Values "logzio-fluentd" "enabled") }}
+[ DEPRICATION ] You are using fluetnd agent for log collection, this option will be disabled by default in upcoming releases.
+You can change to opentelemetry logzio-logs-collector by setting the following values:
+
+  --set logs.enabled=true \
+  --set logzio-fluentd.enabled=false \
+  --set logzio-logs-collector.enabled=true \
+  --set logzio-logs-collector.secrets.logzioLogsToken=<<token>> \
+  --set logzio-logs-collector.secrets.logzioRegion=<<region>> \
+  --set logzio-logs-collector.secrets.env_id=<<env_id>> \
+  --set logzio-logs-collector.secrets.logType=<<log_type>> \
+
+{{ end }}
+
+
+{{- if and (.Values.logs.enabled) (index .Values "logzio-logs-collector" "enabled") (index .Values "logzio-fluentd" "enabled") }}
+[ WARNING ] You enabled both fluetnd agent and opentelemetry logzio-logs-collector for log collection, you will have duplicated log data entries in logz.io
+You can change to opentelemetry logzio-logs-collector by setting the following values:
+
+  --set logs.enabled=true \
+  --set logzio-fluentd.enabled=false \
+  --set logzio-logs-collector.enabled=true \
+  --set logzio-logs-collector.secrets.logzioLogsToken=<<token>> \
+  --set logzio-logs-collector.secrets.logzioRegion=<<region>> \
+  --set logzio-logs-collector.secrets.env_id=<<env_id>> \
+  --set logzio-logs-collector.secrets.logType=<<log_type>> \
+{{ end }}
+
+
+{{- if and (.Values.logs.enabled) (index .Values "logzio-logs-collector" "enabled")}}
+[ INFO ] You enabled opentelemetry logzio-logs-collector for log collection.
+
+{{ end }}
+
+
+

--- a/charts/logzio-monitoring/values.yaml
+++ b/charts/logzio-monitoring/values.yaml
@@ -20,8 +20,12 @@ deployEvents:
 
 # Override values for the Fluentd sub-chart
 logzio-fluentd:
+  enabled: true
   daemonset:
     logType: "agent-k8s"
+
+logzio-logs-collector:
+  enabled: false
 
 # Override values for the opencost sub-chart
 opencost:

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -24,14 +24,14 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.3
+version: 4.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.80.0
+appVersion: 0.97.0
 maintainers:
 - name: yotamloe
   email: yotam.loewenbach@logz.io
-- name: tamirmich
-  email: tamir.michaeli@logz.io
+- name: ralongit
+  email: raul.gurshumo@logz.io

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -58,7 +58,7 @@ Enable the traces configuration for this chart: --set traces.enabled=true
 
 Replace the Logz-io `<<TRACES-SHIPPING-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/manage-tokens/data-shipping) of the traces account to which you want to send your data.
 
-Replace `<<logzio-region>>` with the name of your Logz.io region e.g `us`,`eu`.
+Replace `<<LOGZIO-REGION>>` with the name of your Logz.io region e.g `us`,`eu`.
 
 
 
@@ -80,7 +80,7 @@ logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 helm install \
 --set traces.enabled=true \
 --set secrets.TracesToken=<<TRACES-SHIPPING-TOKEN>> \
---set secrets.LogzioRegion=<<logzio-region>> \
+--set secrets.LogzioRegion=<<LOGZIO-REGION>> \
 --set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
 --set secrets.env_id=<<ENV-ID>> \
 logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
@@ -94,7 +94,7 @@ helm install \
 --set spm.enabled=true \
 --set secrets.SpmToken=<<SPM-SHIPPING-TOKEN>> \
 --set secrets.TracesToken=<<TRACES-SHIPPING-TOKEN>> \
---set secrets.LogzioRegion=<<logzio-region>> \
+--set secrets.LogzioRegion=<<LOGZIO-REGION>> \
 --set secrets.ListenerHost=<<LISTENER-HOST>> \
 --set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
 --set secrets.env_id=<<ENV-ID>> \
@@ -109,7 +109,7 @@ helm install  \
 --set spm.enabled=true \
 --set secrets.TracesToken=<<TRACES-SHIPPING-TOKEN>> \
 --set secrets.SpmToken=<<SPM-SHIPPING-TOKEN>> \
---set secrets.LogzioRegion=<<logzio-region>> \
+--set secrets.LogzioRegion=<<LOGZIO-REGION>> \
 --set metrics.enabled=true \
 --set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
 --set secrets.ListenerHost=<<LISTENER-HOST>> \
@@ -117,6 +117,7 @@ helm install  \
 --set secrets.env_id=<<ENV-ID>> \
 logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 ```
+
 #### Deploy both charts with span metrics and service graph
 **Note** `serviceGraph.enabled=true` will have no effect unless `traces.enabled` & `spm.enabled=true` is also set to `true`
 ```
@@ -126,8 +127,23 @@ helm install  \
 --set serviceGraph.enabled=true \
 --set secrets.TracesToken=<<TRACES-SHIPPING-TOKEN>> \
 --set secrets.SpmToken=<<SPM-SHIPPING-TOKEN>> \
---set secrets.LogzioRegion=<<logzio-region>> \
+--set secrets.LogzioRegion=<<LOGZIO-REGION>> \
 --set metrics.enabled=true \
+--set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
+--set secrets.ListenerHost=<<LISTENER-HOST>> \
+--set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
+--set secrets.env_id=<<ENV-ID>> \
+logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
+```
+
+#### Deploy metrics chart with Kuberenetes object logs correlation
+**Note** `k8sObjectsConfig.enabled=true` will have no effect unless `metrics.enabled` is also set to `true`
+```
+helm install  \
+--set metrics.enabled=true \
+--set k8sObjectsConfig.enabled=true \
+--set secrets.LogzioRegion=<<LOGZIO-REGION>> \
+--set secrets.k8sObjectsLogsToken=<<LOGZIO-LOG-SHIPPING-TOKEN>> \
 --set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
 --set secrets.ListenerHost=<<LISTENER-HOST>> \
 --set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
@@ -394,6 +410,11 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 4.2.0
+  - Upgraded `opentelemetry-collector-contrib` image to `v0.97.0`
+  - Added Kubernetes objects receiver
+  - Removed servicegraph connector from span metrics configuration
+  - Allow `env_id` & `p8s_logzio_name` non string values
 * 4.1.3
   - Removed unused prometheus receiver
   - Divide metrics and labels renames to separate processors

--- a/charts/logzio-telemetry/templates/_daemonset-pod.tpl
+++ b/charts/logzio-telemetry/templates/_daemonset-pod.tpl
@@ -54,6 +54,18 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: logzio-metrics-shipping-token
+      {{ if .Values.k8sObjectsConfig.enabled }}
+      - name: OBJECTS_LOGS_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.secrets.name }}
+            key: logzio-k8s-objects-logs-token
+      - name: LOGZIO_LISTENER_REGION
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.secrets.name }}
+            key: logzio-listener-region            
+      {{ end }}            
       - name: LISTENER_URL
         valueFrom:
           secretKeyRef:

--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -58,6 +58,21 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: logzio-metrics-shipping-token
+      {{ if .Values.k8sObjectsConfig.enabled }}
+      - name: OBJECTS_LOGS_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.secrets.name }}
+            key: logzio-k8s-objects-logs-token
+      {{ end }} 
+         
+{{- end }}
+{{- if or (eq .Values.k8sObjectsConfig.enabled true) (eq .Values.traces.enabled true) }}  
+      - name: LOGZIO_LISTENER_REGION
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.secrets.name }}
+            key: logzio-listener-region            
 {{- end }}
 {{- if or (eq .Values.metrics.enabled true) (eq .Values.spm.enabled true) }}
       - name: LISTENER_URL
@@ -69,7 +84,7 @@ containers:
         valueFrom:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
-            key: p8s-logzio-name
+            key: p8s-logzio-name   
 {{- end }}
 {{- if .Values.traces.enabled }}
       - name: TRACES_TOKEN
@@ -77,11 +92,6 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: logzio-traces-shipping-token
-      - name: LOGZIO_LISTENER_REGION
-        valueFrom:
-          secretKeyRef:
-            name: {{ .Values.secrets.name }}
-            key: logzio-listener-region
       {{ if .Values.secrets.CustomTracingEndpoint}}
       - name: CUSTOM_TRACING_ENDPOINT
         valueFrom:
@@ -104,7 +114,7 @@ containers:
         valueFrom:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
-            key: logzio-spm-shipping-token
+            key: logzio-spm-shipping-token        
 {{ end }}
 {{- end }}
       - name: ENV_ID

--- a/charts/logzio-telemetry/templates/secrets.yaml
+++ b/charts/logzio-telemetry/templates/secrets.yaml
@@ -10,13 +10,13 @@ stringData:
 {{- if .Values.opencost.enabled -}}
   opencost-duplicates: container_memory_usage_bytes|container_fs_limit_bytes|container_fs_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total|container_cpu_usage_seconds_total|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_job_status_failed|kube_namespace_annotations|kube_namespace_labels|kube_node_labels|kube_node_status_allocatable|kube_node_status_allocatable_cpu_cores|kube_node_status_allocatable_memory_bytes|kube_node_status_capacity|kube_node_status_capacity_cpu_cores|kube_node_status_capacity_memory_bytes|kube_node_status_condition|kube_persistentvolume_capacity_bytes|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_annotations|kube_pod_container_resource_limits|kube_pod_container_resource_limits_cpu_cores|kube_pod_container_resource_limits_memory_bytes|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_running|kube_pod_container_status_terminated_reason|kube_pod_labels|kube_pod_owner|kube_pod_status_phase|kube_replicaset_owner|node_cpu_seconds_total|node_disk_reads_completed|node_disk_reads_completed_total|node_disk_writes_completed|node_disk_writes_completed_total|node_filesystem_device_error|node_memory_Buffers_bytes|node_memory_Cached_bytes|node_memory_MemAvailable_bytes|node_memory_MemFree_bytes|node_memory_MemTotal_bytes|node_network_transmit_bytes_total|
 {{- end }}  
-  env_id: {{.Values.secrets.env_id}}
+  env_id: {{.Values.secrets.env_id | quote }}
 {{- if .Values.metrics.enabled }}
   logzio-metrics-shipping-token: {{ .Values.secrets.MetricsToken }}
 {{- end }}
 {{- if or (eq .Values.metrics.enabled true) (eq .Values.spm.enabled true) }}
   logzio-metrics-listener: {{ .Values.secrets.ListenerHost }}
-  p8s-logzio-name: {{.Values.secrets.p8s_logzio_name}}
+  p8s-logzio-name: {{.Values.secrets.p8s_logzio_name | quote }}
 {{- end }}
 {{- if .Values.traces.enabled }}
   logzio-traces-shipping-token: {{ .Values.secrets.TracesToken }}
@@ -28,6 +28,10 @@ stringData:
   sampling-probability: {{ .Values.secrets.SamplingProbability | quote}}
 {{ if .Values.spm.enabled }}
   logzio-spm-shipping-token: {{ .Values.secrets.SpmToken }}
+{{ end }}
+{{ if .Values.k8sObjectsConfig.enabled }}
+  logzio-k8s-objects-logs-token: {{.Values.secrets.k8sObjectsLogsToken}}
+  logzio-listener-region: {{ .Values.secrets.LogzioRegion}}
 {{ end }}
 {{- end }}
 {{- if .Values.secrets.windowsNodeUsername }}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -5,34 +5,47 @@
 collector:
   mode: daemonset # possible values: standalone, daemonset
 traces:
-  enabled: false
+  enabled: false # Send traces telemetry
 metrics:
-  enabled: false
+  enabled: false # Send metrics telemetry 
 spm:
-  enabled: false
+  enabled: false # Send Span metrics, requires `traces.enabled`
+
 applicationMetrics:
-  enabled: false
-nameOverride: "otel-collector"
-fullnameOverride: ""
+  ## Send application metrics, requires `metrics.enabled` and the `prometheus.io/scrape: true` annotaion set.
+  enabled: false 
+kubeStateMetrics:
+  ## If false, kube-state-metrics sub-chart will not be installed
+  enabled: true
+pushGateway:
+  ## If false, prometheus-push-gateway sub-chart will not be installed
+  enabled: true
+nodeExporter:
+  ## If false, prometheus-node-exporter will not be installed
+  enabled: true
+
+nameOverride: "otel-collector" # The resources name prefix 
+fullnameOverride: "" # The resources name
 
 secrets:
-  name: logzio-secret
-  enabled: true
-  MetricsToken: ""
-  TracesToken: ""
-  SpmToken: ""
-  ListenerHost: ""
-  env_id: "my_environment"
-  LogzioRegion: "us"
-  CustomTracingEndpoint: ""
-  p8s_logzio_name: ""
-  windowsNodeUsername: ""
-  windowsNodePassword: ""
-  SamplingProbability: 10
-  SamplingLatency: 500
+  name: logzio-secret  # Secret name
+  enabled: true  # Create secret
+  MetricsToken: ""  # Metrics account shipping token
+  TracesToken: ""  # Tracing account shipping token
+  SpmToken: ""  # Span Metrics account shipping token
+  k8sObjectsLogsToken: ""  # Kubernetes objects Logs account shipping token
+  ListenerHost: ""  # Logz.io metrics listener address - https://docs.logz.io/docs/user-guide/admin/hosting-regions/account-region/
+  env_id: "my_environment"  # Environment name 
+  LogzioRegion: "us"  # Traces & Logs listener address region code - https://docs.logz.io/docs/user-guide/admin/hosting-regions/account-region/
+  CustomTracingEndpoint: ""  # Custom Traces listener endpoint
+  p8s_logzio_name: ""  # Metrics Environment name
+  windowsNodeUsername: ""  # Windows Node Username
+  windowsNodePassword: ""  # Windows Node Password
+  SamplingProbability: 10  # Traces Sampling Probability
+  SamplingLatency: 500  # Traces Sampling Latency
 
 
-managedServiceAccount: true
+managedServiceAccount: true 
 
 clusterRole:
   # Specifies whether a clusterRole should be created
@@ -121,27 +134,14 @@ clusterRoleRules:
   - list
   - watch
 
-
-kubeStateMetrics:
-  ## If false, kube-state-metrics sub-chart will not be installed
-  enabled: true
-
-pushGateway:
-  ## If false, prometheus-push-gateway sub-chart will not be installed
-  enabled: true
-
-nodeExporter:
-  ## If false, prometheus-node-exporter will not be installed
-  enabled: true
-
 prometheus-pushgateway:
   serviceAnnotations:
     prometheus.io/scrape: "true"
   nodeSelector:
     kubernetes.io/os: linux
-
+# Configuration merge from the colelctor configs
 emptyConfig: {}
-
+# Base configuration of the collector
 baseCollectorConfig:
   exporters:
     logging:
@@ -230,7 +230,7 @@ baseCollectorConfig:
     telemetry:
       logs:
         level: "info"
-
+# Traces configuration
 tracesConfig:
   exporters:
     logzio:
@@ -308,7 +308,7 @@ spmForwarderConfig:
         receivers: [jaeger, zipkin, otlp]
         processors: [resourcedetection/all, attributes/env_id, k8sattributes]
         exporters: [logging, otlp]
-
+# Metrics standalone collector configuration 
 metricsConfig:
   extensions:
     health_check: {}
@@ -494,7 +494,7 @@ image:
   repository: otel/opentelemetry-collector-contrib
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.80.0"
+  tag: "0.97.0"
 nginxWindowsImage:
   # Reverse proxy image to enable metrics scraping from windows nodes
   repository: logzio/logzio-windows-node-reverse-proxy
@@ -582,7 +582,89 @@ ports:
     hostPort: 9411
     protocol: TCP
 
-# Span and service graph metrics
+# Kubernetes Object logs
+k8sObjectsConfig:
+  enabled: true
+  config:
+    receivers:
+      # Watch for changes in Kubernetes objects
+      k8sobjects/watch:
+        objects:
+          - name: pods
+            mode: watch
+            exclude_watch_type: [ DELETED, BOOKMARK ]
+          - name: deployments
+            mode: watch
+            exclude_watch_type: [ DELETED, BOOKMARK ]
+          - name: daemonsets
+            mode: watch
+            exclude_watch_type: [ DELETED, BOOKMARK ]
+          - name: statefulsets
+            mode: watch
+            exclude_watch_type: [ DELETED, BOOKMARK ]
+          - name: jobs
+            mode: watch
+            exclude_watch_type: [ DELETED, BOOKMARK ]
+          - name: nodes
+            mode: watch
+            exclude_watch_type: [ DELETED, BOOKMARK ]
+      # Pull Kubernetes objects every 3 hours(default)
+      k8sobjects/pull:
+        objects:
+          - name: pods
+            mode: pull
+            interval: 180m
+          - name: deployments
+            mode: pull
+            interval: 180m
+          - name: daemonsets
+            mode: pull
+            interval: 180m
+          - name: statefulsets
+            mode: pull
+            interval: 180m
+          - name: jobs
+            mode: pull
+            interval: 180m
+          - name: nodes
+            mode: pull
+            interval: 180m
+    processors:
+      # Adds eventType key with value of type key, then sets type to k8s_object
+      transform/log_type:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - set(body["eventType"],body["type"]) where body["type"] != "k8s_object"
+              - set(body["type"], "k8s_object")
+      # For pulled objects, copy the log into object key       
+      transform/pulled_object:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - set(body["object"],body) where body["object"] == nil
+              - keep_keys(body, ["object", "type", "eventType"])
+      # Remove managed fields metadata key              
+      transform/remove_managedfields:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - delete_key(body["object"]["metadata"], "managedFields")
+    exporters:
+      logzio/logs:
+        account_token: "${OBJECTS_LOGS_TOKEN}"
+        region: "${LOGZIO_LISTENER_REGION}"
+
+    service:
+      pipelines:
+        logs/k8sobjects:
+          receivers: [k8sobjects/pull,k8sobjects/watch]
+          processors: [transform/pulled_object,transform/remove-managedfields,transform/log_type]
+          exporters: [logzio/logs]
+# Service graph metrics configuration
 serviceGraph:
   enabled: true
   config:
@@ -600,7 +682,7 @@ serviceGraph:
           exporters: [servicegraph]      
         metrics/spm-logzio:
           receivers: [servicegraph]
-
+# Span metrics configuration
 spanMetricsAgregator:
   config:
     processors:
@@ -630,22 +712,6 @@ spanMetricsAgregator:
             label: span.name
             new_label: operation  
     connectors:
-      servicegraph:
-        dimensions:
-        - env_id
-        latency_histogram_buckets:
-        - 2ms
-        - 8ms
-        - 50ms
-        - 100ms
-        - 200ms
-        - 500ms
-        - 1s
-        - 5s
-        - 10s
-        store:
-          max_items: 100000
-          ttl: 5s
       spanmetrics:
         aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
         dimensions:
@@ -726,12 +792,10 @@ spanMetricsAgregator:
           - metricstransform/labels-rename
           receivers:
           - spanmetrics
-          - servicegraph
         traces:
           exporters:
           - logging
           - spanmetrics
-          - servicegraph
           receivers:
           - jaeger
           - zipkin
@@ -799,9 +863,12 @@ standaloneCollector:
       memory: 512Mi
     requests:
       cpu: 200m
+      
+  podLabels:  {}
 
   podAnnotations: {}
-  # Configuration override that will be merged into the colelctor default config
+  
+  # Configuration override that will be merged into the collector default config
   configOverride: {}
 
 daemonsetCollector:
@@ -825,7 +892,10 @@ daemonsetCollector:
     requests:
       cpu: 150m
 
+  podLabels:  {}
+
   podAnnotations: {}
+  
   # Configuration override that will be merged into the daemonset default config
   configOverride: {}
 
@@ -880,15 +950,16 @@ prometheus-node-exporter:
                 operator: DoesNotExist
   rbac:
     pspEnabled: false
-
+# Filter only metrics relevant for prebuilt content
 enableMetricsFilter:
-  gke: false
-  eks: false
-  aks: false
-  dropKubeSystem: false
+  gke: false  # Google Kubernetes Engine
+  eks: false  # Amazon Elastic Kubernetes Service
+  aks: false  # Azure Kubernetes Service
+  dropKubeSystem: false  # Drop kube-system metrics
 
-disableKubeDnsScraping: false
+disableKubeDnsScraping: false  # Kube DNS metrics scraping
 
+# Metrics Daemonset collector configuration
 daemonsetConfig:
   extensions:
     health_check: {}

--- a/charts/logzio-trivy/Chart.yaml
+++ b/charts/logzio-trivy/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - trivy
   - security
-version: 0.3.0
+version: 0.3.1
 appVersion: 0.2.1
 sources:
   - https://github.com/logzio/logzio-helm

--- a/charts/logzio-trivy/templates/deployment.yaml
+++ b/charts/logzio-trivy/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
               name: {{ .Values.secrets.name }}
               key: logzio-log-listener
         - name: ENV_ID
-          value: {{ .Values.env_id }}
+          value: {{ .Values.env_id | quote }}
         - name: SCHEDULE
           value: {{ .Values.schedule }}
         - name: LOG_LEVEL


### PR DESCRIPTION
  - Add `logzio-logs-collector.enabled` + `fluentd.enabled` values
  - Upgrade `logzio-k8s-telemetry` to `4.2.0`:
    - Upgraded opentelemetry-collector-contrib image to v0.97.0
    - Added Kubernetes objects receiver
    - Removed servicegraph connector from span metrics configuration
    - Allow env_id & p8s_logzio_name non string values
  - Upgrade `logzio-logs-collector` version to `1.0.1`:
    - Create NOTES.txt for Helm install notes
	- Enhanced env_id handling to support both numeric and string formats
    - Change default log type
	- Update multiline parsing and error detection
	- Update error detection in logs
  - Upgrade `logzio-fluentd` to `0.29.2`:
    - Enhanced env_id handling to support both numeric and string formats
  - Upgrade `logzio-trivy` to `0.4.0`:
    - Enhanced env_id handling to support both numeric and string formats
  - Upgrade `logzio-k8s-events` to `0.0.4`:
    - Enhanced env_id handling to support both numeric and string formats