### PR TITLE
Upgrade logzio-monitoring chart to v6.0.5

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 6.0.4
+version: 6.0.5
 
 
 
@@ -10,11 +10,11 @@ sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: logzio-fluentd
-    version: "0.30.0"
+    version: "0.30.1"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "4.2.5"
+    version: "4.2.6"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy
@@ -30,7 +30,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
   - name: logzio-logs-collector
-    version: "1.0.4"
+    version: "1.0.5"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
 maintainers:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -224,6 +224,14 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **6.0.5**:
+  - Upgrade `logzio-k8s-telemetry` chart to `v4.2.4`
+    - Upgrade `otel/opentelemetry-collector-contrib` image to `v0.103.0`
+	- Fix standalone self metrics collection for EKS Fargate
+  - Upgrade `logzio-logs-collector` chart to `v1.0.5`
+    - Upgrade `otel/opentelemetry-collector-contrib` image to `v0.103.0`
+  - Upgrade `logzio-fluentd` chart to `v0.30.1`
+    - Handle empty etcd `log` field, populated based on `message` field.		
 - **6.0.4**:
   - Upgrade `logzio-k8s-telemetry` chart to `4.2.5`
     - Added 'user-agent' header for telemetry data.


### PR DESCRIPTION
  - Upgrade `logzio-k8s-telemetry` chart to `v4.2.4` - Upgrade `otel/opentelemetry-collector-contrib` image to `v0.103.0`
	- Fix standalone self metrics collection for EKS Fargate
  - Upgrade `logzio-logs-collector` chart to `v1.0.5`
    - Upgrade `otel/opentelemetry-collector-contrib` image to `v0.103.0`
  - Upgrade `logzio-fluentd` chart to `v0.30.1` - Handle empty etcd `log` field, populated based on `message` field.