### PR TITLE
logzio-logs-collector 1.0.8

### DIFF
--- a/charts/logzio-logs-collector/Chart.yaml
+++ b/charts/logzio-logs-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: logzio-logs-collector
-version: 1.0.7
+version: 1.0.8
 description: kubernetes logs collection agent for logz.io based on opentelemetry collector
 type: application
 home: https://logz.io/

--- a/charts/logzio-logs-collector/README.md
+++ b/charts/logzio-logs-collector/README.md
@@ -142,6 +142,9 @@ Multi line logs configuration
 The collector supports by default various log formats (including multiline logs) such as `CRI-O` `CRI-Containerd` `Docker` formats. You can configure the chart to parse custom multiline logs pattern according to your needs, please read [Customizing Multiline Log Handling](./examples/multiline.md) guide for more details.
 
 ## Change log
+* 1.0.8
+  - Bug-fix:
+    - Remove comment from `_helpers.tpl` template that breaks aws-logging configmap
 * 1.0.7
   - Upgrade `otel/opentelemetry-collector-contrib` image to v0.107.0
     - Adjusted health check extension endpoint

--- a/charts/logzio-logs-collector/templates/_helpers.tpl
+++ b/charts/logzio-logs-collector/templates/_helpers.tpl
@@ -200,7 +200,7 @@ listener-eu.logz.io
 {{- else if eq $region "uk" -}}
 listener-uk.logz.io
 {{- else -}}
-listener.logz.io  # Default to US if no match
+listener.logz.io
 {{- end -}}
 {{- end }}
 


### PR DESCRIPTION
bug-fix:
- Remove comment from `_helpers.tpl` template that breaks aws-logging configmap