### PR TITLE
Release/logzio monitoring 6.0.9

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 6.0.8
+version: 6.0.9
 
 
 
@@ -30,7 +30,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
   - name: logzio-logs-collector
-    version: "1.0.7"
+    version: "1.0.8"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
 maintainers:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -224,6 +224,9 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **6.0.9**:
+  - Upgrade `logzio-logs-collector` chart to `v1.0.8`
+    - Bug-fix: Remove comment from `_helpers.tpl` template that breaks `aws-logging` configmap
 - **6.0.8**:
   - Upgrade `logzio-logs-collector` chart to `v1.0.7`
     - Upgrade `otel/opentelemetry-collector-contrib` image to v0.107.0


### PR DESCRIPTION
- **6.0.9**:
  - Upgrade `logzio-logs-collector` chart to `v1.0.8`
    - Bug-fix: Remove comment from `_helpers.tpl` template that breaks `aws-logging` configmap