### PR TITLE
Fix standalone cAdvisor metrics collection

### DIFF
--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 4.2.6
+version: 4.2.7
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -412,6 +412,8 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 4.2.7
+  - Fix `cluster-admin` cluster role binding creation condition
 * 4.2.6
   - Upgrade `otel/opentelemetry-collector-contrib` image to `v0.103.0`
   - Fix standalone self metrics collection for EKS Fargate 

--- a/charts/logzio-telemetry/templates/clusterrolebinding.yaml
+++ b/charts/logzio-telemetry/templates/clusterrolebinding.yaml
@@ -18,7 +18,7 @@ subjects:
   name: {{ include "opentelemetry-collector.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}
-{{- if and .Values.managedServiceAccount .Values.standaloneCollector.enabled }}
+{{- if and (eq .Values.collector.mode "standalone") (.Values.managedServiceAccount) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
- Fix `cluster-admin` cluster role binding creation condition