### PR TITLE
update release workflow actions versions

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -24,7 +24,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0


### PR DESCRIPTION
- `actions/checkout@v3` >> `actions/checkout@v4`
- `azure/setup-helm@v3` >> `azure/setup-helm@v4.2.0`

**Note**: didn't miss `helm/chart-releaser-action@v1.6.0`, it's just still the newest versions yet