### PR TITLE
Release `logzio-monitoring` v6.1.2

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 6.1.1
+version: 6.1.2
 
 
 
@@ -10,11 +10,11 @@ sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: logzio-fluentd
-    version: "0.30.1"
+    version: "0.30.2"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "4.2.7"
+    version: "4.2.8"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy
@@ -26,7 +26,7 @@ dependencies:
     repository: "https://opencost.github.io/opencost-helm-chart"
     condition: finops.enabled
   - name: logzio-k8s-events
-    version: "0.0.6"
+    version: "0.0.7"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
   - name: logzio-logs-collector

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -228,6 +228,14 @@ There are two possible approaches to the upgrade you can choose from:
 
 
 ## Changelog
+- **6.1.2**:
+  - Upgrade `logzio-k8s-events` chart to `v0.0.7`
+	- Remove default resources `limits`
+  - Upgrade `logzio-k8s-telemetry` chart to `v4.2.8`
+	- Upgrade `otel/opentelemetry-collector-contrib` image to `v0.108.0`
+	- Remove default resources `limits`
+  - Upgrade `logzio-fluentd` chart to `v0.30.2`
+	- Remove default resources `limits`
 - **6.1.1**:
   - Upgrade `logzio-trivy` chart to `v0.3.4`
     - Bump Trivy-Operator version to `0.24.1`.


### PR DESCRIPTION
  - Upgrade `logzio-k8s-events` chart to `v0.0.7`
	- Remove default resources `limits`
  - Upgrade `logzio-k8s-telemetry` chart to `v4.2.8`
	- Upgrade `otel/opentelemetry-collector-contrib` image to `v0.108.0`
	- Remove default resources `limits`
  - Upgrade `logzio-fluentd` chart to `v0.30.2`
	- Remove default resources `limits`