### PR TITLE
Release/logzio monitoring 6.0.0

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.3.4
+version: 6.0.0
 
 
 sources:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -128,7 +128,7 @@ For example, to change a value named `someField` in `logzio-telemetry`'s `values
 --set logzio-k8s-telemetry.someField="my new value"
 ```
 
-### Migrate to OpenTelemetry for log collection
+### Migrate to OpenTelemetry for log collection (Migrating to logzio-monitoring 6.0.0)
 
 The `logzio-fluentd` chart is disabled by default in favor of the `logzio-logs-collector` for log collection. To use `logzio-fluentd`, add the following `--set` flags:
 

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -48,9 +48,9 @@ Use the following command, and replace the placeholders with your parameters:
 ```shell
 helm install -n monitoring \
 --set logs.enabled=true \
---set logzio-fluentd.secrets.logzioShippingToken="<<LOG-SHIPPING-TOKEN>>" \
---set logzio-fluentd.secrets.logzioListener="<<LISTENER-HOST>>" \
---set logzio-fluentd.env_id="<<ENV-ID>>" \
+--set logzio-logs-collector.secrets.logzioLogsToken="<<LOG-SHIPPING-TOKEN>>" \
+--set logzio-logs-collector.secrets.logzioRegion="<<LOGZIO-REGION>>" \
+--set logzio-logs-collector.secrets.env_id="<<ENV-ID>>" \
 --set metricsOrTraces.enabled=true \
 --set logzio-k8s-telemetry.metrics.enabled=true \
 --set logzio-k8s-telemetry.secrets.MetricsToken="<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>" \
@@ -130,17 +130,16 @@ For example, to change a value named `someField` in `logzio-telemetry`'s `values
 
 ### Migrate to OpenTelemetry for log collection
 
-The `logzio-fluentd` chart will be disabled by default in favor of the `logzio-logs-collector` for log collection in upcoming releases. To migrate to `logzio-logs-collector`, add the following `--set` flags:
+The `logzio-fluentd` chart is disabled by default in favor of the `logzio-logs-collector` for log collection. To use `logzio-fluentd`, add the following `--set` flags:
 
 ```sh
 helm install -n monitoring \
 --set logs.enabled=true \  
---set logzio-fluentd.enabled=false \  
---set logzio-logs-collector.enabled=true \  
---set logzio-logs-collector.secrets.logzioLogsToken=<<token>> \  
---set logzio-logs-collector.secrets.logzioRegion=<<region>> \  
---set logzio-logs-collector.secrets.env_id=<<env_id>> \  
---set logzio-logs-collector.secrets.logType=<<log_type>> \
+--set logzio-fluentd.enabled=true \  
+--set logzio-logs-collector.enabled=false \  
+--set logzio-fluentd.secrets.logzioShippingToken="<<LOG-SHIPPING-TOKEN>>" \
+--set logzio-fluentd.secrets.logzioListener="<<LISTENER-HOST>>" \
+--set logzio-fluentd.env_id="<<ENV-ID>>" \
 logzio-monitoring logzio-helm/logzio-monitoring
 ```
 
@@ -151,9 +150,9 @@ To ship logs from pods running on Fargate, set the `fargateLogRouter.enabled` va
 ```shell
 helm install -n monitoring \
 --set logs.enabled=true \
---set logzio-fluentd.fargateLogRouter.enabled=true \
---set logzio-fluentd.secrets.logzioShippingToken="<<LOG-SHIPPING-TOKEN>>" \
---set logzio-fluentd.secrets.logzioListener="<<LISTENER-HOST>>" \
+--set logzio-logs-collector.fargateLogRouter.enabled=true \
+--set logzio-logs-collector.secrets.logzioLogsToken="<<LOG-SHIPPING-TOKEN>>" \
+--set logzio-logs-collector.secrets.logzioRegion="<<LOGZIO-REGION>>" \
 --set metricsOrTraces.enabled=true \
 --set logzio-k8s-telemetry.metrics.enabled=true \
 --set logzio-k8s-telemetry.secrets.MetricsToken="<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>" \
@@ -225,7 +224,9 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
-- **5.3.4**:
+- **6.0.0**:
+  - **Breaking changes**:
+  	- Make `logzio-logs-collector` default subchart for logging instead of `logzio-fluentd`
   - Upgrade `logzio-k8s-telemetry` version to `4.2.1`:
   	- Filter in `container_cpu_cfs_throttled_seconds_total` and `kube_pod_container_info` metrics.
 - **5.3.3**:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -227,6 +227,7 @@ There are two possible approaches to the upgrade you can choose from:
 - **6.0.0**:
   - **Breaking changes**:
   	- Make `logzio-logs-collector` default subchart for logging instead of `logzio-fluentd`
+- **5.3.4**:
   - Upgrade `logzio-k8s-telemetry` version to `4.2.1`:
   	- Filter in `container_cpu_cfs_throttled_seconds_total` and `kube_pod_container_info` metrics.
 - **5.3.3**:

--- a/charts/logzio-monitoring/templates/NOTES.txt
+++ b/charts/logzio-monitoring/templates/NOTES.txt
@@ -1,6 +1,6 @@
 
 {{- if and (.Values.logs.enabled) (not (index .Values "logzio-logs-collector" "enabled")) (index .Values "logzio-fluentd" "enabled") }}
-[ DEPRICATION ] You are using fluetnd agent for log collection, this option will be disabled by default in upcoming releases.
+[ DEPRICATION ] You are using fluetnd agent for log collection.
 You can change to opentelemetry logzio-logs-collector by setting the following values:
 
   --set logs.enabled=true \
@@ -25,12 +25,6 @@ You can change to opentelemetry logzio-logs-collector by setting the following v
   --set logzio-logs-collector.secrets.logzioRegion=<<region>> \
   --set logzio-logs-collector.secrets.env_id=<<env_id>> \
   --set logzio-logs-collector.secrets.logType=<<log_type>> \
-{{ end }}
-
-
-{{- if and (.Values.logs.enabled) (index .Values "logzio-logs-collector" "enabled")}}
-[ INFO ] You enabled opentelemetry logzio-logs-collector for log collection.
-
 {{ end }}
 
 

--- a/charts/logzio-monitoring/values.yaml
+++ b/charts/logzio-monitoring/values.yaml
@@ -20,12 +20,12 @@ deployEvents:
 
 # Override values for the Fluentd sub-chart
 logzio-fluentd:
-  enabled: true
+  enabled: false
   daemonset:
     logType: "agent-k8s"
 
 logzio-logs-collector:
-  enabled: false
+  enabled: true
 
 # Override values for the opencost sub-chart
 opencost:


### PR DESCRIPTION
- **6.0.0**:
  - **Breaking changes**:
  	- Make `logzio-logs-collector` default subchart for logging instead of `logzio-fluentd`