### PR TITLE
Upgrade `logzio-trivy` to v0.3.3

### DIFF
--- a/charts/logzio-trivy/Chart.yaml
+++ b/charts/logzio-trivy/Chart.yaml
@@ -5,14 +5,16 @@ keywords:
   - logging
   - trivy
   - security
-version: 0.3.2
-appVersion: 0.2.2
+version: 0.3.3
+appVersion: 0.2.3
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: trivy-operator
-    version: "0.15.1"
+    version: "0.24.0"
     repository: "https://aquasecurity.github.io/helm-charts/"
 maintainers:
   - name: Miri Bar
     email: miri.ignatiev@logz.io
+  - name: Raul Gurshumov
+    email: raul.gurshumo@logz.io    

--- a/charts/logzio-trivy/README.md
+++ b/charts/logzio-trivy/README.md
@@ -75,6 +75,11 @@ In these cases we can use the following `--set` command to use an alternative im
 
 
 ## Changelog
+- **0.3.3**:
+  - Upgrade to image `logzio/trivy-to-logzio:0.3.3`.
+    - Upgrade python version to 3.12.5.
+    - Re-build image to include the latest version of git(CVE-2024-32002).
+  - Bump Trivy-Operator version to `0.24.0`.
 - **0.3.2**:
   - Added 'user-agent' header for telemetry data.
 - **0.3.0**:

--- a/charts/logzio-trivy/values.yaml
+++ b/charts/logzio-trivy/values.yaml
@@ -24,7 +24,7 @@ schedule: "07:00"
 # Container image
 image: logzio/trivy-to-logzio
 # Container image tag
-imageTag: 0.2.2
+imageTag: 0.2.3
 # The name for your environment's identifier (cluster name), to easily identify the telemetry data for each environment
 env_id: ""
 # Termination period (in seconds) to wait before killing Fluentd pod process on pod shutdown


### PR DESCRIPTION
  - Upgrade to image `logzio/trivy-to-logzio:0.3.3`. 
    - Upgrade python version to 3.12.5. 
    - Re-build image to include the latest version of git(CVE-2024-32002).
  - Bump Trivy-Operator version to `0.24.0`.