### PR TITLE
Upgrade logzio-monitoring to v6.0.1

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 6.0.0
+version: 6.0.1
 
 
 
@@ -30,7 +30,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
   - name: logzio-logs-collector
-    version: "1.0.3"
+    version: "1.0.4"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
 maintainers:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -224,6 +224,11 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **6.0.1**:
+  - Upgrade `logzio-logs-collector` chart to v1.0.4
+    - Add standalone deployment mode
+    - Rename `LogzioRegion` to camelCase - `logzioRegion`
+    - Add user-agent header
 - **6.0.0**:
   - **Breaking changes**:
   	- Make `logzio-logs-collector` default subchart for logging instead of `logzio-fluentd`


### PR DESCRIPTION
- Upgrade `logzio-logs-collector` chart to v1.0.4
  - Add standalone deployment mode
  - Rename `LogzioRegion` to camelCase - `logzioRegion` closes #492
  - Add user-agent header