### PR TITLE
[Bug fix] resolve bug with deploying APM chart on fargate

### DIFF
--- a/charts/logzio-apm-collector/CHANGELOG.md
+++ b/charts/logzio-apm-collector/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changes by Version
 
 <!-- next version -->
+## 1.2.0
+- Resolve issue preventing APM chart deployment on Fargate
+- Upgrade OpenTelemetry Collector from `0.117.0` to `0.119.0`
 
 ## 1.1.0
 - Implement option to override the global Logz.io shipping tokens
-- Upgrade OpenTelemetry Collector from `1.116.1` to `1.117.0`
+- Upgrade OpenTelemetry Collector from `0.116.1` to `0.117.0`
 
 ## 1.0.0
 - Initial release 

--- a/charts/logzio-apm-collector/Chart.yaml
+++ b/charts/logzio-apm-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: logzio-apm-collector
-version: 1.1.0
+version: 1.2.0
 description: Kubernetes APM agent for Logz.io based on OpenTelemetry Collector
 type: application
 home: https://logz.io/
@@ -8,4 +8,4 @@ icon: https://logzbucket.s3.eu-west-1.amazonaws.com/logz-io-img/logo400x400.png
 maintainers:
   - name: Naama Bendalak
     email: naama.bendalak@logz.io
-appVersion: 0.117.0
+appVersion: 0.119.0

--- a/charts/logzio-apm-collector/values.yaml
+++ b/charts/logzio-apm-collector/values.yaml
@@ -488,16 +488,7 @@ containerSecurityContext: {}
 
 nodeSelector: {}
 tolerations: []
-# Set affinity rules for the scheduler to determine where all DaemonSet pods can be placed.
-# The following configuration prevent logzio APM collector DaemonSet deployment on fargate nodes
-# DaemonSet mode is not used in the current APM chart, this configuration is retained for potential future support.
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: eks.amazonaws.com/compute-type
-              operator: DoesNotExist
+affinity: {}
 topologySpreadConstraints: []
 
 # Allows for pod scheduler prioritisation


### PR DESCRIPTION
## Description 

- resolve bug of deploying the APM chart on fargate
  - I kept in the `values.yaml` an affinity configuration from `logzio-telemetry` which is relevant for daemonset mode (that is not supported in this chart) and caused the pods to not be scheduled on a node in fargate.
- Upgrade OTEL Collector version to 0.119.0
- Update changelog

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
