### PR TITLE
[Feature] add `otlp` metrics receivers support to `logzio-telemetry`

### DIFF
--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 5.0.0
+version: 5.0.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -397,6 +397,8 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 5.0.1
+  - Add `otlp` receivers to the metrics pipeline.
 * 5.0.0
   - **Breaking Changes**
     - Logz.io secret values are now global

--- a/charts/logzio-telemetry/templates/_daemonset-pod.tpl
+++ b/charts/logzio-telemetry/templates/_daemonset-pod.tpl
@@ -18,7 +18,7 @@ containers:
       {{- toYaml .Values.containerSecurityContext | nindent 6 }}
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
     imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.traces.enabled }}
+{{- if (and (not .Values.traces.enabled) .Values.metrics.enabled) }}
     ports:
       {{- range $key, $port := .Values.ports }}
       {{- if $port.enabled }}

--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -18,7 +18,7 @@ containers:
       {{- toYaml .Values.containerSecurityContext | nindent 6 }}
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
     imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.traces.enabled }}
+{{- if (or .Values.traces.enabled .Values.metrics.enabled) }}
     ports:
       {{- range $key, $port := .Values.ports }}
       {{- if $port.enabled }}

--- a/charts/logzio-telemetry/templates/daemonset-collector.yaml
+++ b/charts/logzio-telemetry/templates/daemonset-collector.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "opentelemetry-collector.selectorLabels" . | nindent 6 }}
-      component: daemonset-collector
+      component: logzio-telemetry-collector
   template:
     metadata:
       annotations:
@@ -19,7 +19,7 @@ spec:
         {{- end }}
       labels:
         {{- include "opentelemetry-collector.selectorLabels" . | nindent 8 }}
-        component: daemonset-collector
+        component: logzio-telemetry-collector
         {{- with .Values.daemonsetCollector.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/logzio-telemetry/templates/deployment.yaml
+++ b/charts/logzio-telemetry/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "opentelemetry-collector.selectorLabels" . | nindent 6 }}
-      component: standalone-collector
+      component: logzio-telemetry-collector
   template:
     metadata:
       annotations:
@@ -22,7 +22,7 @@ spec:
         {{- end }}
       labels:
         {{- include "opentelemetry-collector.selectorLabels" . | nindent 8 }}
-        component: standalone-collector
+        component: logzio-telemetry-collector
         {{- with .Values.standaloneCollector.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/logzio-telemetry/templates/service.yaml
+++ b/charts/logzio-telemetry/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.collector.mode "standalone") (.Values.traces.enabled) }}
+{{- if or .Values.traces.enabled .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -26,5 +26,5 @@ spec:
     {{- end }}
   selector:
     {{- include "opentelemetry-collector.selectorLabels" . | nindent 4 }}
-    component: standalone-collector
+    component: logzio-telemetry-collector
 {{- end }}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -1072,6 +1072,12 @@ daemonsetConfig:
         Authorization: "Bearer ${METRICS_TOKEN}"
         user-agent: "{{ .Chart.Name }}-{{ .Chart.Version }}-helm"
   receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
     prometheus/applications:
       config:
         global:
@@ -1275,6 +1281,7 @@ daemonsetConfig:
           - prometheus/cadvisor
           - prometheus/kubelet
           - prometheus/collector
+          - otlp
     telemetry:
       logs:
         level: "info" 

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -347,6 +347,12 @@ metricsConfig:
         Authorization: "Bearer ${METRICS_TOKEN}"
         user-agent: "{{ .Chart.Name }}-{{ .Chart.Version }}-helm"
   receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
     prometheus/applications:
       config:
         global:
@@ -544,6 +550,7 @@ metricsConfig:
           - prometheus/cadvisor
           - prometheus/kubelet
           - prometheus/collector
+          - otlp
           
 # Shared params for daemonsetCollector and standaloneCollector deployment pods.
 # Can be overridden here or for any component independently using the same keys.


### PR DESCRIPTION
## Description 

- Add `otlp` metrics receivers
  - Required for the opentelemetry operator up coming PR 
  - By default, Kubernetes Services balance traffic between all pods matching the service's selector. Therefore, in order to handle case where both traces and metrics are enabled (and the metrics is in `daemonset` mode) - OTLP receiver for metrics will only be supported under the condition:
    - only metrics is enabled, supports both `daemonset` and `standalone` modes
    - both metrics and traces, supports only `standalone` mode
- Update readme


## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
