### PR TITLE
[Bugfix] Standalone node metrics endpoint

### DIFF
--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 4.3.1
+version: 4.3.2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -412,6 +412,8 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 4.3.2
+  - Fix `prometheus/kubelet` scrape endpoint for standalone deployment
 * 4.3.1
   - Add `prometheus/kubelet` job for kubelet metrics
 * 4.3.0

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -389,17 +389,26 @@ metricsConfig:
           scrape_interval: 30s
           scrape_timeout: 30s
         scrape_configs:
-        - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        - authorization:
+            credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            type: Bearer
           job_name: kubernetes-nodes
           kubernetes_sd_configs:
           - role: node
-            selectors:
-            - field: metadata.name=$KUBE_NODE_NAME
-              role: node
-          metrics_path: /metrics
+          metric_relabel_configs: []
           relabel_configs:
+          - replacement: kubernetes.default.svc:443
+            target_label: __address__
           - action: labelmap
             regex: __meta_kubernetes_node_label_(.+)
+          - action: replace
+            replacement: kubernetes360
+            target_label: logzio_app            
+          - regex: (.+)            
+            replacement: /api/v1/nodes/$${1}/proxy/metrics
+            source_labels:
+            - __meta_kubernetes_node_name
+            target_label: __metrics_path__
           - action: replace
             replacement: kubernetes360
             target_label: logzio_app


### PR DESCRIPTION
## Description 

* 4.3.2
  - Fix `prometheus/kubelet` scrape endpoint for standalone deployment

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
