### PR TITLE
Release/logzio logs collector 1.0.9

### DIFF
--- a/charts/logzio-logs-collector/Chart.yaml
+++ b/charts/logzio-logs-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: logzio-logs-collector
-version: 1.0.8
+version: 1.0.9
 description: kubernetes logs collection agent for logz.io based on opentelemetry collector
 type: application
 home: https://logz.io/

--- a/charts/logzio-logs-collector/README.md
+++ b/charts/logzio-logs-collector/README.md
@@ -142,6 +142,14 @@ Multi line logs configuration
 The collector supports by default various log formats (including multiline logs) such as `CRI-O` `CRI-Containerd` `Docker` formats. You can configure the chart to parse custom multiline logs pattern according to your needs, please read [Customizing Multiline Log Handling](./examples/multiline.md) guide for more details.
 
 ## Change log
+* 1.0.9
+  - **EKS fargate Breaking changes**:
+   - Add `nest` filters to remove dots from kubernetes metadata keys.
+    Changes in fields names:
+    - `kubernetes.*` -> `kubernetes_*`
+    - `kubernetes.labels.*` -> `kubernetes_labels_*`
+    - `kubernetes.annotations.*` -> `kubernetes_annotations_*`
+
 * 1.0.8
   - Bug-fix:
     - Remove comment from `_helpers.tpl` template that breaks aws-logging configmap

--- a/charts/logzio-logs-collector/README.md
+++ b/charts/logzio-logs-collector/README.md
@@ -141,6 +141,25 @@ Multi line logs configuration
 -----------------------------
 The collector supports by default various log formats (including multiline logs) such as `CRI-O` `CRI-Containerd` `Docker` formats. You can configure the chart to parse custom multiline logs pattern according to your needs, please read [Customizing Multiline Log Handling](./examples/multiline.md) guide for more details.
 
+Log collection in eks fargate environemnt
+-----------------------------
+You can use the `fargateLogRouter.enabled` value to enable log collection in eks fargate environemnt via fluentbit log-router
+```sh
+    helm install logzio-logs-collector -n monitoring \
+    --set enabled=true \
+    --set secrets.logzioLogsToken=<<token>> \
+    --set secrets.logzioRegion=<<region>> \
+    --set secrets.env_id=<<env_id>> \
+    --set secrets.logType=<<logType>> \
+    --set fargateLogRouter.enabled="true" \
+    logzio-helm/logzio-logs-collector
+```
+### Kubernetes metadata fields naming changes in eks fargate environemnt >= `1.0.9`
+Changes in fields names:
+  - `kubernetes.*` -> `kubernetes_*`
+  - `kubernetes.labels.*` -> `kubernetes_labels_*`
+  - `kubernetes.annotations.*` -> `kubernetes_annotations_*`
+  
 ## Change log
 * 1.0.9
   - **EKS fargate Breaking changes**:

--- a/charts/logzio-logs-collector/templates/fargate-logging-configmap.yaml
+++ b/charts/logzio-logs-collector/templates/fargate-logging-configmap.yaml
@@ -35,6 +35,25 @@ data:
       Match *
       Condition Key_value_does_not_match message (?i)(error|failure|failed|exception|panic|warn|warning)
       Add log_level INFO
+    [FILTER]
+      Name nest
+      Match *
+      Operation lift
+      Nested_under kubernetes
+      Add_prefix kubernetes_
+    [FILTER]
+      Name nest
+      Match *
+      Operation lift
+      Nested_under kubernetes_labels
+      Add_prefix kubernetes_labels_
+    [FILTER]
+      Name nest
+      Match *
+      Operation lift
+      Nested_under kubernetes_annotations
+      Add_prefix kubernetes_annotations_
+      
   output.conf: |
     [OUTPUT]
       Name  es


### PR DESCRIPTION
* 1.0.9
  - **EKS fargate Breaking changes**:
   - Add `nest` filters to remove dots from kubernetes metadata keys.
    Changes in fields names:
    - `kubernetes.*` -> `kubernetes_*`
    - `kubernetes.labels.*` -> `kubernetes_labels_*`
    - `kubernetes.annotations.*` -> `kubernetes_annotations_*`