### PR TITLE
Upgrade logzio-monitoring chart v5.3.6

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 5.3.5
+version: 5.3.6
 
 
 sources:
@@ -13,7 +13,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "4.2.2"
+    version: "4.2.3"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -225,6 +225,9 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **5.3.6**:
+  - Upgrade `logzio-k8s-telemetry` version to `4.2.3`:
+	- Disable Kubernetes objects receiver by default.
 - **5.3.5**:
   - Upgrade `logzio-k8s-telemetry` version to `4.2.2`:
   	- Fix missing `logzio-k8s-objects-logs-token` key from secret.


### PR DESCRIPTION
  - Upgrade `logzio-k8s-telemetry` version to `4.2.3`:
	- Disable Kubernetes objects receiver by default.