### PR TITLE
[Feature] upgrade to `logzio-telemetry` version `5.0.1`

### DIFF
--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changes by Version
 
 <!-- next version -->
+## 7.0.1
+- Upgrade `logzio-telemetry` chart to `v5.0.1`
+  - Add `otlp` receivers to the metrics pipeline.
 
 ## 7.0.0
 - **Breaking changes:**

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 7.0.0
+version: 7.0.1
 
 
 
@@ -14,7 +14,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "5.0.0"
+    version: "5.0.1"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logzio-k8s-telemetry.metrics.enabled
   - name: logzio-trivy


### PR DESCRIPTION
## Description 

this pr should resolve #585

- Upgrade `logzio-telemetry` chart to `v5.0.1`
  - Add `otlp` receivers to the metrics pipeline.

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
