### PR TITLE
[Release] logzio-monitoring 6.2.2

### DIFF
--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -93,8 +93,8 @@ jobs:
           --set logzio-k8s-telemetry.spm.enabled=true \
           --set logzio-k8s-telemetry.secrets.env_id='${{ env.ENV_ID }}' \
           --set logzio-k8s-telemetry.secrets.SpmToken='${{ secrets.LOGZIO_METRICS_TOKEN }}' \
-          --set logzio-k8s-telemetry.serviceGraph.enabled=true"
-          
+          --set logzio-k8s-telemetry.serviceGraph.enabled=true \
+        
           if [ "${{ matrix.environment }}" == "eks-fargate" ]; then
             HELM_CMD="$HELM_CMD --set logzio-logs-collector.fargateLogRouter.enabled='true' --set logzio-k8s-telemetry.collector.mode=standalone"
           fi

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -83,17 +83,17 @@ jobs:
           --set logzio-logs-collector.secrets.env_id='${{ env.ENV_ID }}' \
           --set logzio-logs-collector.secrets.logType='${{ env.ENV_ID }}' \
           --set metricsOrTraces.enabled=true \
+          --set logzio-k8s-telemetry.traces.enabled=true \
+          --set logzio-k8s-telemetry.spm.enabled=true \
+          --set logzio-k8s-telemetry.serviceGraph.enabled=true \
           --set logzio-k8s-telemetry.metrics.enabled=true \
           --set logzio-k8s-telemetry.secrets.MetricsToken='${{ secrets.LOGZIO_METRICS_TOKEN }}' \
           --set logzio-k8s-telemetry.secrets.ListenerHost='https://listener.logz.io:8053' \
           --set logzio-k8s-telemetry.secrets.p8s_logzio_name='${{ env.ENV_ID }}' \
-          --set logzio-k8s-telemetry.traces.enabled=true \
           --set logzio-k8s-telemetry.secrets.TracesToken='${{ secrets.LOGZIO_TRACES_TOKEN }}' \
           --set logzio-k8s-telemetry.secrets.LogzioRegion='us' \
-          --set logzio-k8s-telemetry.spm.enabled=true \
           --set logzio-k8s-telemetry.secrets.env_id='${{ env.ENV_ID }}' \
-          --set logzio-k8s-telemetry.secrets.SpmToken='${{ secrets.LOGZIO_METRICS_TOKEN }}' \
-          --set logzio-k8s-telemetry.serviceGraph.enabled=true \
+          --set logzio-k8s-telemetry.secrets.SpmToken='${{ secrets.LOGZIO_METRICS_TOKEN }}' "
         
           if [ "${{ matrix.environment }}" == "eks-fargate" ]; then
             HELM_CMD="$HELM_CMD --set logzio-logs-collector.fargateLogRouter.enabled='true' --set logzio-k8s-telemetry.collector.mode=standalone"

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 6.2.1
+version: 6.2.2
 
 
 
@@ -14,7 +14,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "4.2.9"
+    version: "4.3.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: metricsOrTraces.enabled
   - name: logzio-trivy

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -228,7 +228,7 @@ There are two possible approaches to the upgrade you can choose from:
 
 ## Changelog
 - **6.2.2**:
-	- Upgrade `logzio-telemetry` chart to `v4.3.0`
+  - Upgrade `logzio-telemetry` chart to `v4.3.0`
     - Set `servicegraph` connector, `metrics_flush_interval` setting to `60s` to reduce outgoing connections
 - **6.2.1**:
 	- Upgrade `logzio-telemetry` chart to `v4.2.9`

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -226,8 +226,10 @@ There are two possible approaches to the upgrade you can choose from:
 - Reinstall the chart.
 - Before running the `helm upgrade` command, delete the old subcharts resources: `logzio-monitoring-prometheus-pushgateway` deployment and the `logzio-monitoring-prometheus-node-exporter` daemonset.
 
-
 ## Changelog
+- **6.2.2**:
+	- Upgrade `logzio-telemetry` chart to `v4.3.0`
+    - Set `servicegraph` connector, `metrics_flush_interval` setting to `60s` to reduce outgoing connections
 - **6.2.1**:
 	- Upgrade `logzio-telemetry` chart to `v4.2.9`
 		- Add batch processor to the SPM pipeline, to reduce stress and increase efficiency.

--- a/tests/resources/otel-demo-monitoring.yaml
+++ b/tests/resources/otel-demo-monitoring.yaml
@@ -2,7 +2,7 @@
 default:
   envOverrides:
     - name: OTEL_COLLECTOR_NAME
-      value: logzio-monitoring-otel-collector.monitoring.svc.cluster.local
+      value: logzio-monitoring-otel-collector.default.svc.cluster.local
 
 opentelemetry-collector:
   enabled: false


### PR DESCRIPTION
## Description 
6.2.2
- Upgrade `logzio-telemetry` chart to `v4.3.0`
  - Set `servicegraph` connector, `metrics_flush_interval` setting to `60s` to reduce outgoing connections
- Update e2e test
## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
