### PR TITLE
Logzio k8s events 0.0.5

### DIFF
--- a/charts/logzio-k8s-events/Chart.yaml
+++ b/charts/logzio-k8s-events/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - k8s
   - kubernetes
-version: 0.0.4
+version: 0.0.5
 appVersion: 0.0.2
 maintainers:
   - name: Raul Gurshumov

--- a/charts/logzio-k8s-events/templates/_helpers.tpl
+++ b/charts/logzio-k8s-events/templates/_helpers.tpl
@@ -40,7 +40,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ include "logzio-k8s-events.selectorLabels" . }}
 {{- end }}
 


### PR DESCRIPTION
- bugfix/remove `kubernetes.io/managed-by` duplicate label