### PR TITLE
Upgrade logzio-monitoring chart to v5.3.5

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.3.4
+version: 5.3.5
 
 
 sources:
@@ -13,7 +13,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "4.2.1"
+    version: "4.2.2"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -225,6 +225,9 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **5.3.5**:
+  - Upgrade `logzio-k8s-telemetry` version to `4.2.2`:
+  	- Fix missing `logzio-k8s-objects-logs-token` key from secret.
 - **5.3.4**:
   - Upgrade `logzio-k8s-telemetry` version to `4.2.1`:
   	- Filter in `container_cpu_cfs_throttled_seconds_total` and `kube_pod_container_info` metrics.

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -412,6 +412,8 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 4.2.2
+  - Fix missing `logzio-k8s-objects-logs-token` key from secret.
 * 4.2.1
   - Filter in `container_cpu_cfs_throttled_seconds_total` and `kube_pod_container_info` metrics.
 * 4.2.0


### PR DESCRIPTION
  - Upgrade `logzio-k8s-telemetry` version to `4.2.2`:
  	- Fix missing `logzio-k8s-objects-logs-token` key from secret.