### PR TITLE
Bugfix/logzio logs collector 1.0.2 change template function

### DIFF
--- a/charts/logzio-logs-collector/Chart.yaml
+++ b/charts/logzio-logs-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: logzio-logs-collector
-version: 1.0.1
+version: 1.0.2
 description: kubernetes logs collection agent for logz.io based on opentelemetry collector
 type: application
 home: https://logz.io/

--- a/charts/logzio-logs-collector/README.md
+++ b/charts/logzio-logs-collector/README.md
@@ -142,6 +142,8 @@ Multi line logs configuration
 The collector supports by default various log formats (including multiline logs) such as `CRI-O` `CRI-Containerd` `Docker` formats. You can configure the chart to parse custom multiline logs pattern according to your needs, please read [Customizing Multiline Log Handling](./examples/multiline.md) guide for more details.
 
 ## Change log
+* 1.0.2
+  - Change template function name `baseConfig` -> `baseLoggingConfig` to avoid conflicts with other charts deployed
 * 1.0.1
   - Update multiline parsing
   - Update error detection in logs

--- a/charts/logzio-logs-collector/README.md
+++ b/charts/logzio-logs-collector/README.md
@@ -144,6 +144,7 @@ The collector supports by default various log formats (including multiline logs)
 ## Change log
 * 1.0.2
   - Change template function name `baseConfig` -> `baseLoggingConfig` to avoid conflicts with other charts deployed
+  - Refactor tempaltes function names `opentelemetry-collector` -> `logs-collector` to avoid conflicts with other charts templates
 * 1.0.1
   - Update multiline parsing
   - Update error detection in logs

--- a/charts/logzio-logs-collector/templates/_config.tpl
+++ b/charts/logzio-logs-collector/templates/_config.tpl
@@ -1,14 +1,14 @@
 # Merge user supplied config.
-{{- define "opentelemetry-collector.baseConfig" -}}
+{{- define "opentelemetry-collector.baseLoggingConfig" -}}
 {{- $config := .Values.config | toYaml -}}
 {{- toYaml $config -}}
 {{- end }}
 
 # Build config file for daemonset OpenTelemetry Collector
-{{- define "opentelemetry-collector.daemonsetConfig" -}}
+{{- define "opentelemetry-collector.loggingDaemonsetConfig" -}}
 {{- $values := deepCopy .Values -}}
 {{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) -}}
-{{- $config := include "opentelemetry-collector.baseConfig" $data -}}
+{{- $config := include "opentelemetry-collector.baseLoggingConfig" $data -}}
 {{- tpl $config . -}}
 {{- end }}
 

--- a/charts/logzio-logs-collector/templates/_config.tpl
+++ b/charts/logzio-logs-collector/templates/_config.tpl
@@ -1,19 +1,19 @@
 # Merge user supplied config.
-{{- define "opentelemetry-collector.baseLoggingConfig" -}}
+{{- define "logs-collector.baseLoggingConfig" -}}
 {{- $config := .Values.config | toYaml -}}
 {{- toYaml $config -}}
 {{- end }}
 
-# Build config file for daemonset OpenTelemetry Collector
-{{- define "opentelemetry-collector.loggingDaemonsetConfig" -}}
+# Build config file for daemonset logs Collector
+{{- define "logs-collector.loggingDaemonsetConfig" -}}
 {{- $values := deepCopy .Values -}}
 {{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) -}}
-{{- $config := include "opentelemetry-collector.baseLoggingConfig" $data -}}
+{{- $config := include "logs-collector.baseLoggingConfig" $data -}}
 {{- tpl $config . -}}
 {{- end }}
 
 {{/* Build the list of port for service */}}
-{{- define "opentelemetry-collector.servicePortsConfig" -}}
+{{- define "logs-collector.servicePortsConfig" -}}
 {{- $ports := deepCopy .Values.ports }}
 {{- range $key, $port := $ports }}
 {{- if $port.enabled }}
@@ -32,7 +32,7 @@
 {{- end }}
 
 {{/* Build the list of port for pod */}}
-{{- define "opentelemetry-collector.podPortsConfig" -}}
+{{- define "logs-collector.podPortsConfig" -}}
 {{- $ports := deepCopy .Values.ports }}
 {{- range $key, $port := $ports }}
 {{- if $port.enabled }}

--- a/charts/logzio-logs-collector/templates/_helpers.tpl
+++ b/charts/logzio-logs-collector/templates/_helpers.tpl
@@ -1,18 +1,18 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "opentelemetry-collector.name" -}}
+{{- define "logs-collector.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{- define "opentelemetry-collector.lowercase_chartname" -}}
+{{- define "logs-collector.lowercase_chartname" -}}
 {{- default .Chart.Name | lower }}
 {{- end }}
 
 {{/*
 Get component name
 */}}
-{{- define "opentelemetry-collector.component" -}}
+{{- define "logs-collector.component" -}}
 {{- if eq .Values.mode "daemonset" -}}
 component: logs-collector
 {{- end -}}
@@ -23,7 +23,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "opentelemetry-collector.fullname" -}}
+{{- define "logs-collector.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -34,37 +34,37 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "opentelemetry-collector.chart" -}}
+{{- define "logs-collector.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "opentelemetry-collector.labels" -}}
-helm.sh/chart: {{ include "opentelemetry-collector.chart" . }}
-{{ include "opentelemetry-collector.selectorLabels" . }}
+{{- define "logs-collector.labels" -}}
+helm.sh/chart: {{ include "logs-collector.chart" . }}
+{{ include "logs-collector.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{ include "opentelemetry-collector.additionalLabels" . }}
+{{ include "logs-collector.additionalLabels" . }}
 {{- end }}
 
 {{/*
 Selector labels
 */}}
-{{- define "opentelemetry-collector.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "opentelemetry-collector.name" . }}
+{{- define "logs-collector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "logs-collector.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "opentelemetry-collector.serviceAccountName" -}}
+{{- define "logs-collector.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "opentelemetry-collector.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "logs-collector.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
@@ -74,30 +74,30 @@ Create the name of the service account to use
 {{/*
 Create the name of the clusterRole to use
 */}}
-{{- define "opentelemetry-collector.clusterRoleName" -}}
-{{- default (include "opentelemetry-collector.fullname" .) .Values.clusterRole.name }}
+{{- define "logs-collector.clusterRoleName" -}}
+{{- default (include "logs-collector.fullname" .) .Values.clusterRole.name }}
 {{- end }}
 
 {{/*
 Create the name of the clusterRoleBinding to use
 */}}
-{{- define "opentelemetry-collector.clusterRoleBindingName" -}}
-{{- default (include "opentelemetry-collector.fullname" .) .Values.clusterRole.clusterRoleBinding.name }}
+{{- define "logs-collector.clusterRoleBindingName" -}}
+{{- default (include "logs-collector.fullname" .) .Values.clusterRole.clusterRoleBinding.name }}
 {{- end }}
 
-{{- define "opentelemetry-collector.podAnnotations" -}}
+{{- define "logs-collector.podAnnotations" -}}
 {{- if .Values.podAnnotations }}
 {{- tpl (.Values.podAnnotations | toYaml) . }}
 {{- end }}
 {{- end }}
 
-{{- define "opentelemetry-collector.podLabels" -}}
+{{- define "logs-collector.podLabels" -}}
 {{- if .Values.podLabels }}
 {{- tpl (.Values.podLabels | toYaml) . }}
 {{- end }}
 {{- end }}
 
-{{- define "opentelemetry-collector.additionalLabels" -}}
+{{- define "logs-collector.additionalLabels" -}}
 {{- if .Values.additionalLabels }}
 {{- tpl (.Values.additionalLabels | toYaml) . }}
 {{- end }}
@@ -107,7 +107,7 @@ Create the name of the clusterRoleBinding to use
 {{/*
 Compute Service creation on mode
 */}}
-{{- define "opentelemetry-collector.serviceEnabled" }}
+{{- define "logs-collector.serviceEnabled" }}
   {{- $serviceEnabled := true }}
   {{- if not (eq (toString .Values.service.enabled) "<nil>") }}
     {{- $serviceEnabled = .Values.service.enabled -}}
@@ -123,7 +123,7 @@ Compute Service creation on mode
 {{/*
 Compute InternalTrafficPolicy on Service creation
 */}}
-{{- define "opentelemetry-collector.serviceInternalTrafficPolicy" }}
+{{- define "logs-collector.serviceInternalTrafficPolicy" }}
   {{- if and (eq .Values.mode "daemonset") (eq .Values.service.enabled true) }}
     {{- print (.Values.service.internalTrafficPolicy | default "Local") -}}
   {{- else }}
@@ -134,7 +134,7 @@ Compute InternalTrafficPolicy on Service creation
 {{/*
 Allow the release namespace to be overridden
 */}}
-{{- define "opentelemetry-collector.namespace" -}}
+{{- define "logs-collector.namespace" -}}
   {{- if .Values.namespaceOverride -}}
     {{- .Values.namespaceOverride -}}
   {{- else -}}
@@ -146,7 +146,7 @@ Allow the release namespace to be overridden
   This helper converts the input value of memory to Bytes.
   Input needs to be a valid value as supported by k8s memory resource field.
  */}}
-{{- define "opentelemetry-collector.convertMemToBytes" }}
+{{- define "logs-collector.convertMemToBytes" }}
   {{- $mem := lower . -}}
   {{- if hasSuffix "e" $mem -}}
     {{- $mem = mulf (trimSuffix "e" $mem | float64) 1e18 -}}
@@ -176,8 +176,8 @@ Allow the release namespace to be overridden
 {{- $mem }}
 {{- end }}
 
-{{- define "opentelemetry-collector.gomemlimit" }}
-{{- $memlimitBytes := include "opentelemetry-collector.convertMemToBytes" . | mulf 0.8 -}}
+{{- define "logs-collector.gomemlimit" }}
+{{- $memlimitBytes := include "logs-collector.convertMemToBytes" . | mulf 0.8 -}}
 {{- printf "%dMiB" (divf $memlimitBytes 0x1p20 | floor | int64) -}}
 {{- end }}
 

--- a/charts/logzio-logs-collector/templates/_pod.tpl
+++ b/charts/logzio-logs-collector/templates/_pod.tpl
@@ -1,9 +1,9 @@
-{{- define "opentelemetry-collector.loggingPod" -}}
+{{- define "logs-collector.loggingPod" -}}
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-serviceAccountName: {{ include "opentelemetry-collector.serviceAccountName" . }}
+serviceAccountName: {{ include "logs-collector.serviceAccountName" . }}
 securityContext:
   {{- toYaml .Values.podSecurityContext | nindent 2 }}
 {{- with .Values.hostAliases }}
@@ -11,7 +11,7 @@ hostAliases:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 containers:
-  - name: {{ include "opentelemetry-collector.lowercase_chartname" . }}
+  - name: {{ include "logs-collector.lowercase_chartname" . }}
     command:
       - /{{ .Values.command.name }}
       {{- if .Values.configMap.create }}
@@ -34,7 +34,7 @@ containers:
     {{- end }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
 
-    {{- $ports := include "opentelemetry-collector.podPortsConfig" . }}
+    {{- $ports := include "logs-collector.podPortsConfig" . }}
     {{- if $ports }}
     ports:
       {{- $ports | nindent 6}}
@@ -80,7 +80,7 @@ containers:
       {{ end }}
       {{- if and (.Values.useGOMEMLIMIT) ((((.Values.resources).limits).memory))  }}
       - name: GOMEMLIMIT
-        value: {{ include "opentelemetry-collector.gomemlimit" .Values.resources.limits.memory | quote }}
+        value: {{ include "logs-collector.gomemlimit" .Values.resources.limits.memory | quote }}
       {{- end }}
       {{- with .Values.extraEnvs }}
       {{- . | toYaml | nindent 6 }}
@@ -138,7 +138,7 @@ containers:
     volumeMounts:
       {{- if .Values.configMap.create }}
       - mountPath: /conf
-        name: {{ include "opentelemetry-collector.lowercase_chartname" . }}-configmap
+        name: {{ include "logs-collector.lowercase_chartname" . }}-configmap
       {{- end }}
       - name: varlogpods
         mountPath: /var/log/pods
@@ -163,9 +163,9 @@ priorityClassName: {{ .Values.priorityClassName | quote }}
 {{- end }}
 volumes:
   {{- if .Values.configMap.create }}
-  - name: {{ include "opentelemetry-collector.lowercase_chartname" . }}-configmap
+  - name: {{ include "logs-collector.lowercase_chartname" . }}-configmap
     configMap:
-      name: {{ include "opentelemetry-collector.fullname" . }}{{ .configmapSuffix }}
+      name: {{ include "logs-collector.fullname" . }}{{ .configmapSuffix }}
       items:
         - key: relay
           path: relay.yaml

--- a/charts/logzio-logs-collector/templates/_pod.tpl
+++ b/charts/logzio-logs-collector/templates/_pod.tpl
@@ -1,4 +1,4 @@
-{{- define "opentelemetry-collector.pod" -}}
+{{- define "opentelemetry-collector.loggingPod" -}}
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/charts/logzio-logs-collector/templates/clusterrole.yaml
+++ b/charts/logzio-logs-collector/templates/clusterrole.yaml
@@ -3,9 +3,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "opentelemetry-collector.clusterRoleName" . }}
+  name: {{ include "logs-collector.clusterRoleName" . }}
   labels:
-    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+    {{- include "logs-collector.labels" . | nindent 4 }}
   {{- if .Values.clusterRole.annotations }}
   annotations:
     {{- range $key, $value := .Values.clusterRole.annotations }}

--- a/charts/logzio-logs-collector/templates/clusterrolebinding.yaml
+++ b/charts/logzio-logs-collector/templates/clusterrolebinding.yaml
@@ -3,9 +3,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "opentelemetry-collector.clusterRoleBindingName" . }}
+  name: {{ include "logs-collector.clusterRoleBindingName" . }}
   labels:
-    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+    {{- include "logs-collector.labels" . | nindent 4 }}
   {{- if .Values.clusterRole.clusterRoleBinding.annotations }}
   annotations:
     {{- range $key, $value := .Values.clusterRole.clusterRoleBinding.annotations }}
@@ -15,10 +15,10 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "opentelemetry-collector.clusterRoleName" . }}
+  name: {{ include "logs-collector.clusterRoleName" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "opentelemetry-collector.serviceAccountName" . }}
-  namespace: {{ include "opentelemetry-collector.namespace" . }}
+  name: {{ include "logs-collector.serviceAccountName" . }}
+  namespace: {{ include "logs-collector.namespace" . }}
 {{- end }}
 {{ end }}

--- a/charts/logzio-logs-collector/templates/configmap-agent.yaml
+++ b/charts/logzio-logs-collector/templates/configmap-agent.yaml
@@ -8,6 +8,6 @@ metadata:
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 data:
-  relay: {{- include "opentelemetry-collector.daemonsetConfig" . | nindent 4 }}
+  relay: {{- include "opentelemetry-collector.loggingDaemonsetConfig" . | nindent 4 }}
 {{- end }}
 {{ end }}

--- a/charts/logzio-logs-collector/templates/configmap-agent.yaml
+++ b/charts/logzio-logs-collector/templates/configmap-agent.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "opentelemetry-collector.fullname" . }}-daemonset
-  namespace: {{ template "opentelemetry-collector.namespace" . }}
+  name: {{ include "logs-collector.fullname" . }}-daemonset
+  namespace: {{ template "logs-collector.namespace" . }}
   labels:
-    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+    {{- include "logs-collector.labels" . | nindent 4 }}
 data:
-  relay: {{- include "opentelemetry-collector.loggingDaemonsetConfig" . | nindent 4 }}
+  relay: {{- include "logs-collector.loggingDaemonsetConfig" . | nindent 4 }}
 {{- end }}
 {{ end }}

--- a/charts/logzio-logs-collector/templates/daemonset.yaml
+++ b/charts/logzio-logs-collector/templates/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       {{- $podValues := deepCopy .Values }}
       {{- $podData := dict "Values" $podValues "configmapSuffix" "-daemonset" "isAgent" true }}
-      {{- include "opentelemetry-collector.pod" ($podData | mustMergeOverwrite (deepCopy .)) | nindent 6 }}
+      {{- include "opentelemetry-collector.loggingPod" ($podData | mustMergeOverwrite (deepCopy .)) | nindent 6 }}
       hostNetwork: {{ .Values.hostNetwork }}
       {{- with .Values.dnsPolicy }}
       dnsPolicy: {{ . }}

--- a/charts/logzio-logs-collector/templates/daemonset.yaml
+++ b/charts/logzio-logs-collector/templates/daemonset.yaml
@@ -3,10 +3,10 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "opentelemetry-collector.fullname" . }}
-  namespace: {{ template "opentelemetry-collector.namespace" . }}
+  name: {{ include "logs-collector.fullname" . }}
+  namespace: {{ template "logs-collector.namespace" . }}
   labels:
-    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+    {{- include "logs-collector.labels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations:
     {{- range $key, $value := .Values.annotations }}
@@ -16,8 +16,8 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "opentelemetry-collector.selectorLabels" . | nindent 6 }}
-      {{- include "opentelemetry-collector.component" . | nindent 6 }}
+      {{- include "logs-collector.selectorLabels" . | nindent 6 }}
+      {{- include "logs-collector.component" . | nindent 6 }}
   updateStrategy:
     {{- if eq .Values.rollout.strategy "RollingUpdate" }}
     {{- with .Values.rollout.rollingUpdate }}
@@ -30,15 +30,15 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-agent.yaml") . | sha256sum }}
-        {{- include "opentelemetry-collector.podAnnotations" . | nindent 8 }}
+        {{- include "logs-collector.podAnnotations" . | nindent 8 }}
       labels:
-        {{- include "opentelemetry-collector.selectorLabels" . | nindent 8 }}
-        {{- include "opentelemetry-collector.component" . | nindent 8 }}
-        {{- include "opentelemetry-collector.podLabels" . | nindent 8 }}
+        {{- include "logs-collector.selectorLabels" . | nindent 8 }}
+        {{- include "logs-collector.component" . | nindent 8 }}
+        {{- include "logs-collector.podLabels" . | nindent 8 }}
     spec:
       {{- $podValues := deepCopy .Values }}
       {{- $podData := dict "Values" $podValues "configmapSuffix" "-daemonset" "isAgent" true }}
-      {{- include "opentelemetry-collector.loggingPod" ($podData | mustMergeOverwrite (deepCopy .)) | nindent 6 }}
+      {{- include "logs-collector.loggingPod" ($podData | mustMergeOverwrite (deepCopy .)) | nindent 6 }}
       hostNetwork: {{ .Values.hostNetwork }}
       {{- with .Values.dnsPolicy }}
       dnsPolicy: {{ . }}

--- a/charts/logzio-logs-collector/templates/ingress.yaml
+++ b/charts/logzio-logs-collector/templates/ingress.yaml
@@ -6,14 +6,14 @@ apiVersion: "networking.k8s.io/v1"
 kind: Ingress
 metadata:
   {{- if .name }}
-  name: {{ printf "%s-%s" (include "opentelemetry-collector.fullname" $) .name }}
+  name: {{ printf "%s-%s" (include "logs-collector.fullname" $) .name }}
   {{- else }}
-  name: {{ include "opentelemetry-collector.fullname" $ }}
+  name: {{ include "logs-collector.fullname" $ }}
   {{- end }}
-  namespace: {{ template "opentelemetry-collector.namespace" $ }}
+  namespace: {{ template "logs-collector.namespace" $ }}
   labels:
-    {{- include "opentelemetry-collector.labels" $ | nindent 4 }}
-    {{- include "opentelemetry-collector.component" $ | nindent 4 }}
+    {{- include "logs-collector.labels" $ | nindent 4 }}
+    {{- include "logs-collector.component" $ | nindent 4 }}
   {{- if .annotations }}
   annotations:
     {{- range $key, $value := .annotations }}
@@ -46,7 +46,7 @@ spec:
             pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "opentelemetry-collector.fullname" $ }}
+                name: {{ include "logs-collector.fullname" $ }}
                 port:
                   number: {{ .port }}
           {{- end }}

--- a/charts/logzio-logs-collector/templates/networkpolicy.yaml
+++ b/charts/logzio-logs-collector/templates/networkpolicy.yaml
@@ -3,10 +3,10 @@
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: {{ include "opentelemetry-collector.fullname" . }}
-  namespace: {{ template "opentelemetry-collector.namespace" . }}
+  name: {{ include "logs-collector.fullname" . }}
+  namespace: {{ template "logs-collector.namespace" . }}
   labels:
-    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+    {{- include "logs-collector.labels" . | nindent 4 }}
   {{- if .Values.networkPolicy.annotations }}
   annotations:
     {{- range $key, $value := .Values.networkPolicy.annotations }}
@@ -16,8 +16,8 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      {{- include "opentelemetry-collector.selectorLabels" . | nindent 6 }}
-      {{- include "opentelemetry-collector.component" . | nindent 6 }}
+      {{- include "logs-collector.selectorLabels" . | nindent 6 }}
+      {{- include "logs-collector.component" . | nindent 6 }}
   ingress:
     - ports:
         {{- range $port := .Values.ports }}

--- a/charts/logzio-logs-collector/templates/podmonitor.yaml
+++ b/charts/logzio-logs-collector/templates/podmonitor.yaml
@@ -3,18 +3,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "opentelemetry-collector.fullname" . }}-agent
-  namespace: {{ template "opentelemetry-collector.namespace" . }}
+  name: {{ include "logs-collector.fullname" . }}-agent
+  namespace: {{ template "logs-collector.namespace" . }}
   labels:
-    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+    {{- include "logs-collector.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.podMonitor.extraLabels }}
     {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
     {{- end }}
 spec:
   selector:
     matchLabels:
-      {{- include "opentelemetry-collector.selectorLabels" . | nindent 6 }}
-      {{- include "opentelemetry-collector.component" . | nindent 6 }}
+      {{- include "logs-collector.selectorLabels" . | nindent 6 }}
+      {{- include "logs-collector.component" . | nindent 6 }}
   podMetricsEndpoints:
   {{- toYaml .Values.podMonitor.metricsEndpoints | nindent 2 }}
 {{- end }}

--- a/charts/logzio-logs-collector/templates/service.yaml
+++ b/charts/logzio-logs-collector/templates/service.yaml
@@ -1,13 +1,13 @@
 {{ if .Values.enabled}}
-{{- if or (eq (include "opentelemetry-collector.serviceEnabled" .) "true") (.Values.ingress.enabled) -}}
+{{- if or (eq (include "logs-collector.serviceEnabled" .) "true") (.Values.ingress.enabled) -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "opentelemetry-collector.fullname" . }}
-  namespace: {{ template "opentelemetry-collector.namespace" . }}
+  name: {{ include "logs-collector.fullname" . }}
+  namespace: {{ template "logs-collector.namespace" . }}
   labels:
-    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
-    {{- include "opentelemetry-collector.component" . | nindent 4 }}
+    {{- include "logs-collector.labels" . | nindent 4 }}
+    {{- include "logs-collector.component" . | nindent 4 }}
   {{- if .Values.service.annotations }}
   annotations:
     {{- range $key, $value := .Values.service.annotations }}
@@ -28,15 +28,15 @@ spec:
     - {{ . }}
     {{- end }}
   {{- end }}
-  {{- $ports := include "opentelemetry-collector.servicePortsConfig" . }}
+  {{- $ports := include "logs-collector.servicePortsConfig" . }}
   {{- if $ports }}
   ports:
     {{- $ports | nindent 4}}
   {{- end }}
   selector:
-    {{- include "opentelemetry-collector.selectorLabels" . | nindent 4 }}
-    {{- include "opentelemetry-collector.component" . | nindent 4 }}
-  internalTrafficPolicy: {{ include "opentelemetry-collector.serviceInternalTrafficPolicy" . }}
+    {{- include "logs-collector.selectorLabels" . | nindent 4 }}
+    {{- include "logs-collector.component" . | nindent 4 }}
+  internalTrafficPolicy: {{ include "logs-collector.serviceInternalTrafficPolicy" . }}
   {{- if and (eq .Values.service.type "LoadBalancer") (.Values.service.externalTrafficPolicy) }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}

--- a/charts/logzio-logs-collector/templates/serviceaccount.yaml
+++ b/charts/logzio-logs-collector/templates/serviceaccount.yaml
@@ -3,10 +3,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "opentelemetry-collector.serviceAccountName" . }}
-  namespace: {{ template "opentelemetry-collector.namespace" . }}
+  name: {{ include "logs-collector.serviceAccountName" . }}
+  namespace: {{ template "logs-collector.namespace" . }}
   labels:
-    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+    {{- include "logs-collector.labels" . | nindent 4 }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
     {{- range $key, $value := .Values.serviceAccount.annotations }}

--- a/charts/logzio-logs-collector/values.yaml
+++ b/charts/logzio-logs-collector/values.yaml
@@ -118,7 +118,7 @@ config:
       # store check point in `directory: /var/lib/otelcol`
       storage: file_storage
       # Exclude collector container's logs. The file format is /var/log/pods/<namespace_name>_<pod_name>_<pod_uid>/<container_name>/<run_id>.log
-      exclude: [ "/var/log/pods/{{ .Release.Namespace }}_{{ include \"opentelemetry-collector.fullname\" . }}*_*/{{ include \"opentelemetry-collector.lowercase_chartname\" . }}/*.log" ]
+      exclude: [ "/var/log/pods/{{ .Release.Namespace }}_{{ include \"logs-collector.fullname\" . }}*_*/{{ include \"logs-collector.lowercase_chartname\" . }}/*.log" ]
       include:
       - /var/log/pods/*/*/*.log
       include_file_name: false


### PR DESCRIPTION
* 1.0.2
  - Change template function name `baseConfig` -> `baseLoggingConfig` to avoid conflicts with other charts deployed
  - Refactor tempaltes function names `opentelemetry-collector` -> `logs-collector` to avoid conflicts with other charts templates
