### PR TITLE
Release/logzio monitoring 6.1.0

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 6.0.9
+version: 6.1.0
 
 
 
@@ -30,7 +30,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
   - name: logzio-logs-collector
-    version: "1.0.8"
+    version: "1.0.9"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
 maintainers:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -169,7 +169,11 @@ Then use `kubectl port-forward` to accsess the user intefrace in your browser:
 ```shell
 kubectl port-forward svc/ezkonnect-ui -n monitoring 31032:31032
 ```
-
+### Changes in kubernetes metadate fields names from version 6.1.0
+Changes in field names (replacing dots with underscore):
+  - `kubernetes.*` -> `kubernetes_*`
+  - `kubernetes.labels.*` -> `kubernetes_labels_*`
+  - `kubernetes.annotations.*` -> `kubernetes_annotations_*`
 
 ### Handling image pull rate limit
 
@@ -224,6 +228,14 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **6.1.0**:
+  - Upgrade `logzio-logs-collector` chart to `v1.0.9`
+    - EKS fargate Breaking changes:
+      - Add nest filters to remove dots from kubernetes metadata keys. 
+      - Changes in fields names:
+        - `kubernetes.*` -> `kubernetes_*`
+        - `kubernetes.labels.*` -> `kubernetes_labels_*`
+        - `kubernetes.annotations.*` -> `kubernetes_annotations_*`
 - **6.0.9**:
   - Upgrade `logzio-logs-collector` chart to `v1.0.8`
     - Bug-fix: Remove comment from `_helpers.tpl` template that breaks `aws-logging` configmap


### PR DESCRIPTION
- **6.1.0**:
  - Upgrade `logzio-logs-collector` chart to `v1.0.9`
    - EKS fargate Breaking changes:
      - Add nest filters to remove dots from kubernetes metadata keys. 
      - Changes in fields names:
        - `kubernetes.*` -> `kubernetes_*`
        - `kubernetes.labels.*` -> `kubernetes_labels_*`
        - `kubernetes.annotations.*` -> `kubernetes_annotations_*`