### PR TITLE
Release/logzio monitoring 6.1.1

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 6.1.0
+version: 6.1.1
 
 
 
@@ -18,7 +18,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy
-    version: "0.3.3"
+    version: "0.3.4"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: securityReport.enabled
   - name: opencost

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -229,7 +229,7 @@ There are two possible approaches to the upgrade you can choose from:
 
 ## Changelog
 - **6.1.1**:
-	- Upgrade `logzio-trivy` chart to `v0.3.4`
+  - Upgrade `logzio-trivy` chart to `v0.3.4`
 - **6.1.0**:
   - Upgrade `logzio-logs-collector` chart to `v1.0.9`
     - EKS fargate Breaking changes:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -228,6 +228,8 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **6.1.1**:
+	- Upgrade `logzio-trivy` chart to `v0.3.4`
 - **6.1.0**:
   - Upgrade `logzio-logs-collector` chart to `v1.0.9`
     - EKS fargate Breaking changes:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -230,6 +230,7 @@ There are two possible approaches to the upgrade you can choose from:
 ## Changelog
 - **6.1.1**:
   - Upgrade `logzio-trivy` chart to `v0.3.4`
+	- Bump Trivy-Operator version to `0.24.1`.
 - **6.1.0**:
   - Upgrade `logzio-logs-collector` chart to `v1.0.9`
     - EKS fargate Breaking changes:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -230,7 +230,7 @@ There are two possible approaches to the upgrade you can choose from:
 ## Changelog
 - **6.1.1**:
   - Upgrade `logzio-trivy` chart to `v0.3.4`
-	- Bump Trivy-Operator version to `0.24.1`.
+    - Bump Trivy-Operator version to `0.24.1`.
 - **6.1.0**:
   - Upgrade `logzio-logs-collector` chart to `v1.0.9`
     - EKS fargate Breaking changes:


### PR DESCRIPTION
- 6.1.1
  - Upgrade `logzio-trivy` chart to `v0.3.4`
	- Bump Trivy-Operator version to `0.24.1`.