### PR TITLE
Logzio monitoring 5.3.1

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.3.0
+version: 5.3.1
 
 
 sources:
@@ -29,7 +29,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
   - name: logzio-logs-collector
-    version: "1.0.1"
+    version: "1.0.2"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
 maintainers:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -227,7 +227,7 @@ There are two possible approaches to the upgrade you can choose from:
 ## Changelog
 - **5.3.1**:
   Upgrade `logzio-logs-collector` version to `1.0.2`:
-    - Refactor tempaltes function names, to avoid conflicts with other charts templates
+    - Refactor templates function names, to avoid conflicts with other charts templates
 - **5.3.0**:
   - Add `logzio-logs-collector.enabled` + `fluentd.enabled` values
   - Upgrade `logzio-k8s-telemetry` to `4.2.0`:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -225,6 +225,9 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **5.3.1**:
+  Upgrade `logzio-logs-collector` version to `1.0.2`:
+    - Refactor tempaltes function names, to avoid conflicts with other charts templates
 - **5.3.0**:
   - Add `logzio-logs-collector.enabled` + `fluentd.enabled` values
   - Upgrade `logzio-k8s-telemetry` to `4.2.0`:


### PR DESCRIPTION
- **5.3.1**:
  Upgrade `logzio-logs-collector` version to `1.0.2`:
    - Refactor templates function names, to avoid conflicts with other charts templates