### PR TITLE
[Release] `logzio-k8s-telemetry` align to new global structure

### DIFF
--- a/.github/workflows/logzio-telemetry-test.yaml
+++ b/.github/workflows/logzio-telemetry-test.yaml
@@ -58,12 +58,11 @@ jobs:
           --set spm.enabled=true \
           --set serviceGraph.enabled=true \
           --set metrics.enabled=true \
-          --set secrets.TracesToken=${{ secrets.LOGZIO_TRACES_TOKEN }} \
-          --set secrets.SpmToken=${{ secrets.LOGZIO_METRICS_TOKEN }} \
-          --set secrets.MetricsToken=${{ secrets.LOGZIO_METRICS_TOKEN }} \
-          --set secrets.ListenerHost=https://listener.logz.io:8053 \
-          --set secrets.p8s_logzio_name=${{ env.ENV_ID }} \
-          --set secrets.env_id=${{ env.ENV_ID }} \
+          --set global.logzioTracesToken=${{ secrets.LOGZIO_TRACES_TOKEN }} \
+          --set global.logzioSpmToken=${{ secrets.LOGZIO_METRICS_TOKEN }} \
+          --set global.logzioMetricsToken=${{ secrets.LOGZIO_METRICS_TOKEN }} \
+          --set global.logzioRegion=us \
+          --set global.env_id=${{ env.ENV_ID }} \
           --set collector.mode=${{ matrix.mode }} \
           logzio-k8s-telemetry .
           kubectl rollout status deployment/logzio-k8s-telemetry-otel-collector-standalone --timeout=300s

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 4.3.0
+version: 5.0.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -408,6 +408,7 @@ If you don't want the sub charts to installed add the relevant flag per sub char
       - `secrets.LogzioRegion` >> `global.logzioRegion`
       - `secrets.CustomTracingEndpoint` >> `global.customTracesEndpoint`
       - Deprecate `secrets.p8s_logzio_name` and `secrets.ListenerHost`
+        - Add `global.customMetricsEndpoint` to support sending metrics to a custom endpoint
 * 4.3.0
   - Set `servicegraph` connector, `metrics_flush_interval` setting to `60s` to reduce outgoing connections
 * 4.2.9

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -43,22 +43,17 @@ helm repo update
 To deploy the Helm chart, enter the relevant parameters for the placeholders and run the code. 
 
 ###### Configure the parameters in the code
-Replace `<<*P8S-LOGZIO-NAME*>>` with the name for the environment's metrics, to easily identify the metrics for each environment.
-Replace `<<*ENV-ID*>>` with the name for your environment's identifier, to easily identify the telemetry data for each environment.
+- Replace `<<*ENV-ID*>>` with the name for your environment's identifier, to easily identify the telemetry data for each environment.
+- Replace `<<LOGZIO-REGION>>` with the name of your Logz.io region e.g `us`,`eu`.
 
 #### For metrics:
-Enable the metrics configuration for this chart: `--set metrics.enabled=true`
+- Enable the metrics configuration for this chart: `--set metrics.enabled=true`
+- Replace the Logz-io `<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/manage-tokens/data-shipping) of the metrics account to which you want to send your data.
 
-Replace the Logz-io `<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/manage-tokens/data-shipping) of the metrics account to which you want to send your data.
-
-Replace `<<LISTENER-HOST>>` with your region’s listener host (for example, `https://listener.logz.io:8053`). For more information on finding your account’s region, see [Account region](https://docs.logz.io/user-guide/accounts/account-region.html).
 
 #### For traces:
-Enable the traces configuration for this chart: --set traces.enabled=true
-
-Replace the Logz-io `<<TRACES-SHIPPING-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/manage-tokens/data-shipping) of the traces account to which you want to send your data.
-
-Replace `<<LOGZIO-REGION>>` with the name of your Logz.io region e.g `us`,`eu`.
+- Enable the traces configuration for this chart: --set traces.enabled=true
+- Replace the Logz-io `<<TRACES-SHIPPING-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/settings/manage-tokens/data-shipping) of the traces account to which you want to send your data.
 
 
 
@@ -68,10 +63,9 @@ Replace `<<LOGZIO-REGION>>` with the name of your Logz.io region e.g `us`,`eu`.
 ```
 helm install  \
 --set metrics.enabled=true \
---set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
---set secrets.ListenerHost=<<LISTENER-HOST>> \
---set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
---set secrets.env_id=<<ENV-ID>> \
+--set global.logzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
+--set global.logzioRegion=<<LOGZIO-REGION>> \
+--set global.env_id=<<ENV-ID>> \
 logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 ```
 
@@ -79,10 +73,9 @@ logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 ```
 helm install \
 --set traces.enabled=true \
---set secrets.TracesToken=<<TRACES-SHIPPING-TOKEN>> \
---set secrets.LogzioRegion=<<LOGZIO-REGION>> \
---set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
---set secrets.env_id=<<ENV-ID>> \
+--set global.logzioTracesToken=<<TRACES-SHIPPING-TOKEN>> \
+--set global.logzioRegion=<<LOGZIO-REGION>> \
+--set global.env_id=<<ENV-ID>> \
 logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 ```
 
@@ -92,12 +85,10 @@ logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 helm install \
 --set traces.enabled=true \
 --set spm.enabled=true \
---set secrets.SpmToken=<<SPM-SHIPPING-TOKEN>> \
---set secrets.TracesToken=<<TRACES-SHIPPING-TOKEN>> \
---set secrets.LogzioRegion=<<LOGZIO-REGION>> \
---set secrets.ListenerHost=<<LISTENER-HOST>> \
---set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
---set secrets.env_id=<<ENV-ID>> \
+--set global.logzioSpmToken=<<SPM-SHIPPING-TOKEN>> \
+--set global.logzioTracesToken=<<TRACES-SHIPPING-TOKEN>> \
+--set global.logzioRegion=<<LOGZIO-REGION>> \
+--set global.env_id=<<ENV-ID>> \
 logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 ```
 
@@ -107,14 +98,12 @@ logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 helm install  \
 --set traces.enabled=true \
 --set spm.enabled=true \
---set secrets.TracesToken=<<TRACES-SHIPPING-TOKEN>> \
---set secrets.SpmToken=<<SPM-SHIPPING-TOKEN>> \
---set secrets.LogzioRegion=<<LOGZIO-REGION>> \
+--set global.logzioTracesToken=<<TRACES-SHIPPING-TOKEN>> \
+--set global.logzioSpmToken=<<SPM-SHIPPING-TOKEN>> \
+--set global.logzioRegion=<<LOGZIO-REGION>> \
 --set metrics.enabled=true \
---set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
---set secrets.ListenerHost=<<LISTENER-HOST>> \
---set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
---set secrets.env_id=<<ENV-ID>> \
+--set global.logzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
+--set global.env_id=<<ENV-ID>> \
 logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 ```
 
@@ -125,14 +114,12 @@ helm install  \
 --set traces.enabled=true \
 --set spm.enabled=true \
 --set serviceGraph.enabled=true \
---set secrets.TracesToken=<<TRACES-SHIPPING-TOKEN>> \
---set secrets.SpmToken=<<SPM-SHIPPING-TOKEN>> \
---set secrets.LogzioRegion=<<LOGZIO-REGION>> \
+--set global.logzioTracesToken=<<TRACES-SHIPPING-TOKEN>> \
+--set global.logzioSpmToken=<<SPM-SHIPPING-TOKEN>> \
+--set global.logzioRegion=<<LOGZIO-REGION>> \
 --set metrics.enabled=true \
---set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
---set secrets.ListenerHost=<<LISTENER-HOST>> \
---set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
---set secrets.env_id=<<ENV-ID>> \
+--set global.logzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
+--set global.env_id=<<ENV-ID>> \
 logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 ```
 
@@ -142,12 +129,10 @@ logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 helm install  \
 --set metrics.enabled=true \
 --set k8sObjectsConfig.enabled=true \
---set secrets.LogzioRegion=<<LOGZIO-REGION>> \
---set secrets.k8sObjectsLogsToken=<<LOGZIO-LOG-SHIPPING-TOKEN>> \
---set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
---set secrets.ListenerHost=<<LISTENER-HOST>> \
---set secrets.p8s_logzio_name=<<P8S-LOGZIO-NAME>> \
---set secrets.env_id=<<ENV-ID>> \
+--set global.logzioRegion=<<LOGZIO-REGION>> \
+--set global.logzioLogsToken=<<LOGZIO-LOG-SHIPPING-TOKEN>> \
+--set global.logzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
+--set global.env_id=<<ENV-ID>> \
 logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
 ```
 #### Handling image pull rate limit
@@ -196,9 +181,9 @@ under `How do I change the administrator password for Windows Server nodes on my
 
 ```
 helm install  \
---set secrets.MetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
---set secrets.ListenerHost=<<LISTENER-HOST>> \
---set secrets.p8s_logzio_name=<<ENV-TAG>> \
+--set global.logzioMetricsToken=<<PROMETHEUS-METRICS-SHIPPING-TOKEN>> \
+--set global.logzioRegion=<<LISTENER-HOST>> \
+--set global.env_id=<<ENV-TAG>> \
 --set secrets.windowsNodeUsername=<<WINDOWS-NODE-USERNAME>> \
 --set secrets.windowsNodePassword=<<WINDOWS-NODE-PASSWORD>> \
 logzio-k8s-telemetry logzio-helm/logzio-k8s-telemetry
@@ -412,6 +397,17 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 5.0.0
+  - **Breaking Changes**
+    - Logz.io secret values are now global
+      - `secrets.MetricsToken` >> `global.logzioMetricsToken`
+      - `secrets.TracesToken` >> `global.logzioTracesToken`
+      - `secrets.SpmToken` >> `global.logzioSpmToken`
+      - `secrets.k8sObjectsLogsToken` >> `global.logzioLogsToken`
+      - `secrets.env_id` >> `global.env_id`
+      - `secrets.LogzioRegion` >> `global.logzioRegion`
+      - `secrets.CustomTracingEndpoint` >> `global.customTracesEndpoint`
+      - Deprecate `secrets.p8s_logzio_name` and `secrets.ListenerHost`
 * 4.3.0
   - Set `servicegraph` connector, `metrics_flush_interval` setting to `60s` to reduce outgoing connections
 * 4.2.9

--- a/charts/logzio-telemetry/VALUES.md
+++ b/charts/logzio-telemetry/VALUES.md
@@ -50,13 +50,11 @@ logzio-k8s-telemetry allows you to ship metrics and traces from your Kubernetes 
 | nameOverride | string | `"otel-collector"` | Name override for the opentelemetry collector. |
 | nodeExporter.enabled | bool | `true` | Controlles the deployment of the node-exporter sub chart. |
 | pushGateway.enabled | bool | `true` | Controlles the deployment of the prometheus-pushgateway sub chart. |
-| secrets.ListenerHost | string | `""` | Logzio listener host. |
-| secrets.LogzioRegion | string | `"us"` | Logzio listener region. |
-| secrets.MetricsToken | string | `""` | Logzio metrics token. |
-| secrets.SpmToken | string | `""` | Logzio spm metrics token. |
-| secrets.TracesToken | string | `""` | Logzio traces token. |
-| secrets.env_id | string | `"my_environment"` | Env id to be used with k8s 360. |
-| secrets.p8s_logzio_name | string | `""` | Cluster name that will be added as a label. |
+| global.logzioRegion | string | `"us"` | Logzio listener region. |
+| global.logzioMetricsToken | string | `""` | Logzio metrics token. |
+| global.logzioSpmToken | string | `""` | Logzio spm metrics token. |
+| global.logzioTracesToken | string | `""` | Logzio traces token. |
+| global.env_id | string | `"my_environment"` | Env id to be used with k8s 360. |
 | secrets.windowsNodePassword | string | `""` | Windows node password - will be used to install node-exporter for windows nodes. |
 | secrets.windowsNodeUsername | string | `""` | Windows username - will be used to install node-exporter for windows nodes. |
 | standaloneCollector.resources.limits.cpu | string | `"200m"` | Cpu limit for the opentelemetry collector pod. |

--- a/charts/logzio-telemetry/templates/_daemonset-pod.tpl
+++ b/charts/logzio-telemetry/templates/_daemonset-pod.tpl
@@ -71,11 +71,6 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: logzio-metrics-listener
-      - name: P8S_LOGZIO_NAME
-        valueFrom:
-          secretKeyRef:
-            name: {{ .Values.secrets.name }}
-            key: p8s-logzio-name
       - name: ENV_ID
         valueFrom:
           secretKeyRef:

--- a/charts/logzio-telemetry/templates/_helpers.tpl
+++ b/charts/logzio-telemetry/templates/_helpers.tpl
@@ -149,3 +149,15 @@ If any OOB filters is being used the function return the OOB filter concatenated
 {{- end }}
 {{- $metrics }}
 {{- end }}
+
+{{/*
+Builds the full logzio listener host
+*/}}
+{{- define "metrics-collector.listenerAddress" }}
+{{- $region := .Values.global.logzioRegion -}}
+{{- if or (eq $region "us") (not $region) -}}
+https://listener.logz.io:8053
+{{- else }}
+{{- printf "https://listener-%s.logz.io:8053" $region }}
+{{- end }}
+{{- end }}

--- a/charts/logzio-telemetry/templates/_helpers.tpl
+++ b/charts/logzio-telemetry/templates/_helpers.tpl
@@ -154,7 +154,6 @@ If any OOB filters is being used the function return the OOB filter concatenated
 Builds the full logzio listener host
 */}}
 {{- define "metrics-collector.listenerAddress" }}
-{{- if .Values.global.customMetricsEndpoint }}
 {{- if not (eq .Values.global.customMetricsEndpoint "") -}}
 {{- printf "%s" .Values.global.customMetricsEndpoint -}}
 {{- else }}

--- a/charts/logzio-telemetry/templates/_helpers.tpl
+++ b/charts/logzio-telemetry/templates/_helpers.tpl
@@ -154,10 +154,15 @@ If any OOB filters is being used the function return the OOB filter concatenated
 Builds the full logzio listener host
 */}}
 {{- define "metrics-collector.listenerAddress" }}
+{{- if .Values.global.customMetricsEndpoint }}
+{{- if not (eq .Values.global.customMetricsEndpoint "") -}}
+{{- printf "%s" .Values.global.customMetricsEndpoint -}}
+{{- else }}
 {{- $region := .Values.global.logzioRegion -}}
 {{- if or (eq $region "us") (not $region) -}}
 https://listener.logz.io:8053
 {{- else }}
 {{- printf "https://listener-%s.logz.io:8053" $region }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/logzio-telemetry/templates/_pod-spm.tpl
+++ b/charts/logzio-telemetry/templates/_pod-spm.tpl
@@ -42,11 +42,6 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: logzio-metrics-listener
-      - name: P8S_LOGZIO_NAME
-        valueFrom:
-          secretKeyRef:
-            name: {{ .Values.secrets.name }}
-            key: p8s-logzio-name
       - name: SPM_TOKEN
         valueFrom:
           secretKeyRef:

--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -80,11 +80,6 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: logzio-metrics-listener
-      - name: P8S_LOGZIO_NAME
-        valueFrom:
-          secretKeyRef:
-            name: {{ .Values.secrets.name }}
-            key: p8s-logzio-name   
 {{- end }}
 {{- if .Values.traces.enabled }}
       - name: TRACES_TOKEN
@@ -92,7 +87,7 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: logzio-traces-shipping-token
-      {{ if .Values.secrets.CustomTracingEndpoint}}
+      {{ if .Values.global.CustomTracingEndpoint }}
       - name: CUSTOM_TRACING_ENDPOINT
         valueFrom:
           secretKeyRef:

--- a/charts/logzio-telemetry/templates/secrets.yaml
+++ b/charts/logzio-telemetry/templates/secrets.yaml
@@ -10,28 +10,28 @@ stringData:
 {{- if .Values.opencost.enabled -}}
   opencost-duplicates: container_memory_usage_bytes|container_fs_limit_bytes|container_fs_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total|container_cpu_usage_seconds_total|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_job_status_failed|kube_namespace_annotations|kube_namespace_labels|kube_node_labels|kube_node_status_allocatable|kube_node_status_allocatable_cpu_cores|kube_node_status_allocatable_memory_bytes|kube_node_status_capacity|kube_node_status_capacity_cpu_cores|kube_node_status_capacity_memory_bytes|kube_node_status_condition|kube_persistentvolume_capacity_bytes|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_annotations|kube_pod_container_resource_limits|kube_pod_container_resource_limits_cpu_cores|kube_pod_container_resource_limits_memory_bytes|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_running|kube_pod_container_status_terminated_reason|kube_pod_labels|kube_pod_owner|kube_pod_status_phase|kube_replicaset_owner|node_cpu_seconds_total|node_disk_reads_completed|node_disk_reads_completed_total|node_disk_writes_completed|node_disk_writes_completed_total|node_filesystem_device_error|node_memory_Buffers_bytes|node_memory_Cached_bytes|node_memory_MemAvailable_bytes|node_memory_MemFree_bytes|node_memory_MemTotal_bytes|node_network_transmit_bytes_total|
 {{- end }}  
-  env_id: {{.Values.secrets.env_id | quote }}
+  env_id: {{.Values.global.env_id | quote }}
 {{- if .Values.metrics.enabled }}
-  logzio-metrics-shipping-token: {{ .Values.secrets.MetricsToken }}
+  logzio-metrics-shipping-token: {{ .Values.logzioMetricsToken | default .Values.global.logzioMetricsToken }}
   {{ if .Values.k8sObjectsConfig.enabled }}
-  logzio-k8s-objects-logs-token: {{ .Values.secrets.k8sObjectsLogsToken }}
-  logzio-listener-region: {{ .Values.secrets.LogzioRegion }}
+  logzio-k8s-objects-logs-token: {{ .Values.logzioLogsToken | default .Values.global.logzioLogsToken }}
   {{ end }}    
 {{- end }}
+{{- if or .Values.traces.enabled .Values.k8sObjectsConfig.enabled }}
+  logzio-listener-region: {{ .Values.global.logzioRegion }}
+{{- end }}
 {{- if or (eq .Values.metrics.enabled true) (eq .Values.spm.enabled true) }}
-  logzio-metrics-listener: {{ .Values.secrets.ListenerHost }}
-  p8s-logzio-name: {{.Values.secrets.p8s_logzio_name | quote }}
+  logzio-metrics-listener: {{ template "metrics-collector.listenerAddress" . }}
 {{- end }}
 {{- if .Values.traces.enabled }}
-  logzio-traces-shipping-token: {{ .Values.secrets.TracesToken }}
-  logzio-listener-region: {{ .Values.secrets.LogzioRegion}}
-  {{ if .Values.secrets.CustomTracingEndpoint }}
-  custom-tracing-endpoint: {{ .Values.secrets.CustomTracingEndpoint}}
+  logzio-traces-shipping-token: {{ .Values.logzioTracesToken | default .Values.global.logzioTracesToken }}
+  {{ if .Values.global.CustomTracingEndpoint }}
+  custom-tracing-endpoint: {{ .Values.global.customTracesEndpoint }}
   {{ end }}
   sampling-latency: {{ .Values.secrets.SamplingLatency | quote }}
   sampling-probability: {{ .Values.secrets.SamplingProbability | quote}}
 {{ if .Values.spm.enabled }}
-  logzio-spm-shipping-token: {{ .Values.secrets.SpmToken }}
+  logzio-spm-shipping-token: {{ .Values.logzioSpmToken | default .Values.global.logzioSpmToken }}
 {{ end }}
 {{- end }}
 {{- if .Values.secrets.windowsNodeUsername }}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -27,18 +27,25 @@ nodeExporter:
 nameOverride: "otel-collector" # The resources name prefix 
 fullnameOverride: "" # The resources name
 
+global:
+  # Metrics account shipping token
+  logzioMetricsToken: ""
+  # Tracing account shipping token
+  logzioTracesToken: ""
+  # Span Metrics account shipping token
+  logzioSpmToken: ""
+  # Kubernetes objects Logs account shipping token
+  logzioLogsToken: ""
+  # Environment name 
+  env_id: "my_environment"
+  # Traces & Logs listener address region code - https://docs.logz.io/docs/user-guide/admin/hosting-regions/account-region/
+  logzioRegion: "us"
+  # Custom Traces listener endpoint
+  customTracesEndpoint: ""
+
 secrets:
   name: logzio-secret  # Secret name
   enabled: true  # Create secret
-  MetricsToken: ""  # Metrics account shipping token
-  TracesToken: ""  # Tracing account shipping token
-  SpmToken: ""  # Span Metrics account shipping token
-  k8sObjectsLogsToken: ""  # Kubernetes objects Logs account shipping token
-  ListenerHost: ""  # Logz.io metrics listener address - https://docs.logz.io/docs/user-guide/admin/hosting-regions/account-region/
-  env_id: "my_environment"  # Environment name 
-  LogzioRegion: "us"  # Traces & Logs listener address region code - https://docs.logz.io/docs/user-guide/admin/hosting-regions/account-region/
-  CustomTracingEndpoint: ""  # Custom Traces listener endpoint
-  p8s_logzio_name: ""  # Metrics Environment name
   windowsNodeUsername: ""  # Windows Node Username
   windowsNodePassword: ""  # Windows Node Password
   SamplingProbability: 10  # Traces Sampling Probability
@@ -325,7 +332,7 @@ metricsConfig:
       timeout: 30s
       endpoint: ${LISTENER_URL}
       external_labels:
-        p8s_logzio_name: ${P8S_LOGZIO_NAME}
+        p8s_logzio_name: ${ENV_ID}
       headers:
         Authorization: "Bearer ${METRICS_TOKEN}"
         user-agent: "{{ .Chart.Name }}-{{ .Chart.Version }}-helm"
@@ -333,7 +340,7 @@ metricsConfig:
       timeout: 30s
       endpoint: ${LISTENER_URL}
       external_labels:
-        p8s_logzio_name: ${P8S_LOGZIO_NAME}
+        p8s_logzio_name: ${ENV_ID}
       headers:
         Authorization: "Bearer ${METRICS_TOKEN}"
         user-agent: "{{ .Chart.Name }}-{{ .Chart.Version }}-helm"
@@ -1009,7 +1016,7 @@ daemonsetConfig:
       timeout: 30s
       endpoint: ${LISTENER_URL}
       external_labels:
-        p8s_logzio_name: ${P8S_LOGZIO_NAME}
+        p8s_logzio_name: ${ENV_ID}
       headers:
         Authorization: "Bearer ${METRICS_TOKEN}"
         user-agent: "{{ .Chart.Name }}-{{ .Chart.Version }}-helm"
@@ -1017,7 +1024,7 @@ daemonsetConfig:
       timeout: 30s
       endpoint: ${LISTENER_URL}
       external_labels:
-        p8s_logzio_name: ${P8S_LOGZIO_NAME}
+        p8s_logzio_name: ${ENV_ID}
       headers:
         Authorization: "Bearer ${METRICS_TOKEN}"
         user-agent: "{{ .Chart.Name }}-{{ .Chart.Version }}-helm"

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -40,8 +40,10 @@ global:
   env_id: "my_environment"
   # Traces & Logs listener address region code - https://docs.logz.io/docs/user-guide/admin/hosting-regions/account-region/
   logzioRegion: "us"
-  # Custom Traces listener endpoint
+  # Custom Traces endpoint, overrides global.LogzioRegion listener address
   customTracesEndpoint: ""
+  # Custom Metrics endpoint, overrides global.LogzioRegion listener address
+  customMetricsEndpoint: ""
 
 secrets:
   name: logzio-secret  # Secret name


### PR DESCRIPTION
## Description 

- Change Logz.io secret values to global to prevent duplicate values in the parent chart
  - `secrets.MetricsToken` >> `global.logzioMetricsToken`
  - `secrets.TracesToken` >> `global.logzioTracesToken`
  - `secrets.SpmToken` >> `global.logzioSpmToken`
  - `secrets.k8sObjectsLogsToken` >> `global.logzioLogsToken`
  - `secrets.env_id` >> `global.env_id`
  - `secrets.LogzioRegion` >> `global.logzioRegion`
  - `secrets.CustomTracingEndpoint` >> `global.customTracesEndpoint`
  - Deprecate `secrets.p8s_logzio_name` and `secrets.ListenerHost`
    - Add support for `global.customMetricsEndpoint` to substitute the custom endpoint ability that was supported with `secrets.ListenerHost`
- Update readme
- Align tests

**Note:** in contrast to the changes in other charts, I didn't make the below changes due to `logzio-k8s-telemetry` being replaced with `logzio-metrics-collector` in the near future:
1. Move changelog from `README.md` to `CHANGELOG.md`
2. Rename K8s secret resource configuration `secrets` >> `secret`

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
