### PR TITLE
Release `promtheus-alerts-migrator` chart to`v2.0.3`

### DIFF
--- a/charts/prometheus-alerts-migrator/Chart.yaml
+++ b/charts/prometheus-alerts-migrator/Chart.yaml
@@ -4,9 +4,9 @@ description: This Helm chart serves as a Kubernetes controller that automates th
 
 type: application
 
-version: 2.0.2
+version: 2.0.3
 
-appVersion: "1.0.3"
+appVersion: "v1.1.0"
 
 maintainers:
 - name: yotamloe

--- a/charts/prometheus-alerts-migrator/README.md
+++ b/charts/prometheus-alerts-migrator/README.md
@@ -165,6 +165,19 @@ data:
 
 
 ## Changelog
+- v2.0.3
+  - Upgrade `logzio/prometheus-alerts-migrator` image `v1.0.3`->`v1.1.0`
+    - Add support for migrating alert rules groups
+    - Upgrade GoLang version to 1.23
+    - Upgrade dependencies
+      - `k8s.io/client-go`: `v0.28.3` -> `v0.31.2`
+      - `k8s.io/apimachinery`: `v0.28.3` -> `v0.31.2`
+      - `k8s.io/api`: `v0.28.3` -> `v0.31.2`
+      - `k8s.io/klog/v2`: `v2.110.1` -> `v2.130.1`
+      - `logzio_terraform_client`: `1.20.0` -> `1.22.0`
+      - `prometheus/common`: `v0.44.0` -> `v0.60.1`
+      - `prometheus/alertmanager`: `v0.26.0` -> `v0.27.0`
+      - `prometheus/prometheus`: `v0.47.2` -> `v0.55.0`
 - v2.0.2
   - Remove default resources `limits`
 - v2.0.1

--- a/charts/prometheus-alerts-migrator/values.yaml
+++ b/charts/prometheus-alerts-migrator/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 image:
   repository: logzio/prometheus-alerts-migrator
   pullPolicy: IfNotPresent
-  tag: "v1.0.3"
+  tag: "v1.1.0"
 
 serviceAccount:
   create: true


### PR DESCRIPTION
  - Upgrade `logzio/prometheus-alerts-migrator` image `v1.0.3`->`v1.1.0`
    - Add support for migrating alert rules groups
    - Upgrade GoLang version to 1.23
    - Upgrade dependencies
      - `k8s.io/client-go`: `v0.28.3` -> `v0.31.2`
      - `k8s.io/apimachinery`: `v0.28.3` -> `v0.31.2` - `k8s.io/api`: `v0.28.3` -> `v0.31.2` - `k8s.io/klog/v2`: `v2.110.1` -> `v2.130.1` - `logzio_terraform_client`: `1.20.0` -> `1.22.0` - `prometheus/common`: `v0.44.0` -> `v0.60.1` - `prometheus/alertmanager`: `v0.26.0` -> `v0.27.0` - `prometheus/prometheus`: `v0.47.2` -> `v0.55.0`

## Description 

<!-- 
    "This PR [adds/removes/fixes/replaces] the [feature/bug/etc].."
    Do not leave this blank.
    If relevant, describe the previous behaviour compared to the behaviour post your code change.
-->

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
