### PR TITLE
[RELEASE] Update API Fetcher Image to `0.2.2`

### DIFF
--- a/charts/logzio-api-fetcher/Chart.yaml
+++ b/charts/logzio-api-fetcher/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: logzio-api-fetcher
 description: Helm chart for deploying the Logz.io API Fetcher
 type: application
-version: 1.0.1
-appVersion: "0.2.0"
+version: 1.0.2
+appVersion: "0.2.2"
 maintainers:
   - name: yotamloe
     email: yotam.loewenbach@logz.io

--- a/charts/logzio-api-fetcher/README.md
+++ b/charts/logzio-api-fetcher/README.md
@@ -369,6 +369,8 @@ oauth_apis:
 
 ## Changelog:
 
+- **1.0.2**:
+  - Update api fetcher version to 0.2.2
 - **1.0.1**:
   - Update api fetcher version to 0.2.0
 - **1.0.0**:

--- a/charts/logzio-api-fetcher/templates/deployment.yaml
+++ b/charts/logzio-api-fetcher/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
               mountPath: /app/src/shared
       containers:
         - name: logzio-api-fetcher
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: config-volume

--- a/charts/logzio-api-fetcher/values.yaml
+++ b/charts/logzio-api-fetcher/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: logzio/logzio-api-fetcher
-  tag: 0.2.0
+  tag: 0.2.2
   pullPolicy: IfNotPresent
 
 # Custom configuration section for logzio-api-fetcher


### PR DESCRIPTION
## Description 

- upgrade api fetcher chart to use version 0.2.2 of the api fetcher image
- add image tag default fallback to be `.Config.AppVersion `

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
