### PR TITLE
[Release] `logzio-logs-collector` align to new global structure

### DIFF
--- a/.github/workflows/logzio-logs-collector-test.yaml
+++ b/.github/workflows/logzio-logs-collector-test.yaml
@@ -49,10 +49,10 @@ jobs:
         run: |
           cd charts/logzio-logs-collector
           helm upgrade --install \
-          --set secrets.env_id=${{ env.ENV_ID }} \
-          --set secrets.logzioLogsToken=${{ secrets.LOGZIO_LOGS_TOKEN }} \
-          --set secrets.logzioRegion=us \
-          --set secrets.logType=${{ env.ENV_ID }} \
+          --set global.env_id=${{ env.ENV_ID }} \
+          --set global.logzioLogsToken=${{ secrets.LOGZIO_LOGS_TOKEN }} \
+          --set global.logzioRegion=us \
+          --set global.logType=${{ env.ENV_ID }} \
           logzio-logs-collector .
 
       - name: Run log generator

--- a/charts/logzio-logs-collector/CHANGELOG.md
+++ b/charts/logzio-logs-collector/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changes by Version
+
+<!-- next version -->
+
+## 2.0.0
+- **Breaking changes**
+    - Secret values are now global
+      - `secrets.secretParam` >> `global.secretParam` to prevent duplicate values in the parent chart
+      - Update `secrets.customEndpoint` >> `global.customLogsEndpoint` to avoid conflicts with other charts
+    - K8s secret resource configuration has been renamed from `secrets` >> `secret`
+- Upgrade `otel/opentelemetry-collector-contrib` image to `v.0.109.0`
+
+## 1.1.0
+- Simplified user experience for independently managing logzio secrets.
+    - Remove requirment to set environment variables in the pods independently.
+    - Provided instructions in `values.yaml` regarding the process.
+
+## 1.0.9
+- **EKS fargate Breaking changes**:
+    - Add `nest` filters to remove dots from kubernetes metadata keys.
+    Changes in fields names:
+    - `kubernetes.*` -> `kubernetes_*`
+    - `kubernetes.labels.*` -> `kubernetes_labels_*`
+    - `kubernetes.annotations.*` -> `kubernetes_annotations_*`
+
+## 1.0.8
+- Bug-fix:
+    - Remove comment from `_helpers.tpl` template that breaks aws-logging configmap
+
+## 1.0.7
+- Upgrade `otel/opentelemetry-collector-contrib` image to v0.107.0
+    - Adjusted health check extension endpoint
+  - In case `json_parser` fails, send the log anyway and print the error only in debug mode.
+
+## 1.0.6
+- Added `varlogcontainers` volume and volume mounts
+- Added new `container` operator instead of complex operator sequence
+- Remove default resources `limits`
+- Add default resources `requests`
+
+## 1.0.5
+- Upgrade `otel/opentelemetry-collector-contrib` image to `v0.103.0`
+
+## 1.0.4
+- Add standalone deployment mode
+- Rename `LogzioRegion` to camelCase - `logzioRegion`
+- Add user-agent header
+
+## 1.0.3
+- Replace dots (".") with underscores ("_") in log attributes keys:
+    - Added `transform/dedot` proccesor. 
+    - Edited `k8sattributes`, `transform/log_type`, `transform/log_level` proccesors.
+
+## 1.0.2
+- Change template function name `baseConfig` -> `baseLoggingConfig` to avoid conflicts with other charts deployed
+- Refactor tempaltes function names `opentelemetry-collector` -> `logs-collector` to avoid conflicts with other charts templates
+
+## 1.0.1
+- Update multiline parsing
+- Update error detection in logs
+- Change default log type
+- Enhanced env_id handling to support both numeric and string formats.
+
+## 1.0.0
+- kubernetes logs collection agent for logz.io based on opentelemetry collector

--- a/charts/logzio-logs-collector/Chart.yaml
+++ b/charts/logzio-logs-collector/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: logzio-logs-collector
-version: 1.1.0
+version: 2.0.0
 description: kubernetes logs collection agent for logz.io based on opentelemetry collector
 type: application
 home: https://logz.io/
 maintainers:
   - name: yotam loewenbach
     email: yotam.loewenbach@logz.io
-appVersion: 0.107.0
+appVersion: 0.109.0

--- a/charts/logzio-logs-collector/README.md
+++ b/charts/logzio-logs-collector/README.md
@@ -50,10 +50,10 @@ helm repo update
     ```
     helm install logzio-logs-collector -n monitoring \
     --set enabled=true \
-    --set secrets.logzioLogsToken=<<token>> \
-    --set secrets.logzioRegion=<<region>> \
-    --set secrets.env_id=<<env_id>> \
-    --set secrets.logType=<<logType>> \
+    --set global.logzioLogsToken=<<token>> \
+    --set global.logzioRegion=<<region>> \
+    --set global.env_id=<<env_id>> \
+    --set global.logType=<<logType>> \
     logzio-helm/logzio-logs-collector
     ```
 
@@ -86,13 +86,13 @@ The table below lists the configurable parameters of the `logzio-logs-collector`
 | mode                     | Deployment mode (currently supports `"daemonset"` and `"standalone"`).           | `"daemonset"`                           |
 | namespaceOverride        | Override the namespace into which the resources will be deployed.                | `""`                                     |
 | fargateLogRouter.enabled | Boolean to decide if to configure Fargate log router (EKS Fargate environments). | `false`                                  |
-| secrets.enabled          | Toggle for creating and managing the Logz.io secret by this chart.               | `true`                                   |
-| secrets.name             | The name of the secret for Logz.io log collector.                                | `"logzio-log-collector-secrets"`         |
-| secrets.env_id           | Environment identifier attribute added to all logs.                              | `"my_env"`                               |
-| secrets.logType          | Default log type field.                                                          | `"k8s"`                                  |
-| secrets.logzioLogsToken  | Secret with your Logz.io logs shipping token.                                    | `"token"`                                |
-| secrets.LogzioRegion     | Secret with your Logz.io region.                                                 | `"us"`                                   |
-| secrets.customEndpoint   | Secret with your custom endpoint, overrides Logz.io region listener address.     | `""`                                     |
+| secret.enabled          | Toggle for creating and managing the Logz.io secret by this chart.               | `true`                                   |
+| secret.name             | The name of the secret for Logz.io log collector.                                | `"logzio-log-collector-secrets"`         |
+| global.env_id           | Environment identifier attribute added to all logs.                              | `"my_env"`                               |
+| global.logType          | Default log type field.                                                          | `"k8s"`                                  |
+| global.logzioLogsToken  | Secret with your Logz.io logs shipping token.                                    | `"token"`                                |
+| global.LogzioRegion     | Secret with your Logz.io region.                                                 | `"us"`                                   |
+| global.customLogsEndpoint   | Secret with your custom endpoint, overrides Logz.io region listener address.     | `""`                                     |
 | configMap.create         | Specifies whether a configMap should be created.                                 | `true`                                   |
 | config                   | Base collector configuration, supports templating.                               | Complex structure (see `values.yaml`)    |
 | image.repository         | Docker image repository.                                                         | `"otel/opentelemetry-collector-contrib"` |
@@ -147,10 +147,10 @@ You can use the `fargateLogRouter.enabled` value to enable log collection in eks
 ```sh
     helm install logzio-logs-collector -n monitoring \
     --set enabled=true \
-    --set secrets.logzioLogsToken=<<token>> \
-    --set secrets.logzioRegion=<<region>> \
-    --set secrets.env_id=<<env_id>> \
-    --set secrets.logType=<<logType>> \
+    --set global.logzioLogsToken=<<token>> \
+    --set global.logzioRegion=<<region>> \
+    --set global.env_id=<<env_id>> \
+    --set global.logType=<<logType>> \
     --set fargateLogRouter.enabled="true" \
     logzio-helm/logzio-logs-collector
 ```
@@ -160,47 +160,3 @@ Changes in fields names:
   - `kubernetes.labels.*` -> `kubernetes_labels_*`
   - `kubernetes.annotations.*` -> `kubernetes_annotations_*`
   
-## Change log
-* 1.1.0
-  - Simplified user experience for independently managing logzio secrets.
-    - Remove requirment to set environment variables in the pods independently.
-    - Provided instructions in `values.yaml` regarding the process.
-* 1.0.9
-  - **EKS fargate Breaking changes**:
-   - Add `nest` filters to remove dots from kubernetes metadata keys.
-    Changes in fields names:
-    - `kubernetes.*` -> `kubernetes_*`
-    - `kubernetes.labels.*` -> `kubernetes_labels_*`
-    - `kubernetes.annotations.*` -> `kubernetes_annotations_*`
-* 1.0.8
-  - Bug-fix:
-    - Remove comment from `_helpers.tpl` template that breaks aws-logging configmap
-* 1.0.7
-  - Upgrade `otel/opentelemetry-collector-contrib` image to v0.107.0
-    - Adjusted health check extension endpoint
-  - In case `json_parser` fails, send the log anyway and print the error only in debug mode.
-* 1.0.6
-  - Added `varlogcontainers` volume and volume mounts
-  - Added new `container` operator instead of complex operator sequence
-  - Remove default resources `limits`
-  - Add default resources `requests`
-* 1.0.5
-  - Upgrade `otel/opentelemetry-collector-contrib` image to `v0.103.0`
-* 1.0.4
-  - Add standalone deployment mode
-  - Rename `LogzioRegion` to camelCase - `logzioRegion`
-  - Add user-agent header
-* 1.0.3
-  - Replace dots (".") with underscores ("_") in log attributes keys:
-    - Added `transform/dedot` proccesor. 
-    - Edited `k8sattributes`, `transform/log_type`, `transform/log_level` proccesors.
-* 1.0.2
-  - Change template function name `baseConfig` -> `baseLoggingConfig` to avoid conflicts with other charts deployed
-  - Refactor tempaltes function names `opentelemetry-collector` -> `logs-collector` to avoid conflicts with other charts templates
-* 1.0.1
-  - Update multiline parsing
-  - Update error detection in logs
-  - Change default log type
-  - Enhanced env_id handling to support both numeric and string formats.
-* 1.0.0
-  - kubernetes logs collection agent for logz.io based on opentelemetry collector

--- a/charts/logzio-logs-collector/templates/_helpers.tpl
+++ b/charts/logzio-logs-collector/templates/_helpers.tpl
@@ -188,7 +188,7 @@ Allow the release namespace to be overridden
 Calculate Logz.io listener address based on region
 */}}
 {{- define "logzio.listenerAddress" -}}
-{{- $region := .Values.global.LogzioRegion -}}
+{{- $region := .Values.global.logzioRegion -}}
 {{- if eq $region "us" -}}
 listener.logz.io
 {{- else if eq $region "au" -}}

--- a/charts/logzio-logs-collector/templates/_helpers.tpl
+++ b/charts/logzio-logs-collector/templates/_helpers.tpl
@@ -188,7 +188,7 @@ Allow the release namespace to be overridden
 Calculate Logz.io listener address based on region
 */}}
 {{- define "logzio.listenerAddress" -}}
-{{- $region := .Values.secrets.LogzioRegion -}}
+{{- $region := .Values.global.LogzioRegion -}}
 {{- if eq $region "us" -}}
 listener.logz.io
 {{- else if eq $region "au" -}}

--- a/charts/logzio-logs-collector/templates/_pod.tpl
+++ b/charts/logzio-logs-collector/templates/_pod.tpl
@@ -52,28 +52,28 @@ containers:
       - name: ENV_ID
         valueFrom:
           secretKeyRef:
-            name: {{ .Values.secrets.name }}
+            name: {{ .Values.secret.name }}
             key: env-id
       - name: LOG_TYPE
         valueFrom:
           secretKeyRef:
-            name: {{ .Values.secrets.name }}
+            name: {{ .Values.secret.name }}
             key: log-type
       - name: LOGZIO_REGION
         valueFrom:
           secretKeyRef:
-            name: {{ .Values.secrets.name }}
+            name: {{ .Values.secret.name }}
             key: logzio-listener-region
       - name: LOGZIO_LOGS_TOKEN
         valueFrom:
           secretKeyRef:
-            name: {{ .Values.secrets.name }}
+            name: {{ .Values.secret.name }}
             key: logzio-logs-token
-      {{- if .Values.secrets.customEndpoint }}
+      {{- if .Values.global.customLogsEndpoint }}
       - name: CUSTOM_ENDPOINT
         valueFrom:
           secretKeyRef:
-            name: {{ .Values.secrets.name }}
+            name: {{ .Values.secret.name }}
             key: custom-endpoint
       {{- end -}}
       {{- if and (.Values.useGOMEMLIMIT) ((((.Values.resources).limits).memory))  }}

--- a/charts/logzio-logs-collector/templates/fargate-logging-configmap.yaml
+++ b/charts/logzio-logs-collector/templates/fargate-logging-configmap.yaml
@@ -10,8 +10,8 @@ data:
     [FILTER]
       Name modify
       Match *
-      Add token {{ .Values.secrets.logzioLogsToken }}
-      Add type {{ .Values.secrets.logType }}
+      Add token {{ .Values.logzioLogsToken | default .Values.global.logzioLogsToken }}
+      Add type {{ .Values.global.logType }}
       Rename log message
     [FILTER]
       Name kubernetes
@@ -60,7 +60,7 @@ data:
       Match *
       Host  {{ template "logzio.listenerAddress" . }}
       HTTP_User token
-      HTTP_Passwd {{ .Values.secrets.logzioLogsToken }}
+      HTTP_Passwd {{ .Values.logzioLogsToken | default .Values.global.logzioLogsToken }}
       Port  8070
       Retry_Limit no_retries
       Index logzioCustomerIndex

--- a/charts/logzio-logs-collector/templates/secret.yaml
+++ b/charts/logzio-logs-collector/templates/secret.yaml
@@ -1,21 +1,21 @@
 
 {{ if .Values.enabled}}
-{{- if .Values.secrets.enabled }}
+{{- if .Values.secret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.secrets.name }}
+  name: {{ .Values.secret.name }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
-  env-id: {{.Values.secrets.env_id | quote}}
-  log-type: {{ .Values.secrets.logType}}
-  logzio-listener-region: {{ .Values.secrets.logzioRegion}}
-  {{ if .Values.secrets.logzioLogsToken}}
-  logzio-logs-token: {{ .Values.secrets.logzioLogsToken }}
+  env-id: {{ .Values.global.env_id | quote }}
+  log-type: {{ .Values.global.logType }}
+  logzio-listener-region: {{ .Values.global.logzioRegion }}
+  {{ if or .Values.global.logzioLogsToken .Values.logzioLogsToken }}
+  logzio-logs-token: {{ .Values.logzioLogsToken | default .Values.global.logzioLogsToken }}
   {{ end }}
-  {{ if .Values.secrets.customEndpoint}}
-  custom-endpoint: {{ .Values.secrets.customEndpoint}}
+  {{ if .Values.global.customLogsEndpoint}}
+  custom-endpoint: {{ .Values.global.customLogsEndpoint}}
   {{ end }}
 {{- end }}
 {{ end }}

--- a/charts/logzio-logs-collector/values.yaml
+++ b/charts/logzio-logs-collector/values.yaml
@@ -18,15 +18,10 @@ fargateLogRouter:
   # Boolen to decide if to configure fargate log router (eks fargate envirinments)
   enabled: false
 
-secrets:
-  # When secrets.enabled is true, the logzio secret will be created and managed by this Chart.
-  # If you're managing the logzio secrets by yourself, set to false. 
-  # Note that in order for the default configuration to work properly, you need to:
-  # 1. Update secrets.name to your custom secret name
-  # 2. Include these keys in your secret: env-id, log-type, logzio-listener-region, logzio-logs-token
-  # To use a custom endpoint, include custom-endpoint parameter in your secret and set secrets.customEndpoint to true.
-  enabled: true
-  name: logzio-log-collector-secrets
+#######################################################################################################################
+# Base Configuration Parameters
+#######################################################################################################################
+global:
   # environment indentifier attribute that will be added to all logs
   env_id: "my_env"
   # defualt log type field
@@ -36,22 +31,21 @@ secrets:
   # Secret with your logzio region
   logzioRegion: "us"
   # Secret with your custom endpoint, for example:http://endpoint:8080. Overrides secrets.LogzioRegion listener adress
-  customEndpoint: ""
-
-configMap:
-  # Specifies whether a configMap should be created (true by default)
-  create: true
+  customLogsEndpoint: ""
 
 standaloneCollector:
   # Number of replicas in standalone collector mode
   replicaCount: 1
+
+#######################################################################################################################
+# OpenTelemetry Collector Configuration
+#######################################################################################################################
 
 # Base collector configuration.
 # Supports templating. To escape existing instances of {{ }}, use {{` <original content> `}}.
 # For example, {{ REDACTED_EMAIL }} becomes {{` {{ REDACTED_EMAIL }} `}}.
 config:
   exporters:
-    logging: {}
     logzio/logs:
       account_token: ${env:LOGZIO_LOGS_TOKEN}
       region: ${env:LOGZIO_REGION}
@@ -184,7 +178,6 @@ config:
       logs:
         exporters:
         - logzio/logs
-        - logging
         processors:
         - k8sattributes
         - transform/log_level
@@ -200,6 +193,9 @@ config:
       logs:
         level: info
 
+#######################################################################################################################
+# OpenTelemetry Collector Image Settings
+#######################################################################################################################
 image:
   # If you want to use the core image `otel/opentelemetry-collector`, you also need to change `command.name` value to `otelcol`.
   repository: otel/opentelemetry-collector-contrib
@@ -214,6 +210,23 @@ imagePullSecrets: []
 command:
   name: otelcol-contrib
   extraArgs: []
+
+#######################################################################################################################
+# Kubernetes Resources Configuration
+#######################################################################################################################
+secret:
+  # When secret.enabled is true, the logzio secret will be created and managed by this Chart.
+  # If you're managing the logzio secrets by yourself, set to false. 
+  # Note that in order for the default configuration to work properly, you need to:
+  # 1. Update secret.name to your custom secret name
+  # 2. Include these keys in your secret: env-id, log-type, logzio-listener-region, logzio-logs-token
+  # To use a custom endpoint, include custom-endpoint parameter in your secret and set global.customLogsEndpoint to true.
+  enabled: true
+  name: logzio-log-collector-secrets
+
+configMap:
+  # Specifies whether a configMap should be created (true by default)
+  create: true
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
## Description 

- Change secret values to global to prevent duplicate values in the parent chart
  - `secrets.secretParam` >> `global.secretParam` 
  - Update `secrets.customEndpoint` >> `global.customLogsEndpoint` to avoid conflicts with other charts
- K8s secret resource configuration has been renamed `secrets` >> `secret`
- Upgrade `otel/opentelemetry-collector-contrib` image to `v.0.109.0`
  - **Note:** we can't upgrade beyond `v.0.109.0`, since starting at `v.0.110.0+`, the `time` field (which holds the original log timestamp) has been removed. This change was made because it was duplicate - appearing both as `Timestamp` at the log root and as `Attributes.time`.  To upgrade to a newer version without losing this field, we would need to update our OTEL exporter to explicitly include the log's `Timestamp` as an additional field.
- Move changelog from `README.md` >> `CHANGELOG.md`
- Update readme
- Align the command in E2E test

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
