### PR TITLE
[Release] `logzio-k8s-events` align to new global structure

### DIFF
--- a/charts/logzio-k8s-events/CHANGELOG.md
+++ b/charts/logzio-k8s-events/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changes by Version
+
+<!-- next version -->
+
+## 1.0.0
+- **Breaking changes:**
+  - Secret values are now global and aligned to prevent duplicate values in the parent chart
+    - `secrets.logzioShippingToken` >> `global.logzioLogsToken`
+    - `secrets.logzioListener` >> `global.logzioRegion`
+    - `secrets.env_id` >> `global.env_id`
+    - `secrets.customListener` >> `global.customLogsEndpoint`
+  -  K8s secret resource configuration has been renamed from `secrets` >> `secret`
+    - `secretName` >> `secret.name`
+
+## 0.0.8
+- Upgrade `logzio-k8s-events` to v`0.0.4`
+  - Upgrade GoLang version to `v1.23.0`
+  - Upgrade `github.com/logzio/logzio-go` to `v1.0.9`
+  - Upgrade GoLang docker image to `golang:1.23.0-alpine3.20`
+
+## 0.0.7
+- Remove default resources `limits`
+
+## 0.0.6
+- Upgrade `logzio-k8s-events` to v0.0.3
+  - Upgrade GoLang version to `v1.22.3`
+  - Upgrade docker image to `alpine:3.20`
+  - Upgrade GoLang docker image to `golang:1.22.3-alpine3.20`
+
+## 0.0.5
+- Remove the duplicate label `app.kubernetes.io/managed-by` @philwelz
+
+## 0.0.4
+- Enhanced env_id handling to support both numeric and string formats.
+
+## 0.0.3
+- Rename listener template.
+
+## 0.0.2
+- Ignore internal event changes.
+
+## 0.0.1
+- Initial release.

--- a/charts/logzio-k8s-events/Chart.yaml
+++ b/charts/logzio-k8s-events/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - k8s
   - kubernetes
-version: 0.0.8
+version: 1.0.0
 appVersion: 0.0.4
 maintainers:
   - name: Raul Gurshumov

--- a/charts/logzio-k8s-events/README.md
+++ b/charts/logzio-k8s-events/README.md
@@ -31,9 +31,9 @@ Replace `<<ENV-ID>>` with your Kubernetes cluster name.
 
 ```shell
 helm install --namespace=monitoring \
---set secrets.logzioShippingToken='<<SHIPPING-TOKEN>>' \
---set secrets.logzioListener='<<LISTENER-HOST>>' \
---set secrets.env_id='<<ENV-ID>>' \
+--set global.logzioLogsToken='<<SHIPPING-TOKEN>>' \
+--set global.logzioRegion='<<LOGZIO-REGION>>' \
+--set global.env_id='<<ENV-ID>>' \
 logzio-k8s-events logzio-helm/logzio-k8s-events
 ```
 
@@ -48,9 +48,9 @@ Replace `<<CUSTOM-HOST>>` with your endpoint URL.
 
 ```shell
 helm install --namespace=monitoring \
---set secrets.logzioShippingToken='<<SHIPPING-TOKEN>>' \
---set secrets.customListener='<<CUSTOM-HOST>>' \
---set secrets.env_id='<<ENV-ID>>' \
+--set global.logzioLogsToken='<<SHIPPING-TOKEN>>' \
+--set global.customLogsEndpoint='<<CUSTOM-HOST>>' \
+--set global.env_id='<<ENV-ID>>' \
 logzio-k8s-events logzio-helm/logzio-k8s-events
 ```
 
@@ -95,28 +95,3 @@ To determine if a node uses taints as well as to display the taint keys, run:
 ```sh
 kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.taints}"
 ```
-
-
-## Change log
- - **0.0.8**:
-   - Upgrade `logzio-k8s-events` to v`0.0.4`
-      - Upgrade GoLang version to `v1.23.0`
-      - Upgrade `github.com/logzio/logzio-go` to `v1.0.9`
-      - Upgrade GoLang docker image to `golang:1.23.0-alpine3.20`
- - **0.0.7**:
-   - Remove default resources `limits`
- - **0.0.6**:
-   - Upgrade `logzio-k8s-events` to v0.0.3
-      - Upgrade GoLang version to `v1.22.3`
-      - Upgrade docker image to `alpine:3.20`
-      - Upgrade GoLang docker image to `golang:1.22.3-alpine3.20`
- - **0.0.5**:
-    - Remove the duplicate label `app.kubernetes.io/managed-by` @philwelz
- - **0.0.4**:
-    - Enhanced env_id handling to support both numeric and string formats.
- - **0.0.3**:
-    - Rename listener template.
- - **0.0.2**:
-    - Ignore internal event changes.
- - **0.0.1**:
-    - Initial release.

--- a/charts/logzio-k8s-events/templates/_helpers.tpl
+++ b/charts/logzio-k8s-events/templates/_helpers.tpl
@@ -68,13 +68,13 @@ Create the name of the service account to use
 Builds the full logzio listener host
 */}}
 {{- define "logzio-k8s-events.listenerHost" }}
-{{- if not (eq .Values.secrets.customListener "") -}}
-{{- printf "%s" .Values.secrets.customListener -}}
+{{- if not (eq .Values.global.customLogsEndpoint "") -}}
+{{- printf "%s" .Values.global.customLogsEndpoint -}}
 {{- else -}}
-{{- if or ( eq $.Values.secrets.logzioListener "listener.logz.io" ) ( eq $.Values.secrets.logzioListener "" ) -}}
+{{- if or ( eq $.Values.global.logzioRegion "us" ) ( eq $.Values.global.logzioRegion "" ) -}}
 {{- printf "https://listener.logz.io:8071" }}
 {{- else }}
-{{- printf "https://%s:8071" .Values.secrets.logzioListener -}}
+{{- printf "https://listener-%s.logz.io:8071" $.Values.global.logzioRegion }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/logzio-k8s-events/templates/deployment.yaml
+++ b/charts/logzio-k8s-events/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
         - name: {{ .Values.k8sApp }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- if (or .Values.secretName .Values.envVars) }}
+        {{- if (or .Values.secret.name .Values.envVars) }}
           env:
           {{- range .Values.envVars }}
             - name: {{ .name | quote }}
@@ -48,21 +48,21 @@ spec:
             {{ .valueFrom | toYaml | indent 16 }}
             {{- end }}
           {{- end }}
-          {{- if .Values.secretName }}
+          {{- if .Values.secret.name }}
             - name: LOGZIO_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{.Values.secretName}}
+                  name: {{.Values.secret.name}}
                   key: logzio-log-shipping-token
             - name: LOGZIO_LISTENER
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secretName }}
+                  name: {{ .Values.secret.name }}
                   key: logzio-log-listener
             - name: ENV_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secretName }}
+                  name: {{ .Values.secret.name }}
                   key: env-id     
           {{- end }}
         {{- end }}

--- a/charts/logzio-k8s-events/templates/secret.yaml
+++ b/charts/logzio-k8s-events/templates/secret.yaml
@@ -1,15 +1,15 @@
-{{- if .Values.secrets.enabled -}}
+{{- if .Values.secret.enabled -}}
 apiVersion: {{ .Values.apiVersions.secret }}
 kind: Secret
 metadata:
-  name: {{ .Values.secretName }}
+  name: {{ .Values.secret.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: {{ .Values.k8sApp }}
     {{- include "logzio-k8s-events.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  logzio-log-shipping-token: {{ required "Logzio shipping token is required!" .Values.secrets.logzioShippingToken }}
+  logzio-log-shipping-token: {{ required "Logzio shipping token is required!" (.Values.logzioLogsToken | default .Values.global.logzioLogsToken) }}
   logzio-log-listener: {{ template "logzio-k8s-events.listenerHost" . }}
-  env-id: {{ .Values.secrets.env_id | quote }}
+  env-id: {{ .Values.global.env_id | quote }}
 {{- end }}

--- a/charts/logzio-k8s-events/values.yaml
+++ b/charts/logzio-k8s-events/values.yaml
@@ -21,6 +21,12 @@ apiVersions:
 nameOverride: ""
 fullnameOverride: ""
 
+global:
+  logzioLogsToken: ""
+  logzioRegion: "" # Defaults to us
+  env_id: ""
+  customLogsEndpoint: "" # Overrides Logz.io listener
+
 isRBAC: true
 
 serviceAccount:
@@ -38,14 +44,9 @@ terminationGracePeriodSeconds: 30
 nodeArchitectures: 
   - arm64
   - amd64
-secrets:
+secret:
   enabled: true
-  logzioShippingToken: ""
-  logzioListener: "" # Defaults to listener.logz.io
-  env_id: ""
-  customListener: "" # Overrides Logz.io listener
-
-secretName: logzio-k8s-events-secret
+  name: logzio-k8s-events-secret
 
 clusterRole:
   rules:


### PR DESCRIPTION
## Description 

- Change secret values to global to prevent duplicate values in the parent chart
    - `secrets.logzioShippingToken` >> `global.logzioLogsToken`
    - `secrets.logzioListener` >> `global.logzioRegion`
    - `secrets.env_id` >> `global.env_id`
    - `secrets.customListener` >> `global.customLogsEndpoint`
- K8s secret resource configuration has been renamed `secrets` >> `secret`
    - `secretName` >> `secret.name`
- Move changelog from `README.md` >> `CHANGELOG.md`
- Update readme
- Alighn tests

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
