### PR TITLE
Upgrade `logzio-telemetry` chart to v4.2.3

### DIFF
--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.2.2
+version: 4.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -412,6 +412,8 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 4.2.3
+  - Disable Kubernetes objects receiver by default.
 * 4.2.2
   - Fix missing `logzio-k8s-objects-logs-token` key from secret.
 * 4.2.1

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -584,7 +584,7 @@ ports:
 
 # Kubernetes Object logs
 k8sObjectsConfig:
-  enabled: true
+  enabled: false
   config:
     receivers:
       # Watch for changes in Kubernetes objects


### PR DESCRIPTION
- Disable Kubernetes objects receiver by default.