### PR TITLE
Upgrade `logzio-fluentd` to v0.30.1

### DIFF
--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for shipping Kubernetes logs via Fluentd.
 keywords:
   - logging
   - fluentd
-version: 0.30.0
+version: 0.30.1
 appVersion: 1.5.3
 maintainers:
   - name: Yotam loewenbach

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -301,6 +301,8 @@ If needed, the fluentd image can be changed to support windows server 2022 with 
 
 
 ## Change log
+ - **0.30.1**:
+  - Handle empty etcd `log` key, populated based on `message` key.
  - **0.30.0**:
   - Upgrade fluentd version to `1.16.5`
   - Fix bug of `env-id.conf`

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -379,6 +379,14 @@ configmap:
         @type none
       </parse>
     </source>
+    
+    # This changes message key to log for etcd logs
+    <filter logzio.etcd>
+      @type record_modifier
+      <record>
+      log ${record["message"]}
+      </record>
+    </filter>
 
     <source>
       @type tail


### PR DESCRIPTION
- Handle empty etcd `log` key, populated based on `message` key.