### PR TITLE
Release `logzio-logs-collector` v1.0.7

### DIFF
--- a/charts/logzio-logs-collector/Chart.yaml
+++ b/charts/logzio-logs-collector/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: logzio-logs-collector
-version: 1.0.6
+version: 1.0.7
 description: kubernetes logs collection agent for logz.io based on opentelemetry collector
 type: application
 home: https://logz.io/
 maintainers:
   - name: yotam loewenbach
     email: yotam.loewenbach@logz.io
-appVersion: 0.103.0
+appVersion: 0.107.0

--- a/charts/logzio-logs-collector/README.md
+++ b/charts/logzio-logs-collector/README.md
@@ -142,6 +142,10 @@ Multi line logs configuration
 The collector supports by default various log formats (including multiline logs) such as `CRI-O` `CRI-Containerd` `Docker` formats. You can configure the chart to parse custom multiline logs pattern according to your needs, please read [Customizing Multiline Log Handling](./examples/multiline.md) guide for more details.
 
 ## Change log
+* 1.0.7
+  - Upgrade `otel/opentelemetry-collector-contrib` image to v0.107.0
+    - Adjusted health check extension endpoint
+  - In case `json_parser` fails, send the log anyway and print the error only in debug mode.
 * 1.0.6
   - Added `varlogcontainers` volume and volume mounts
   - Added new `container` operator instead of complex operator sequence

--- a/charts/logzio-logs-collector/values.yaml
+++ b/charts/logzio-logs-collector/values.yaml
@@ -54,7 +54,8 @@ config:
       headers:
         user-agent: "{{ .Chart.Name }}-{{ .Chart.Version }}-helm"
   extensions:
-    health_check: {}
+    health_check:
+      endpoint: ${env:MY_POD_IP}:13133
     file_storage:
       directory: /var/lib/otelcol
   processors:

--- a/charts/logzio-logs-collector/values.yaml
+++ b/charts/logzio-logs-collector/values.yaml
@@ -146,6 +146,7 @@ config:
       # conditional json parser
       - type: json_parser
         id: json
+        on_error: send_quiet
         parse_from: body
         if: 'body matches "^{.*}$"'
       # multiline parsers. add more `type: recombine` operators for custom multiline formats


### PR DESCRIPTION
  - Upgrade `otel/opentelemetry-collector-contrib` image to v0.107.0
    - Adjusted health check extension endpoint
  - In case `json_parser` fails, send the log anyway and print the error only in debug mode.