### PR TITLE
bugfix/ Logzio monitoring 6.0.3

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 6.0.2
+version: 6.0.3
 
 
 
@@ -26,7 +26,7 @@ dependencies:
     repository: "https://opencost.github.io/opencost-helm-chart"
     condition: finops.enabled
   - name: logzio-k8s-events
-    version: "0.0.4"
+    version: "0.0.5"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
   - name: logzio-logs-collector

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -224,6 +224,9 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **6.0.3**:
+  - Upgrade `logzio-k8s-events` chart to `0.0.5`
+    - Remove the duplicate label `app.kubernetes.io/managed-by` @philwelz
 - **6.0.2**:
   - Upgrade `logzio-k8s-telemetry` chart to `v4.2.4`
     - Upgrade `otel/opentelemetry-collector-contrib` image to `v0.102.1`

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -226,7 +226,7 @@ There are two possible approaches to the upgrade you can choose from:
 ## Changelog
 - **6.0.3**:
   - Upgrade `logzio-k8s-events` chart to `0.0.5`
-    - Remove the duplicate label `app.kubernetes.io/managed-by` @philwelz
+    - Bugfix/ Remove the duplicate label `app.kubernetes.io/managed-by` @philwelz
 - **6.0.2**:
   - Upgrade `logzio-k8s-telemetry` chart to `v4.2.4`
     - Upgrade `otel/opentelemetry-collector-contrib` image to `v0.102.1`


### PR DESCRIPTION
- **6.0.3**:
  - Upgrade `logzio-k8s-events` chart to `0.0.5`
    - Remove the duplicate label `app.kubernetes.io/managed-by` @philwelz