### PR TITLE
remove duplicate label

### DIFF
--- a/charts/logzio-k8s-events/templates/_helpers.tpl
+++ b/charts/logzio-k8s-events/templates/_helpers.tpl
@@ -40,7 +40,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ include "logzio-k8s-events.selectorLabels" . }}
 {{- end }}
 


### PR DESCRIPTION
this PR removes the duplicate label `app.kubernetes.io/managed-by` and fixes #421 

```yaml
  name: logzio-monitoring-logzio-k8s-events
  labels:
    k8s-app: logzio-k8s-events
    helm.sh/chart: logzio-k8s-events-0.0.4
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: "0.0.2"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: logzio-k8s-events
    app.kubernetes.io/instance: logzio-monitoring
```