### PR TITLE
EKS fargate support in automatic helm tests

### DIFF
--- a/.github/workflows/logzio-logs-collector-test.yaml
+++ b/.github/workflows/logzio-logs-collector-test.yaml
@@ -1,4 +1,4 @@
-name: Test Logzio Logs Collector Helm Chart on Kind Kubernetes Environment
+name: Test `logzio-logs-collector` chart
 
 on:
   pull_request:

--- a/.github/workflows/logzio-logs-collector-test.yaml
+++ b/.github/workflows/logzio-logs-collector-test.yaml
@@ -52,7 +52,7 @@ jobs:
           --set secrets.logzioRegion=us \
           logzio-logs-collector .
 
-      - name: run log generator
+      - name: Run log generator
         run: |
           kubectl apply -f tests/resources/logsgen.yaml
           kubectl rollout status deployment/log-generator --timeout=300s

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -79,7 +79,7 @@ jobs:
           --set logzio-logs-collector.secrets.logzioLogsToken='${{ secrets.LOGZIO_LOGS_TOKEN }}' \
           --set logzio-logs-collector.secrets.logzioRegion='us' \
           --set logzio-logs-collector.secrets.env_id='${{ env.ENV_ID }}' \
-          --set secrets.logType='test' \
+          --set logzio-logs-collector.secrets.logType='${{ env.ENV_ID }}' \
           --set metricsOrTraces.enabled=true \
           --set logzio-k8s-telemetry.metrics.enabled=true \
           --set logzio-k8s-telemetry.secrets.MetricsToken='${{ secrets.LOGZIO_METRICS_TOKEN }}' \

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -115,7 +115,7 @@ jobs:
           kubectl rollout status deployment/trace-gen --timeout=300s
 
       - name: Sleep
-        run: sleep 180
+        run: sleep 240
 
       - name: Run linux logs tests
         id: linux_logs_tests

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -33,10 +33,12 @@ jobs:
           echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> $GITHUB_ENV
           echo "AWS_REGION=us-east-1" >> $GITHUB_ENV
           echo "NUMBER_OF_NODES=3" >> $GITHUB_ENV
+          echo "NODE_TYPE=t3.medium" >> $GITHUB_ENV
           echo "KUBERNETES_ENV=${{ matrix.environment }}" >> $GITHUB_ENV
           echo "LOGZIO_LOGS_API_KEY=${{ secrets.LOGZIO_LOGS_API_KEY }}" >> $GITHUB_ENV
           echo "LOGZIO_METRICS_API_KEY=${{ secrets.LOGZIO_METRICS_API_KEY }}" >> $GITHUB_ENV
           echo "LOGZIO_TRACES_API_KEY=${{ secrets.LOGZIO_TRACES_API_KEY }}" >> $GITHUB_ENV
+        
 
       - name: Set up eksctl
         run: |
@@ -50,7 +52,8 @@ jobs:
         run: |
           if [ "${{ matrix.environment }}" == "eks-linux" ]; then
             eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} \
-              --version ${{ matrix.kubernetes_version }} --nodes ${{ env.NUMBER_OF_NODES }} --with-oidc
+              --version ${{ matrix.kubernetes_version }} --nodes ${{ env.NUMBER_OF_NODES }} \
+              --node-type ${{ env.NODE_TYPE }} --with-oidc
           elif [ "${{ matrix.environment }}" == "eks-fargate" ]; then
             eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} \
               --version ${{ matrix.kubernetes_version }} --fargate

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -53,11 +53,11 @@ jobs:
         run: |
           if [ "${{ matrix.environment }}" == "eks-linux" ]; then
             eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} \
-              --nodes ${{ env.NUMBER_OF_NODES }} \
+              --version ${{ matrix.kubernetes_version }} --nodes ${{ env.NUMBER_OF_NODES }} \
               --node-type ${{ env.NODE_TYPE }} --with-oidc
           elif [ "${{ matrix.environment }}" == "eks-fargate" ]; then
             eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} \
-              --fargate
+              --version ${{ matrix.kubernetes_version }} --fargate
           fi
 
       - name: Update kubeconfig

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -1,4 +1,4 @@
-name: Test Logzio Monitoring Helm Chart on EKS Kubernetes Environments
+name: Test `logzio-monitoring` chart
 
 on:
   pull_request:

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -7,20 +7,25 @@ on:
     paths:
       - 'charts/logzio-monitoring/**'
 jobs:
-  test-helm-chart:
-    name: Test Helm Chart
+  setup-cluster:
+    name: Set up EKS Cluster
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [eks-linux]
-
+        kubernetes_version: [1.24, 1.25, 1.27, 1.30]
+        environment: [eks-linux, eks-fargate]
+    outputs:
+      env_id: ${{ steps.set_env_id.outputs.env_id }}
     steps:
       - name: Generate random id
         id: random_id
         run: echo "::set-output name=rand::$(echo $RANDOM)"
 
       - name: Set ENV_ID
-        run: echo "ENV_ID=monitoring-test-run-${{ steps.random_id.outputs.rand }}-${{ matrix.environment }}" >> $GITHUB_ENV
+        id: set_env_id
+        run: |
+          echo "ENV_ID=monitoring-test-run-${{ steps.random_id.outputs.rand }}-${{ matrix.environment }}" >> $GITHUB_ENV
+          echo "::set-output name=env_id::monitoring-test-run-${{ steps.random_id.outputs.rand }}-${{ matrix.environment }}"
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,30 +36,11 @@ jobs:
           echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> $GITHUB_ENV
           echo "AWS_REGION=us-west-1" >> $GITHUB_ENV
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.20'
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v4.2.0
-
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
-
-      - name: Install AWS CLI
-        run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install --update
-
       - name: Set up eksctl
         run: |
           ARCH=amd64
           PLATFORM=$(uname -s)_$ARCH
           curl -sLO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$PLATFORM.tar.gz"
-          # (Optional) Verify checksum
-          curl -sL "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_checksums.txt" | grep $PLATFORM | sha256sum --check
           tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
           sudo mv /tmp/eksctl /usr/local/bin
 
@@ -62,41 +48,55 @@ jobs:
         env:
           NUMBER_OF_NODES: 3
         run: |
-          eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} --nodes ${{ env.NUMBER_OF_NODES }} --with-oidc
-
-          aws eks --region ${{ env.AWS_REGION }} update-kubeconfig --name ${{ env.ENV_ID }}-${{ matrix.environment }}
+          if [ "${{ matrix.environment }}" == "eks-linux" ]; then
+            eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} \
+              --version ${{ matrix.kubernetes_version }} --nodes ${{ env.NUMBER_OF_NODES }} --with-oidc
+          elif [ "${{ matrix.environment }}" == "eks-fargate" ]; then
+            eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} \
+              --version ${{ matrix.kubernetes_version }} --fargate
+          fi
 
       - name: Update kubeconfig
         run: |
           aws eks --region ${{ env.AWS_REGION }} update-kubeconfig --name ${{ env.ENV_ID }}-${{ matrix.environment }}
 
       - name: Label Nodes
+        if: matrix.environment == 'eks-linux'
         run: |
           kubectl get nodes -o name | xargs -I {} kubectl label {} node-role.kubernetes.io/worker=worker --overwrite
+
       - name: Deploy Helm Chart
         run: |
           cd charts/logzio-monitoring
           helm dependency build
-          helm upgrade --install \
+          HELM_CMD="helm upgrade --install \
           --set logs.enabled=true \
           --set logzio-logs-collector.enabled=true \
-          --set logzio-logs-collector.secrets.logzioLogsToken="${{ secrets.LOGZIO_LOGS_TOKEN }}" \
-          --set logzio-logs-collector.secrets.logzioRegion="us" \
-          --set logzio-logs-collector.secrets.env_id="${{ env.ENV_ID }}" \
-          --set secrets.logType="test" \
+          --set logzio-logs-collector.secrets.logzioLogsToken='${{ secrets.LOGZIO_LOGS_TOKEN }}' \
+          --set logzio-logs-collector.secrets.logzioRegion='us' \
+          --set logzio-logs-collector.secrets.env_id='${{ env.ENV_ID }}' \
+          --set secrets.logType='test' \
           --set metricsOrTraces.enabled=true \
           --set logzio-k8s-telemetry.metrics.enabled=true \
-          --set logzio-k8s-telemetry.secrets.MetricsToken="${{ secrets.LOGZIO_METRICS_TOKEN }}" \
-          --set logzio-k8s-telemetry.secrets.ListenerHost="https://listener.logz.io:8053" \
-          --set logzio-k8s-telemetry.secrets.p8s_logzio_name="${{ env.ENV_ID }}" \
+          --set logzio-k8s-telemetry.secrets.MetricsToken='${{ secrets.LOGZIO_METRICS_TOKEN }}' \
+          --set logzio-k8s-telemetry.secrets.ListenerHost='https://listener.logz.io:8053' \
+          --set logzio-k8s-telemetry.secrets.p8s_logzio_name='${{ env.ENV_ID }}' \
           --set logzio-k8s-telemetry.traces.enabled=true \
-          --set logzio-k8s-telemetry.secrets.TracesToken="${{ secrets.LOGZIO_TRACES_TOKEN }}" \
-          --set logzio-k8s-telemetry.secrets.LogzioRegion="us" \
+          --set logzio-k8s-telemetry.secrets.TracesToken='${{ secrets.LOGZIO_TRACES_TOKEN }}' \
+          --set logzio-k8s-telemetry.secrets.LogzioRegion='us' \
           --set logzio-k8s-telemetry.spm.enabled=true \
-          --set logzio-k8s-telemetry.secrets.env_id="${{ env.ENV_ID }}" \
-          --set logzio-k8s-telemetry.secrets.SpmToken="${{ secrets.LOGZIO_METRICS_TOKEN }}" \
-          --set logzio-k8s-telemetry.serviceGraph.enabled=true \
-          logzio-monitoring .
+          --set logzio-k8s-telemetry.secrets.env_id='${{ env.ENV_ID }}' \
+          --set logzio-k8s-telemetry.secrets.SpmToken='${{ secrets.LOGZIO_METRICS_TOKEN }}' \
+          --set logzio-k8s-telemetry.serviceGraph.enabled=true"
+
+          if [ "${{ matrix.environment }}" == "eks-fargate" ]; then
+            HELM_CMD="$HELM_CMD --set logzio-logs-collector.fargateLogRouter.enabled='true'"
+          fi
+
+          HELM_CMD="$HELM_CMD logzio-monitoring ."
+          
+          eval $HELM_CMD
+
           kubectl rollout status deployment/logzio-monitoring-otel-collector-standalone --timeout=300s
           kubectl rollout status deployment/logzio-monitoring-otel-collector-spm --timeout=300s
 
@@ -111,20 +111,9 @@ jobs:
           kubectl rollout status deployment/trace-gen --timeout=300s
 
       - name: sleep
-        run: sleep 120
+        run: sleep 180
 
-      - name: Run Go Tests
-        env:
-          KUBERNETES_ENV: ${{ matrix.environment }}
-          LOGZIO_METRICS_API_KEY: ${{ secrets.LOGZIO_METRICS_API_KEY }}
-          LOGZIO_TRACES_API_KEY: ${{ secrets.LOGZIO_TRACES_API_KEY }}
-          LOGZIO_LOGS_API_KEY: ${{ secrets.LOGZIO_LOGS_API_KEY }}
-        run: |
-          go get go.uber.org/zap
-          go test -v ./tests/traces_e2e_test.go ./tests/common.go
-          go test -v ./tests/metrics_e2e_test.go ./tests/common.go   
-          go test -v ./tests/logs_e2e_test.go ./tests/common.go
-      - name: Cleanup Environment
+      - name: Uninstall Helm Chart
         run: |
           helm uninstall logzio-monitoring
 
@@ -133,3 +122,56 @@ jobs:
         run: |
           eksctl delete cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }}
 
+  run-logs-tests:
+    name: Run Logs Tests
+    runs-on: ubuntu-latest
+    needs: setup-cluster
+    env:
+      ENV_ID: ${{ needs.setup-cluster.outputs.env_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Go Logs Tests
+        env:
+          KUBERNETES_ENV: ${{ matrix.environment }}
+          LOGZIO_LOGS_API_KEY: ${{ secrets.LOGZIO_LOGS_API_KEY }}
+        run: |
+          go get go.uber.org/zap
+          go test -v ./tests/logs_e2e_test.go ./tests/common.go
+
+  run-metrics-tests:
+    name: Run Metrics Tests
+    runs-on: ubuntu-latest
+    needs: setup-cluster
+    env:
+      ENV_ID: ${{ needs.setup-cluster.outputs.env_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Go Metrics Tests
+        env:
+          KUBERNETES_ENV: ${{ matrix.environment }}
+          LOGZIO_METRICS_API_KEY: ${{ secrets.LOGZIO_METRICS_API_KEY }}
+        run: |
+          go get go.uber.org/zap
+          go test -v ./tests/metrics_e2e_test.go ./tests/common.go   
+
+  run-traces-tests:
+    name: Run Traces Tests
+    runs-on: ubuntu-latest
+    needs: setup-cluster
+    env:
+      ENV_ID: ${{ needs.setup-cluster.outputs.env_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Go Traces Tests
+        env:
+          KUBERNETES_ENV: ${{ matrix.environment }}
+          LOGZIO_TRACES_API_KEY: ${{ secrets.LOGZIO_TRACES_API_KEY }}
+        run: |
+          go get go.uber.org/zap
+          go test -v ./tests/traces_e2e_test.go ./tests/common.go

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes_version: [1.24, 1.25, 1.27]
+        kubernetes_version: [1.24]
         environment: [eks-linux, eks-fargate]
     steps:
       - name: Generate random id
@@ -53,11 +53,11 @@ jobs:
         run: |
           if [ "${{ matrix.environment }}" == "eks-linux" ]; then
             eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} \
-              --version ${{ matrix.kubernetes_version }} --nodes ${{ env.NUMBER_OF_NODES }} \
+              --nodes ${{ env.NUMBER_OF_NODES }} \
               --node-type ${{ env.NODE_TYPE }} --with-oidc
           elif [ "${{ matrix.environment }}" == "eks-fargate" ]; then
             eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} \
-              --version ${{ matrix.kubernetes_version }} --fargate
+              --fargate
           fi
 
       - name: Update kubeconfig
@@ -151,9 +151,12 @@ jobs:
 
       - name: Get Logs
         run: |
+          echo "logzio-monitoring-otel-collector-standalone: "
           kubectl logs deployment/logzio-monitoring-otel-collector-standalone
+          echo "logzio-monitoring-otel-collector-spm: "
           kubectl logs deployment/logzio-monitoring-otel-collector-spm
           if [ "${{ matrix.environment }}" == "eks-linux" ]; then
+            echo "logzio-monitoring-otel-collector-ds: "
             kubectl logs ds/logzio-monitoring-otel-collector-ds
           fi
 

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -51,14 +51,13 @@ jobs:
 
       - name: Provision Cluster
         run: |
-          K8S_VERSION=${{ matrix.kubernetes_version }}
           if [ "${{ matrix.environment }}" == "eks-linux" ]; then
             eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} \
-              --version $K8S_VERSION --nodes ${{ env.NUMBER_OF_NODES }} \
+              --version ${{ matrix.kubernetes_version }} --nodes ${{ env.NUMBER_OF_NODES }} \
               --node-type ${{ env.NODE_TYPE }} --with-oidc
           elif [ "${{ matrix.environment }}" == "eks-fargate" ]; then
             eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} \
-              --version $K8S_VERSION --fargate
+              --version ${{ matrix.kubernetes_version }} --fargate
           fi
 
       - name: Update kubeconfig

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -11,6 +11,7 @@ jobs:
     name: EKS e2e Test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         kubernetes_version: [1.24, 1.25, 1.27]
         environment: [eks-linux, eks-fargate]

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -92,17 +92,39 @@ jobs:
           --set logzio-k8s-telemetry.secrets.env_id='${{ env.ENV_ID }}' \
           --set logzio-k8s-telemetry.secrets.SpmToken='${{ secrets.LOGZIO_METRICS_TOKEN }}' \
           --set logzio-k8s-telemetry.serviceGraph.enabled=true"
-
+          
           if [ "${{ matrix.environment }}" == "eks-fargate" ]; then
-            HELM_CMD="$HELM_CMD --set logzio-logs-collector.fargateLogRouter.enabled='true'"
+            HELM_CMD="$HELM_CMD --set logzio-logs-collector.fargateLogRouter.enabled='true' --set logzio-k8s-telemetry.collector.mode=standalone"
           fi
-
+          
           HELM_CMD="$HELM_CMD logzio-monitoring ."
           
           eval $HELM_CMD
-
+          
           kubectl rollout status deployment/logzio-monitoring-otel-collector-standalone --timeout=300s
-          kubectl rollout status deployment/logzio-monitoring-otel-collector-spm --timeout=300s
+          kubectl rollout status deployment/logzio-monitoring-otel-collector-spm --timeout=300s          
+
+      - name: Confirm `aws-observability` namespace and configmap are created (fargate)
+        if: matrix.environment == 'eks-fargate'
+        run: |
+          NAMESPACE="aws-observability"
+          CONFIGMAP="aws-logging"
+          
+          if kubectl get namespace $NAMESPACE; then
+            echo "Namespace $NAMESPACE exists."
+          else
+            echo "Namespace $NAMESPACE does not exist."
+            exit 1
+          fi
+          
+          # Check if the configmap exists in the namespace
+          if kubectl get configmap $CONFIGMAP -n $NAMESPACE; then
+            echo "ConfigMap $CONFIGMAP exists in namespace $NAMESPACE."
+          else
+            echo "ConfigMap $CONFIGMAP does not exist in namespace $NAMESPACE."
+            exit 1
+          fi
+
 
       - name: run log generator
         run: |

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -114,7 +114,7 @@ jobs:
             kubectl rollout status ds/logzio-monitoring-otel-collector-ds --timeout=300s
           fi
 
-      - name: Confirm `aws-observability` namespace and configmap are created (fargate)
+      - name: Check `aws-observability` namespace and configmap (fargate)
         if: matrix.environment == 'eks-fargate'
         run: |
           NAMESPACE="aws-observability"
@@ -136,12 +136,12 @@ jobs:
           fi
 
 
-      - name: run log generator
+      - name: Run log generator
         run: |
           kubectl apply -f tests/resources/logsgen.yaml
           kubectl rollout status deployment/log-generator --timeout=300s
 
-      - name: run trace generator
+      - name: Run trace generator
         run: |
           kubectl apply -f tests/resources/tracegen-monitoring.yaml
           kubectl rollout status deployment/trace-gen --timeout=300s
@@ -160,21 +160,16 @@ jobs:
             kubectl logs ds/logzio-monitoring-otel-collector-ds
           fi
 
-      - name: Run linux logs tests
-        id: linux_logs_tests
+      - name: Run logs tests
+        id: logs_tests
         continue-on-error: true
-        if: matrix.environment == 'eks-linux'
         run: |
           go get go.uber.org/zap
-          go test -v ./tests/logs_e2e_test.go ./tests/common.go
-
-      - name: Run fargate logs tests
-        id: fargate_logs_tests
-        continue-on-error: true
-        if: matrix.environment == 'eks-fargate'
-        run: |
-          go get go.uber.org/zap
-          go test -v ./tests/fargate_logs_e2e_test.go ./tests/common.go
+          if [ "${{ matrix.environment }}" == "eks-linux" ]; then
+            go test -v ./tests/logs_e2e_test.go ./tests/common.go
+          elif [ "${{ matrix.environment }}" == "eks-fargate" ]; then
+            go test -v ./tests/fargate_logs_e2e_test.go ./tests/common.go
+          fi
 
       - name: Run metrics tests
         id: metrics_tests
@@ -192,8 +187,7 @@ jobs:
 
       - name: Check test results
         run: |
-          if [ "${{ steps.linux_logs_tests.outcome }}" == "failure" ] || \
-             [ "${{ steps.fargate_logs_tests.outcome }}" == "failure" ] || \
+          if [ "${{ steps.logs_tests.outcome }}" == "failure" ] || \
              [ "${{ steps.metrics_tests.outcome }}" == "failure" ] || \
              [ "${{ steps.traces_tests.outcome }}" == "failure" ]; then
             echo "One or more tests failed"

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -34,7 +34,7 @@ jobs:
           echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> $GITHUB_ENV
           echo "AWS_REGION=us-east-1" >> $GITHUB_ENV
           echo "NUMBER_OF_NODES=3" >> $GITHUB_ENV
-          echo "NODE_TYPE=t3.medium" >> $GITHUB_ENV
+          echo "NODE_TYPE=t3a.large" >> $GITHUB_ENV
           echo "KUBERNETES_ENV=${{ matrix.environment }}" >> $GITHUB_ENV
           echo "LOGZIO_LOGS_API_KEY=${{ secrets.LOGZIO_LOGS_API_KEY }}" >> $GITHUB_ENV
           echo "LOGZIO_METRICS_API_KEY=${{ secrets.LOGZIO_METRICS_API_KEY }}" >> $GITHUB_ENV

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        kubernetes_version: [1.24, 1.25, 1.27, 1.30]
+        kubernetes_version: [1.24, 1.25, 1.27]
         environment: [eks-linux, eks-fargate]
     outputs:
       env_id: ${{ steps.set_env_id.outputs.env_id }}

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -34,7 +34,7 @@ jobs:
           echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> $GITHUB_ENV
           echo "AWS_REGION=us-east-1" >> $GITHUB_ENV
           echo "NUMBER_OF_NODES=3" >> $GITHUB_ENV
-          echo "NODE_TYPE=t3a.large" >> $GITHUB_ENV
+          echo "NODE_TYPE=m5.large" >> $GITHUB_ENV
           echo "KUBERNETES_ENV=${{ matrix.environment }}" >> $GITHUB_ENV
           echo "LOGZIO_LOGS_API_KEY=${{ secrets.LOGZIO_LOGS_API_KEY }}" >> $GITHUB_ENV
           echo "LOGZIO_METRICS_API_KEY=${{ secrets.LOGZIO_METRICS_API_KEY }}" >> $GITHUB_ENV
@@ -102,9 +102,17 @@ jobs:
           echo "Running Helm command: $HELM_CMD"
           eval $HELM_CMD
           
-          
+        
+
+      - name: Wait for pods to be ready
+        run: |
           kubectl rollout status deployment/logzio-monitoring-otel-collector-standalone --timeout=300s
-          kubectl rollout status deployment/logzio-monitoring-otel-collector-spm --timeout=300s          
+          kubectl rollout status deployment/logzio-monitoring-otel-collector-spm --timeout=300s   
+          kubectl rollout status deployment/logzio-monitoring-kube-state-metrics --timeout=300s
+          if [ "${{ matrix.environment }}" == "eks-linux" ]; then
+            kubectl rollout status ds/logzio-monitoring-prometheus-node-exporter --timeout=300s
+            kubectl rollout status ds/logzio-monitoring-otel-collector-ds --timeout=300s
+          fi
 
       - name: Confirm `aws-observability` namespace and configmap are created (fargate)
         if: matrix.environment == 'eks-fargate'
@@ -139,7 +147,15 @@ jobs:
           kubectl rollout status deployment/trace-gen --timeout=300s
 
       - name: Sleep
-        run: sleep 240
+        run: sleep 180
+
+      - name: Get Logs
+        run: |
+          kubectl logs deployment/deployment/logzio-monitoring-otel-collector-standalone
+          kubectl logs deployment/deployment/logzio-monitoring-otel-collector-spm
+          if [ "${{ matrix.environment }}" == "eks-linux" ]; then
+            kubectl logs ds/logzio-monitoring-otel-collector-ds
+          fi
 
       - name: Run linux logs tests
         id: linux_logs_tests

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes_version: [1.24, 1.25, 1.27, 1.30]
+        kubernetes_version: ['1.24', '1.25', '1.27', '1.30']
         environment: [eks-linux, eks-fargate]
     steps:
       - name: Generate random id

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        kubernetes_version: [1.24, 1.25, 1.27]
+        kubernetes_version: [1.30, 1.24, 1.25, 1.27]
         environment: [eks-linux, eks-fargate]
     steps:
       - name: Generate random id

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -151,8 +151,8 @@ jobs:
 
       - name: Get Logs
         run: |
-          kubectl logs deployment/deployment/logzio-monitoring-otel-collector-standalone
-          kubectl logs deployment/deployment/logzio-monitoring-otel-collector-spm
+          kubectl logs deployment/logzio-monitoring-otel-collector-standalone
+          kubectl logs deployment/logzio-monitoring-otel-collector-spm
           if [ "${{ matrix.environment }}" == "eks-linux" ]; then
             kubectl logs ds/logzio-monitoring-otel-collector-ds
           fi

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -27,11 +27,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up AWS credentials
+      - name: Set up credentials
         run: |
           echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> $GITHUB_ENV
           echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> $GITHUB_ENV
           echo "AWS_REGION=us-east-1" >> $GITHUB_ENV
+          echo "NUMBER_OF_NODES=3" >> $GITHUB_ENV
+          echo "KUBERNETES_ENV=${{ matrix.environment }}" >> $GITHUB_ENV
+          echo "LOGZIO_LOGS_API_KEY=${{ secrets.LOGZIO_LOGS_API_KEY }}" >> $GITHUB_ENV
+          echo "LOGZIO_METRICS_API_KEY=${{ secrets.LOGZIO_METRICS_API_KEY }}" >> $GITHUB_ENV
+          echo "LOGZIO_TRACES_API_KEY=${{ secrets.LOGZIO_TRACES_API_KEY }}" >> $GITHUB_ENV
 
       - name: Set up eksctl
         run: |
@@ -42,8 +47,6 @@ jobs:
           sudo mv /tmp/eksctl /usr/local/bin
 
       - name: Provision Cluster
-        env:
-          NUMBER_OF_NODES: 3
         run: |
           if [ "${{ matrix.environment }}" == "eks-linux" ]; then
             eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} \
@@ -114,9 +117,6 @@ jobs:
         id: linux_logs_tests
         continue-on-error: true
         if: matrix.environment == 'eks-linux'
-        env:
-          KUBERNETES_ENV: ${{ matrix.environment }}
-          LOGZIO_LOGS_API_KEY: ${{ secrets.LOGZIO_LOGS_API_KEY }}
         run: |
           go get go.uber.org/zap
           go test -v ./tests/logs_e2e_test.go ./tests/common.go
@@ -125,9 +125,6 @@ jobs:
         id: fargate_logs_tests
         continue-on-error: true
         if: matrix.environment == 'eks-fargate'
-        env:
-          KUBERNETES_ENV: ${{ matrix.environment }}
-          LOGZIO_LOGS_API_KEY: ${{ secrets.LOGZIO_LOGS_API_KEY }}
         run: |
           go get go.uber.org/zap
           go test -v ./tests/fargate_logs_e2e_test.go ./tests/common.go
@@ -135,9 +132,6 @@ jobs:
       - name: Run metrics tests
         id: metrics_tests
         continue-on-error: true
-        env:
-          KUBERNETES_ENV: ${{ matrix.environment }}
-          LOGZIO_METRICS_API_KEY: ${{ secrets.LOGZIO_METRICS_API_KEY }}
         run: |
           go get go.uber.org/zap
           go test -v ./tests/metrics_e2e_test.go ./tests/common.go   
@@ -145,9 +139,6 @@ jobs:
       - name: Run traces tests
         id: traces_tests
         continue-on-error: true
-        env:
-          KUBERNETES_ENV: ${{ matrix.environment }}
-          LOGZIO_TRACES_API_KEY: ${{ secrets.LOGZIO_TRACES_API_KEY }}
         run: |
           go get go.uber.org/zap
           go test -v ./tests/traces_e2e_test.go ./tests/common.go

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes_version: [1.24]
+        kubernetes_version: [1.24, 1.25, 1.27]
         environment: [eks-linux, eks-fargate]
     steps:
       - name: Generate random id

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> $GITHUB_ENV
           echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> $GITHUB_ENV
-          echo "AWS_REGION=us-west-1" >> $GITHUB_ENV
+          echo "AWS_REGION=us-east-1" >> $GITHUB_ENV
 
       - name: Set up eksctl
         run: |

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - name: Generate random id
         id: random_id
-        run: echo "::set-output name=rand::$(echo $RANDOM)"
+        run: echo "rand=$(echo $RANDOM)" >> $GITHUB_ENV
 
       - name: Set ENV_ID
         id: set_env_id
         run: |
-          echo "ENV_ID=monitoring-test-run-${{ steps.random_id.outputs.rand }}-${{ matrix.environment }}" >> $GITHUB_ENV
+          echo "ENV_ID=monitoring-test-run-${{ env.rand }}-${{ matrix.environment }}" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -51,13 +51,14 @@ jobs:
 
       - name: Provision Cluster
         run: |
+          K8S_VERSION=${{ matrix.kubernetes_version }}
           if [ "${{ matrix.environment }}" == "eks-linux" ]; then
             eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} \
-              --version ${{ matrix.kubernetes_version }} --nodes ${{ env.NUMBER_OF_NODES }} \
+              --version $K8S_VERSION --nodes ${{ env.NUMBER_OF_NODES }} \
               --node-type ${{ env.NODE_TYPE }} --with-oidc
           elif [ "${{ matrix.environment }}" == "eks-fargate" ]; then
             eksctl create cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }} \
-              --version ${{ matrix.kubernetes_version }} --fargate
+              --version $K8S_VERSION --fargate
           fi
 
       - name: Update kubeconfig

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes_version: [1.24, 1.25, 1.27]
+        kubernetes_version: [1.24, 1.25, 1.27, 1.30]
         environment: [eks-linux, eks-fargate]
     steps:
       - name: Generate random id

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        kubernetes_version: [1.30, 1.24, 1.25, 1.27]
+        kubernetes_version: [1.24, 1.25, 1.27]
         environment: [eks-linux, eks-fargate]
     steps:
       - name: Generate random id

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -7,15 +7,13 @@ on:
     paths:
       - 'charts/logzio-monitoring/**'
 jobs:
-  setup-cluster:
-    name: Set up EKS Cluster
+  eks-e2e-test:
+    name: EKS e2e Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
         kubernetes_version: [1.24, 1.25, 1.27]
         environment: [eks-linux, eks-fargate]
-    outputs:
-      env_id: ${{ steps.set_env_id.outputs.env_id }}
     steps:
       - name: Generate random id
         id: random_id
@@ -25,7 +23,6 @@ jobs:
         id: set_env_id
         run: |
           echo "ENV_ID=monitoring-test-run-${{ steps.random_id.outputs.rand }}-${{ matrix.environment }}" >> $GITHUB_ENV
-          echo "::set-output name=env_id::monitoring-test-run-${{ steps.random_id.outputs.rand }}-${{ matrix.environment }}"
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -110,10 +107,63 @@ jobs:
           kubectl apply -f tests/resources/tracegen-monitoring.yaml
           kubectl rollout status deployment/trace-gen --timeout=300s
 
-      - name: sleep
+      - name: Sleep
         run: sleep 180
 
+      - name: Run linux logs tests
+        id: linux_logs_tests
+        continue-on-error: true
+        if: matrix.environment == 'eks-linux'
+        env:
+          KUBERNETES_ENV: ${{ matrix.environment }}
+          LOGZIO_LOGS_API_KEY: ${{ secrets.LOGZIO_LOGS_API_KEY }}
+        run: |
+          go get go.uber.org/zap
+          go test -v ./tests/logs_e2e_test.go ./tests/common.go
+
+      - name: Run fargate logs tests
+        id: fargate_logs_tests
+        continue-on-error: true
+        if: matrix.environment == 'eks-fargate'
+        env:
+          KUBERNETES_ENV: ${{ matrix.environment }}
+          LOGZIO_LOGS_API_KEY: ${{ secrets.LOGZIO_LOGS_API_KEY }}
+        run: |
+          go get go.uber.org/zap
+          go test -v ./tests/fargate_logs_e2e_test.go ./tests/common.go
+
+      - name: Run metrics tests
+        id: metrics_tests
+        continue-on-error: true
+        env:
+          KUBERNETES_ENV: ${{ matrix.environment }}
+          LOGZIO_METRICS_API_KEY: ${{ secrets.LOGZIO_METRICS_API_KEY }}
+        run: |
+          go get go.uber.org/zap
+          go test -v ./tests/metrics_e2e_test.go ./tests/common.go   
+
+      - name: Run traces tests
+        id: traces_tests
+        continue-on-error: true
+        env:
+          KUBERNETES_ENV: ${{ matrix.environment }}
+          LOGZIO_TRACES_API_KEY: ${{ secrets.LOGZIO_TRACES_API_KEY }}
+        run: |
+          go get go.uber.org/zap
+          go test -v ./tests/traces_e2e_test.go ./tests/common.go
+
+      - name: Check test results
+        run: |
+          if [ "${{ steps.linux_logs_tests.outcome }}" == "failure" ] || \
+             [ "${{ steps.fargate_logs_tests.outcome }}" == "failure" ] || \
+             [ "${{ steps.metrics_tests.outcome }}" == "failure" ] || \
+             [ "${{ steps.traces_tests.outcome }}" == "failure" ]; then
+            echo "One or more tests failed"
+            exit 1
+          fi
+
       - name: Uninstall Helm Chart
+        if: always()
         run: |
           helm uninstall logzio-monitoring
 
@@ -122,56 +172,5 @@ jobs:
         run: |
           eksctl delete cluster --name ${{ env.ENV_ID }}-${{ matrix.environment }} --region ${{ env.AWS_REGION }}
 
-  run-logs-tests:
-    name: Run Logs Tests
-    runs-on: ubuntu-latest
-    needs: setup-cluster
-    env:
-      ENV_ID: ${{ needs.setup-cluster.outputs.env_id }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
 
-      - name: Run Go Logs Tests
-        env:
-          KUBERNETES_ENV: ${{ matrix.environment }}
-          LOGZIO_LOGS_API_KEY: ${{ secrets.LOGZIO_LOGS_API_KEY }}
-        run: |
-          go get go.uber.org/zap
-          go test -v ./tests/logs_e2e_test.go ./tests/common.go
 
-  run-metrics-tests:
-    name: Run Metrics Tests
-    runs-on: ubuntu-latest
-    needs: setup-cluster
-    env:
-      ENV_ID: ${{ needs.setup-cluster.outputs.env_id }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Run Go Metrics Tests
-        env:
-          KUBERNETES_ENV: ${{ matrix.environment }}
-          LOGZIO_METRICS_API_KEY: ${{ secrets.LOGZIO_METRICS_API_KEY }}
-        run: |
-          go get go.uber.org/zap
-          go test -v ./tests/metrics_e2e_test.go ./tests/common.go   
-
-  run-traces-tests:
-    name: Run Traces Tests
-    runs-on: ubuntu-latest
-    needs: setup-cluster
-    env:
-      ENV_ID: ${{ needs.setup-cluster.outputs.env_id }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Run Go Traces Tests
-        env:
-          KUBERNETES_ENV: ${{ matrix.environment }}
-          LOGZIO_TRACES_API_KEY: ${{ secrets.LOGZIO_TRACES_API_KEY }}
-        run: |
-          go get go.uber.org/zap
-          go test -v ./tests/traces_e2e_test.go ./tests/common.go

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -99,7 +99,9 @@ jobs:
           
           HELM_CMD="$HELM_CMD logzio-monitoring ."
           
+          echo "Running Helm command: $HELM_CMD"
           eval $HELM_CMD
+          
           
           kubectl rollout status deployment/logzio-monitoring-otel-collector-standalone --timeout=300s
           kubectl rollout status deployment/logzio-monitoring-otel-collector-spm --timeout=300s          

--- a/.github/workflows/logzio-telemetry-test.yaml
+++ b/.github/workflows/logzio-telemetry-test.yaml
@@ -1,4 +1,4 @@
-name: Test Logzio Telemetry Helm Chart on Kind Kubernetes Environment
+name: Test `logzio-telemetry` chart
 
 on:
   pull_request:

--- a/.github/workflows/logzio-telemetry-test.yaml
+++ b/.github/workflows/logzio-telemetry-test.yaml
@@ -64,7 +64,7 @@ jobs:
           kubectl rollout status deployment/logzio-k8s-telemetry-otel-collector-standalone --timeout=300s
           kubectl rollout status deployment/logzio-k8s-telemetry-otel-collector-spm --timeout=300s
 
-      - name: run trace generator
+      - name: Run trace generator
         run: |
           kubectl apply -f tests/resources/tracegen.yaml
           kubectl rollout status deployment/trace-gen --timeout=300s

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 6.0.7
+version: 6.0.7-trigger
 
 
 

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -5,6 +5,7 @@ type: application
 version: 6.1.0
 
 
+
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 6.0.8
+version: 6.0.9-trigger
 
 
 sources:
@@ -29,7 +29,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
   - name: logzio-logs-collector
-    version: "1.0.7"
+    version: "1.0.8"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
 maintainers:

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 6.0.9
+version: 6.1.0
 
 
 sources:
@@ -29,7 +29,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
   - name: logzio-logs-collector
-    version: "1.0.8"
+    version: "1.0.9"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
 maintainers:

--- a/tests/fargate_logs_e2e_test.go
+++ b/tests/fargate_logs_e2e_test.go
@@ -1,0 +1,96 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"go.uber.org/zap"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+)
+
+type FargateLogResponse struct {
+	Hits struct {
+		Total int `json:"total"`
+		Hits  []struct {
+			Source struct {
+				LogLevel   string `json:"log_level"`
+				Kubernetes struct {
+					ContainerName     string `json:"container_name"`
+					ContainerHash     string `json:"container_hash"`
+					Host              string `json:"host"`
+					PodID             string `json:"pod_id"`
+					ContainerImageTag string `json:"container_image"`
+					PodName           string `json:"pod_name"`
+					NamespaceName     string `json:"namespace_name"`
+				} `json:"kubernetes"`
+			} `json:"_source"`
+		} `json:"hits"`
+	} `json:"hits"`
+}
+
+func TestLogzioMonitoringFargateLogs(t *testing.T) {
+	logsApiKey := os.Getenv("LOGZIO_LOGS_API_KEY")
+	if logsApiKey == "" {
+		t.Fatalf("LOGZIO_LOGS_API_KEY environment variable not set")
+	}
+
+	logResponse, err := fetchFargateLogs(logsApiKey)
+	if err != nil {
+		t.Fatalf("Failed to fetch logs: %v", err)
+	}
+
+	if logResponse.Hits.Total == 0 {
+		t.Errorf("No logs found")
+	}
+
+	for _, hit := range logResponse.Hits.Hits {
+		kubernetes := hit.Source.Kubernetes
+		if kubernetes.ContainerImageTag == "" || kubernetes.ContainerName == "" || kubernetes.NamespaceName == "" || kubernetes.PodName == "" || kubernetes.PodID == "" || kubernetes.Host == "" {
+			logger.Error("Missing log fields", zap.Any("log", hit))
+			t.Errorf("Missing log fields")
+			break
+		}
+	}
+}
+
+func fetchFargateLogs(logsApiKey string) (*FargateLogResponse, error) {
+	url := fmt.Sprintf("%s/search", BaseLogzioApiUrl)
+	client := &http.Client{}
+	envID := os.Getenv("ENV_ID")
+	query := fmt.Sprintf("type:%s AND kubernetes.container_name:random-logger", envID)
+	formattedQuery := formatQuery(query)
+	logger.Info("sending api request", zap.String("url", url), zap.String("query", query))
+	req, err := http.NewRequest("POST", url, bytes.NewBufferString(formattedQuery))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-TOKEN", logsApiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var logResponse FargateLogResponse
+	err = json.Unmarshal(body, &logResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &logResponse, nil
+}

--- a/tests/fargate_logs_e2e_test.go
+++ b/tests/fargate_logs_e2e_test.go
@@ -16,16 +16,14 @@ type FargateLogResponse struct {
 		Total int `json:"total"`
 		Hits  []struct {
 			Source struct {
-				LogLevel   string `json:"log_level"`
-				Kubernetes struct {
-					ContainerName     string `json:"container_name"`
-					ContainerHash     string `json:"container_hash"`
-					Host              string `json:"host"`
-					PodID             string `json:"pod_id"`
-					ContainerImageTag string `json:"container_image"`
-					PodName           string `json:"pod_name"`
-					NamespaceName     string `json:"namespace_name"`
-				} `json:"kubernetes"`
+				LogLevel          string `json:"log_level"`
+				ContainerName     string `json:"kubernetes_container_name"`
+				ContainerHash     string `json:"kubernetes_container_hash"`
+				Host              string `json:"kubernetes_host"`
+				PodID             string `json:"kubernetes_pod_id"`
+				ContainerImageTag string `json:"kubernetes_container_image"`
+				PodName           string `json:"kubernetes_pod_name"`
+				NamespaceName     string `json:"kubernetes_namespace_name"`
 			} `json:"_source"`
 		} `json:"hits"`
 	} `json:"hits"`
@@ -47,8 +45,8 @@ func TestLogzioMonitoringFargateLogs(t *testing.T) {
 	}
 
 	for _, hit := range logResponse.Hits.Hits {
-		kubernetes := hit.Source.Kubernetes
-		if kubernetes.ContainerImageTag == "" || kubernetes.ContainerName == "" || kubernetes.NamespaceName == "" || kubernetes.PodName == "" || kubernetes.PodID == "" || kubernetes.Host == "" {
+		log := hit.Source
+		if log.ContainerImageTag == "" || log.ContainerName == "" || log.NamespaceName == "" || log.PodName == "" || log.PodID == "" || log.Host == "" {
 			logger.Error("Missing log fields", zap.Any("log", hit))
 			t.Errorf("Missing log fields")
 			break

--- a/tests/fargate_logs_e2e_test.go
+++ b/tests/fargate_logs_e2e_test.go
@@ -60,7 +60,7 @@ func fetchFargateLogs(logsApiKey string) (*FargateLogResponse, error) {
 	url := fmt.Sprintf("%s/search", BaseLogzioApiUrl)
 	client := &http.Client{}
 	envID := os.Getenv("ENV_ID")
-	query := fmt.Sprintf("type:%s AND kubernetes.container_name:random-logger", envID)
+	query := fmt.Sprintf("type:%s AND kubernetes.container_name:log-generator", envID)
 	formattedQuery := formatQuery(query)
 	logger.Info("sending api request", zap.String("url", url), zap.String("query", query))
 	req, err := http.NewRequest("POST", url, bytes.NewBufferString(formattedQuery))

--- a/tests/fargate_logs_e2e_test.go
+++ b/tests/fargate_logs_e2e_test.go
@@ -58,7 +58,7 @@ func fetchFargateLogs(logsApiKey string) (*FargateLogResponse, error) {
 	url := fmt.Sprintf("%s/search", BaseLogzioApiUrl)
 	client := &http.Client{}
 	envID := os.Getenv("ENV_ID")
-	query := fmt.Sprintf("type:%s AND kubernetes.container_name:log-generator", envID)
+	query := fmt.Sprintf("type:%s AND kubernetes_container_name:log-generator", envID)
 	formattedQuery := formatQuery(query)
 	logger.Info("sending api request", zap.String("url", url), zap.String("query", query))
 	req, err := http.NewRequest("POST", url, bytes.NewBufferString(formattedQuery))

--- a/tests/logs_e2e_test.go
+++ b/tests/logs_e2e_test.go
@@ -58,7 +58,7 @@ func fetchLogs(logsApiKey string) (*LogResponse, error) {
 	url := fmt.Sprintf("%s/search", BaseLogzioApiUrl)
 	client := &http.Client{}
 	envID := os.Getenv("ENV_ID")
-	query := fmt.Sprintf("env_id:%s AND type:agent-k8s AND k8s_deployment_name:log-generator", envID)
+	query := fmt.Sprintf("env_id:%s AND type:%s AND k8s_deployment_name:log-generator", envID, envID)
 	formattedQuery := formatQuery(query)
 	logger.Info("sending api request", zap.String("url", url), zap.String("query", query))
 	req, err := http.NewRequest("POST", url, bytes.NewBufferString(formattedQuery))

--- a/tests/metrics_e2e_test.go
+++ b/tests/metrics_e2e_test.go
@@ -39,6 +39,9 @@ func TestContainerMetrics(t *testing.T) {
 }
 
 func TestInfrastructureMetrics(t *testing.T) {
+	if os.Getenv("KUBERNETES_ENV") == "eks-fargate" {
+		t.Skip("Skipping infrastructure metrics test")
+	}
 	requiredMetrics := map[string][]string{
 		"kube_pod_status_phase":                    {"p8s_logzio_name", "namespace", "pod", "phase", "uid"},
 		"kube_pod_info":                            {"p8s_logzio_name", "namespace", "host_ip", "node", "pod"},
@@ -57,6 +60,28 @@ func TestInfrastructureMetrics(t *testing.T) {
 		"kube_node_created":                        {"p8s_logzio_name", "node"},
 		"node_filesystem_avail_bytes":              {"p8s_logzio_name", "instance", "kubernetes_node"},
 		"node_filesystem_size_bytes":               {"p8s_logzio_name", "instance", "kubernetes_node"},
+		"kube_replicaset_owner":                    {"p8s_logzio_name", "namespace", "owner_kind", "owner_name", "replicaset"},
+		"kube_deployment_created":                  {"p8s_logzio_name", "namespace", "deployment"},
+		"kube_deployment_status_condition":         {"p8s_logzio_name", "namespace", "deployment", "status"},
+	}
+	envId := os.Getenv("ENV_ID")
+	query := fmt.Sprintf(`{env_id='%s'}`, envId)
+	testMetrics(t, requiredMetrics, query)
+}
+
+func TestFargateMetrics(t *testing.T) {
+	if os.Getenv("KUBERNETES_ENV") != "eks-fargate" {
+		t.Skip("Skipping Fargate metrics test")
+	}
+	requiredMetrics := map[string][]string{
+		"kube_pod_status_phase":                    {"p8s_logzio_name", "namespace", "pod", "phase", "uid"},
+		"kube_pod_info":                            {"p8s_logzio_name", "namespace", "host_ip", "pod"},
+		"kube_pod_container_resource_limits":       {"p8s_logzio_name", "namespace", "pod", "resource"},
+		"kube_pod_container_info":                  {"p8s_logzio_name", "namespace", "pod"},
+		"kube_pod_created":                         {"p8s_logzio_name", "namespace", "pod"},
+		"kube_pod_owner":                           {"p8s_logzio_name", "namespace", "pod", "owner_kind", "owner_name"},
+		"kube_pod_container_status_restarts_total": {"p8s_logzio_name", "namespace", "pod"},
+		"kube_pod_status_reason":                   {"p8s_logzio_name", "namespace", "pod", "reason"},
 		"kube_replicaset_owner":                    {"p8s_logzio_name", "namespace", "owner_kind", "owner_name", "replicaset"},
 		"kube_deployment_created":                  {"p8s_logzio_name", "namespace", "deployment"},
 		"kube_deployment_status_condition":         {"p8s_logzio_name", "namespace", "deployment", "status"},

--- a/tests/resources/logsgen.yaml
+++ b/tests/resources/logsgen.yaml
@@ -15,7 +15,7 @@ spec:
         app: log-generator
     spec:
       containers:
-        - name: random-logger
+        - name: log-generator
           image: chentex/random-logger:latest
           args:
             - "100"


### PR DESCRIPTION
- Add EKS fargate deployment 
- Add EKS fargate tests
- run the workflow with different Kubernetes versions :  `[1.24, 1.25, 1.27, 1.30]`
- Change workflow structure and split to multiple jobs