### PR TITLE
[Release] update fluentd chart version to `0.30.6`

### DIFF
--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 6.2.4
+version: 6.2.5
 
 
 
@@ -10,7 +10,7 @@ sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: logzio-fluentd
-    version: "0.30.5"
+    version: "0.30.6"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -269,6 +269,9 @@ Replace `<<TAINT-KEY>>`, `<<TAINT-OPERATOR>>`, `<<TAINT-VALUE>>`, and `<<TAINT-E
 By following these steps, you can ensure that your pods are scheduled on nodes with taints by adding the necessary tolerations to the Helm chart configuration.
 
 ## Changelog
+- **6.2.5**:
+  - Upgrade `logzio-fluentd` chart to `v0.30.6`
+      - Upgrade fluentd version to `1.18.0`
 - **6.2.4**:
   - Upgrade `logzio-trivy` chart to `v0.3.6`
       - Fix `tolerations` value 

--- a/tests/metrics_e2e_test.go
+++ b/tests/metrics_e2e_test.go
@@ -92,7 +92,7 @@ func TestFargateMetrics(t *testing.T) {
 	}
 	requiredMetrics := map[string][]string{
 		"kube_pod_status_phase":                    {"p8s_logzio_name", "namespace", "pod", "phase", "uid"},
-		"kube_pod_info":                            {"p8s_logzio_name", "namespace", "host_ip", "pod"},
+		"kube_pod_info":                            {"p8s_logzio_name", "namespace", "pod"},
 		"kube_pod_container_resource_limits":       {"p8s_logzio_name", "namespace", "pod", "resource"},
 		"kube_pod_container_info":                  {"p8s_logzio_name", "namespace", "pod"},
 		"kube_pod_created":                         {"p8s_logzio_name", "namespace", "pod"},


### PR DESCRIPTION
## Description 

- Update version of fluentd chart to `0.30.6`
    - Update fluentd to `v1.18.0`
- Update readme
- remove `host_ip` label requirement from `kube_pod_info` metric in Fargate tests due to the serverless nature


## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
