### PR TITLE
update monitoring chart to use telemetry chart 4.2.1

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.3.3
+version: 5.3.4
 
 
 sources:
@@ -13,7 +13,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "4.2.0"
+    version: "4.2.1"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -225,6 +225,9 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **5.3.4**:
+  - Upgrade `logzio-k8s-telemetry` version to `4.2.1`:
+  	- Filter in `container_cpu_cfs_throttled_seconds_total` and `kube_pod_container_info` metrics.
 - **5.3.3**:
   - Upgrade `logzio-logs-collector` version to `1.0.3`:
   	- Replace dots `.` with underscores `_` in log attributes keys:


### PR DESCRIPTION
- update `logzio-k8s-telemetry` version to `4.2.1` following #481 