### PR TITLE
[Feature] Add OTEL Operator, `logzio-monitoring` version `7.1.0`

### DIFF
--- a/.github/workflows/auto-release-kube-tools.yaml
+++ b/.github/workflows/auto-release-kube-tools.yaml
@@ -1,0 +1,34 @@
+name: Release kube-tools docker image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'charts/logzio-monitoring/plugins/Dockerfile'
+
+jobs:
+  release-docker:
+    name: release kube-tools docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Get new image version
+        id: extract_version
+        run: echo "NEW_VERSION=$(sed -n 's/^LABEL version="\([0-9.]*\)"/\1/p' charts/logzio-monitoring/plugins/Dockerfile)" >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          platforms: linux/amd64, linux/arm/v7, linux/arm/v8, linux/arm64
+          tags: logzio/kube-tools:latest, logzio/kube-tools:${{ env.NEW_VERSION }}

--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- next version -->
 
+## 7.1.0
+- Upgrade `logzio-k8s-telemetry` chart to `5.0.1`
+  - Add `otlp` receivers to the metrics pipeline.
+- Add option to enable OpenTelemetry Operator for auto-instrumentation of the cluster applications.
+  - Included `opentelemetry-operator` chart in version `~0.79.0`
+  - Allow customization of propagators, sampler, data type to collect and libraries to enable.
+
 ## 7.0.2
 - Upgrade `logzio-telemetry` chart to `v5.0.2`
   - Exposed collector service port for `thrift_binary` jaeger receiver

--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -3,8 +3,6 @@
 <!-- next version -->
 
 ## 7.1.0
-- Upgrade `logzio-k8s-telemetry` chart to `5.0.1`
-  - Add `otlp` receivers to the metrics pipeline.
 - Add option to enable OpenTelemetry Operator for auto-instrumentation of the cluster applications.
   - Included `opentelemetry-operator` chart in version `~0.79.0`
   - Allow customization of propagators, sampler, data type to collect and libraries to enable.

--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changes by Version
 
 <!-- next version -->
+
 ## 7.0.2
 - Upgrade `logzio-telemetry` chart to `v5.0.2`
   - Exposed collector service port for `thrift_binary` jaeger receiver
+
 ## 7.0.1
 - Upgrade `logzio-telemetry` chart to `v5.0.1`
   - Add `otlp` receivers to the metrics pipeline.

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -37,6 +37,11 @@ dependencies:
     version: "1.2.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logzio-apm-collector.enabled
+  - name: opentelemetry-operator
+    alias: otel-operator
+    version: ~0.79.0
+    repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+    condition: otel-operator.enabled
 maintainers:
 - name: yotamloe
   email: yotam.loewenbach@logz.io

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 7.0.2
+version: 7.1.0
 
 
 

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -28,8 +28,8 @@ This project packages the following Helm Charts:
     - [Custom endpoint for traces](#send-traces-to-a-custom-endpoint)
   - [Image pull rate limit issue](#handling-image-pull-rate-limit)
   - [Add tolerations for tainted nodes](#adding-tolerations-for-tainted-nodes)
-  - [Migrating to logzio-monitoring v7.0.0](#migrating-to-logzio-monitoring-700)
-  - [Enabled Auto-Instrumentation](#enable-auto-instrumentation)
+- [Migrating to logzio-monitoring v7.0.0](#migrating-to-logzio-monitoring-700)
+- [Enabled Auto-Instrumentation](#enable-auto-instrumentation)
 
 ## Instructions for standard deployment:
 
@@ -436,7 +436,7 @@ helm upgrade logzio-monitoring logzio-helm/logzio-monitoring -n monitoring \
 
 The Opentelemetry Operator manages auto-instrumentation of workloads using OpenTelemetry instrumentation libraries, automatically generating traces and metrics.
 
-To send the instrumentation data it generates to Logz.io,, you need to enable the operator within the `logzio-monitoring` chart, along with either the `logzio-apm-collector` (for traces), `logzio-k8s-telemetry` (for metrics), or both, both—depending on the type of data you want to forward to the Logz.io platform.
+To send the instrumentation data it generates to Logz.io, you need to enable the operator within the `logzio-monitoring` chart, along with either the `logzio-apm-collector` (for traces), `logzio-k8s-telemetry` (for metrics), or both, both—depending on the type of data you want to forward to the Logz.io platform.
 
 Follow the guide below to enable this feature.
 

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -440,6 +440,10 @@ To send the instrumentation data it generates to Logz.io,, you need to enable th
 
 Follow the guide below to enable this feature.
 
+> [!WARNING]
+> The Operator does not support Windows nodes at the moment.
+
+
 - [Step by step guide](#enable-auto-instrumentation)
   - [Multi-container pods](#multi-container-pods)
 - [Customize Auto-instrumentation](#customize-auto-instrumentation)

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -459,7 +459,7 @@ Follow the guide below to enable this feature.
 
 **Step 2:** Add annotations to your relevant Kubernetes object. You can annotate individual resources such as a Deployment, StatefulSet, DaemonSet, or Pod, or apply annotations at the Namespace level to instrument all pods within that namespace. These annotations should specify the programming language used in your application:
 ```yaml
-instrumentation.opentelemetry.io/inject-<APP_LANGUAGE>: "monitoring/logzio-otel-instrumentation"
+instrumentation.opentelemetry.io/inject-<APP_LANGUAGE>: "monitoring/logzio-monitoring-instrumentation"
 ```
 
 > [!TIP]

--- a/charts/logzio-monitoring/plugins/Dockerfile
+++ b/charts/logzio-monitoring/plugins/Dockerfile
@@ -1,0 +1,10 @@
+################## K8S TOOLS IMAGE ######################
+## Required for the webhook-ready-check-job.
+## ref: https://hub.docker.com/r/logzio/kube-tools/tags
+#########################################################
+FROM alpine:3.21.2
+LABEL version="0.0.1"
+
+RUN apk add --no-cache curl kubectl
+
+CMD ["/bin/sh"]

--- a/charts/logzio-monitoring/templates/operator/_helpers.tpl
+++ b/charts/logzio-monitoring/templates/operator/_helpers.tpl
@@ -21,6 +21,10 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/hook: "post-install, post-upgrade"
 {{- end -}}
 
+{{- define "otel-operator.instrumentationAnnotations" -}}
+helm.sh/hook: "post-install"
+{{- end -}}
+
 {{/* Common annotations */}}
 {{- define "otel-operator.cleanupAnnotations" -}}
 helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded, hook-failed"

--- a/charts/logzio-monitoring/templates/operator/_helpers.tpl
+++ b/charts/logzio-monitoring/templates/operator/_helpers.tpl
@@ -1,0 +1,46 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "otel-operator.fullname" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}-instrumentation
+{{- end -}}
+
+
+{{/* Common labels */}}
+{{- define "otel-operator.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/* Common annotations */}}
+{{- define "otel-operator.annotations" -}}
+helm.sh/hook: "post-install, post-upgrade"
+{{- end -}}
+
+{{/* Common annotations */}}
+{{- define "otel-operator.cleanupAnnotations" -}}
+helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded, hook-failed"
+{{- end -}}
+
+
+{{/* Resource\DataType exporter type definer */}}
+{{- define "otel-operator.rsourceExporterType" -}}
+{{- $enabledResource := .enabledResource -}}
+{{- $enabledSubChart := .enabledSubChart -}}
+{{- if and $enabledResource $enabledSubChart -}}
+"otlp"
+{{- else -}}
+"none"
+{{- end -}}
+{{- end -}}
+
+{{/* The relevant endpoint's service address */}}
+{{- define "otel-operator.serviceAddr" -}}
+{{- $serviceName := .serviceName -}}
+{{- $releaseNamespace := .releaseNamespace -}}
+{{- printf "http://%s.%s.svc.cluster.local" $serviceName $releaseNamespace }}
+{{- end -}}

--- a/charts/logzio-monitoring/templates/operator/_instrumentation.tpl
+++ b/charts/logzio-monitoring/templates/operator/_instrumentation.tpl
@@ -62,6 +62,8 @@ spec:
     env:
       - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
         value: {{ include "otel-operator.serviceAddr" (dict "serviceName" .Values.instrumentation.tracesServiceName "releaseNamespace" .Release.Namespace) }}:4317
+      - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+        value: {{ include "otel-operator.serviceAddr" (dict "serviceName" .Values.instrumentation.metricsServiceName "releaseNamespace" .Release.Namespace) }}:4317
       - name: OTEL_METRICS_EXPORTER
         value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.nodejs.metrics.enabled "enabledSubChart" $metricsEnabled) }}
       - name: OTEL_TRACES_EXPORTER

--- a/charts/logzio-monitoring/templates/operator/_instrumentation.tpl
+++ b/charts/logzio-monitoring/templates/operator/_instrumentation.tpl
@@ -9,7 +9,7 @@ metadata:
   labels:
     {{- include "otel-operator.labels" . | nindent 4 }}
   annotations:
-    {{- include "otel-operator.annotations" . | nindent 4 }}
+    {{- include "otel-operator.instrumentationAnnotations" . | nindent 4 }}
     helm.sh/hook-weight: "3"
 spec:
   env:

--- a/charts/logzio-monitoring/templates/operator/_instrumentation.tpl
+++ b/charts/logzio-monitoring/templates/operator/_instrumentation.tpl
@@ -1,0 +1,72 @@
+{{- define "otel-operator.instrumentation" -}}
+{{- $metricsEnabled := index .Values "logzio-k8s-telemetry" "metrics" "enabled" -}}
+{{- $tracesEnabled := index .Values "logzio-apm-collector" "enabled" -}}
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: {{ include "otel-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "otel-operator.labels" . | nindent 4 }}
+  annotations:
+    {{- include "otel-operator.annotations" . | nindent 4 }}
+    helm.sh/hook-weight: "3"
+spec:
+  env:
+    {{- if $metricsEnabled }}
+    - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+      value: {{ include "otel-operator.serviceAddr" (dict "serviceName" .Values.instrumentation.metricsServiceName "releaseNamespace" .Release.Namespace) }}:4318
+    {{- end }}
+    {{- if $tracesEnabled }}
+    - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+      value: {{ include "otel-operator.serviceAddr" (dict "serviceName" .Values.instrumentation.tracesServiceName "releaseNamespace" .Release.Namespace) }}:4318
+    {{- end }}
+  resource:
+    addK8sUIDAttributes: {{ .Values.instrumentation.addK8sUIDAttributes }}
+  {{- with .Values.instrumentation.propagators }}
+  propagators:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+  {{- with .Values.instrumentation.sampler }}
+  sampler:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+  dotnet:
+    env:
+      - name: OTEL_METRICS_EXPORTER
+        value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.dotnet.metrics.enabled "enabledSubChart" $metricsEnabled) }}
+      - name: OTEL_TRACES_EXPORTER
+        value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.dotnet.traces.enabled "enabledSubChart" $tracesEnabled) }}
+    {{- with .Values.instrumentation.dotnet.extraEnv }}
+      {{- . | toYaml | nindent 6 }}
+    {{- end }}
+  java:
+    env:
+      - name: OTEL_METRICS_EXPORTER
+        value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.java.metrics.enabled "enabledSubChart" $metricsEnabled) }}
+      - name: OTEL_TRACES_EXPORTER
+        value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.java.traces.enabled "enabledSubChart" $tracesEnabled) }}
+    {{- with .Values.instrumentation.java.extraEnv }}
+      {{- . | toYaml | nindent 6 }}
+    {{- end }}
+  python:
+    env:
+      - name: OTEL_METRICS_EXPORTER
+        value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.python.metrics.enabled "enabledSubChart" $metricsEnabled) }}
+      - name: OTEL_TRACES_EXPORTER
+        value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.python.traces.enabled "enabledSubChart" $tracesEnabled) }}
+    {{- with .Values.instrumentation.python.extraEnv }}
+      {{- . | toYaml | nindent 6 }}
+    {{- end }}
+  nodejs:
+    env:
+      - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+        value: {{ include "otel-operator.serviceAddr" (dict "serviceName" .Values.instrumentation.tracesServiceName "releaseNamespace" .Release.Namespace) }}:4317
+      - name: OTEL_METRICS_EXPORTER
+        value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.nodejs.metrics.enabled "enabledSubChart" $metricsEnabled) }}
+      - name: OTEL_TRACES_EXPORTER
+        value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.nodejs.traces.enabled "enabledSubChart" $tracesEnabled) }}
+    {{- with .Values.instrumentation.nodejs.extraEnv }}
+      {{- . | toYaml | nindent 6 }}
+    {{- end -}}
+{{- end -}}

--- a/charts/logzio-monitoring/templates/operator/clusterrole.yaml
+++ b/charts/logzio-monitoring/templates/operator/clusterrole.yaml
@@ -1,0 +1,18 @@
+{{ $operatorEnabled := index .Values "otel-operator" "enabled" }}
+{{- if $operatorEnabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "otel-operator.fullname" . }}
+  labels:
+    {{- include "otel-operator.labels" . | nindent 4 }}
+  annotations:
+    {{- include "otel-operator.annotations" . | nindent 4 }}
+    {{- include "otel-operator.cleanupAnnotations" . | nindent 4 }}
+    helm.sh/hook-weight: "1"
+rules:
+- apiGroups: ["opentelemetry.io"]
+  resources:
+  - instrumentations
+  verbs: ["patch", "get", "create"]
+{{- end -}}

--- a/charts/logzio-monitoring/templates/operator/clusterrolebinding.yaml
+++ b/charts/logzio-monitoring/templates/operator/clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+{{ $operatorEnabled := index .Values "otel-operator" "enabled" }}
+{{- if $operatorEnabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "otel-operator.fullname" . }}
+  labels:
+    {{- include "otel-operator.labels" . | nindent 4 }}
+  annotations:
+    {{- include "otel-operator.annotations" . | nindent 4 }}
+    {{- include "otel-operator.cleanupAnnotations" . | nindent 4 }}
+    helm.sh/hook-weight: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "otel-operator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "otel-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/logzio-monitoring/templates/operator/configmap.yaml
+++ b/charts/logzio-monitoring/templates/operator/configmap.yaml
@@ -1,0 +1,17 @@
+{{ $operatorEnabled := index .Values "otel-operator" "enabled" }}
+{{- if $operatorEnabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logzio-otel-instrumentation
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "otel-operator.labels" . | nindent 4 }}
+  annotations:
+    {{- include "otel-operator.annotations" . | nindent 4 }}
+    {{- include "otel-operator.cleanupAnnotations" . | nindent 4 }}
+    helm.sh/hook-weight: "1"
+data:
+  relay: |
+    {{- include "otel-operator.instrumentation" . | nindent 4 }}
+{{- end -}}

--- a/charts/logzio-monitoring/templates/operator/instrumentation.yaml
+++ b/charts/logzio-monitoring/templates/operator/instrumentation.yaml
@@ -1,0 +1,4 @@
+{{ $operatorEnabled := index .Values "otel-operator" "enabled" }}
+{{- if $operatorEnabled -}}
+{{- include "otel-operator.instrumentation" . }}
+{{- end -}}

--- a/charts/logzio-monitoring/templates/operator/serviceaccount.yaml
+++ b/charts/logzio-monitoring/templates/operator/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{ $operatorEnabled := index .Values "otel-operator" "enabled" }}
+{{- if $operatorEnabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "otel-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "otel-operator.annotations" . | nindent 4 }}
+    {{- include "otel-operator.cleanupAnnotations" . | nindent 4 }}
+    helm.sh/hook-weight: "1"
+  labels:
+    {{- include "otel-operator.labels" . | nindent 4 }}
+{{- end -}}

--- a/charts/logzio-monitoring/templates/operator/webhook-ready-check-job.yaml
+++ b/charts/logzio-monitoring/templates/operator/webhook-ready-check-job.yaml
@@ -23,6 +23,18 @@ spec:
             - |
               max_wait=180
               SECONDS=0
+
+              apply_instrumentation() {
+                while ! kubectl apply -f /conf/relay.yaml; do
+                  echo "Retrying apply, waiting for {{ include "otel-operator.fullname" . }}"
+                  sleep 5
+                  if [ $SECONDS -ge $max_wait ]; then
+                    echo "Timeout exceeded while applying Instrumentation, instrumentation resource was not applied."
+                    exit 1
+                  fi
+                done
+              }
+
               until curl -k https://logzio-monitoring-otel-operator-webhook.monitoring.svc:443/mutate-opentelemetry-io-v1alpha1-instrumentation; do
                 if [ $SECONDS -ge $max_wait ]; then
                   echo "Opentelemetry Operator webhook readiness timeout exceeded, instrumentation resource was not applied."
@@ -31,17 +43,34 @@ spec:
                 echo "Waiting for Opentelemetry Operator webhook to become ready..."
                 sleep 2
               done
-              echo "Opentelemetry Operator webhook is ready,applying Instrumentation resources"
-              until kubectl get instrumentation {{ include "otel-operator.fullname" . }} -n {{ .Release.Namespace }}; do
-                while ! kubectl apply -f /conf/relay.yaml
-                do
-                  echo "Retrying apply, waiting for {{ include "otel-operator.fullname" . }}"
-                  sleep 5
+
+              echo "Opentelemetry Operator webhook is ready, checking if Instrumentation resource exists"
+              if kubectl get instrumentation logzio-monitoring-instrumentation -n monitoring; then
+                echo "Instrumentation resource already exists, checking for changes"
+                while true; do
+                  kubectl diff -f /conf/relay.yaml
+                  exit_code=$?
+                  if [ $exit_code -eq 0 ]; then
+                    echo "No changes were detected, skipping apply"
+                    exit 0
+                  elif [ $exit_code -eq 1 ]; then
+                    echo "Detected changes in Instrumentation resource, applying"
+                    apply_instrumentation
+                    exit 0
+                  else
+                    echo "Error while checking for changes, retrying"
+                    sleep 5
+                  fi
                   if [ $SECONDS -ge $max_wait ]; then
-                    echo "Timeout exceeded while applying Instrumentation, instrumentation resource was not applied."
+                    echo "Timeout exceeded while applying Instrumentation, instrumentation resource was not updated."
                     exit 1
                   fi
                 done
+              fi
+
+              echo "Applying Instrumentation resources"
+              until kubectl get instrumentation {{ include "otel-operator.fullname" . }} -n {{ .Release.Namespace }}; do
+                apply_instrumentation
                 echo "Applied Instrumentation, verifying..."
                 sleep 5
               done

--- a/charts/logzio-monitoring/templates/operator/webhook-ready-check-job.yaml
+++ b/charts/logzio-monitoring/templates/operator/webhook-ready-check-job.yaml
@@ -1,0 +1,61 @@
+{{ $operatorEnabled := index .Values "otel-operator" "enabled" }}
+{{- if $operatorEnabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "otel-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "otel-operator.annotations" . | nindent 4 }}
+    {{- include "otel-operator.cleanupAnnotations" . | nindent 4 }}
+    helm.sh/hook-weight: "2"
+spec:
+  ttlSecondsAfterFinished: 30
+  template:
+    spec:
+      serviceAccountName: {{ include "otel-operator.fullname" . }}
+      containers:
+        - name: curl
+          image: kube-tools:v2.0.0
+          args:
+            - sh
+            - -c
+            - |
+              max_wait=180
+              SECONDS=0
+              until curl -k https://logzio-monitoring-otel-operator-webhook.monitoring.svc:443/mutate-opentelemetry-io-v1alpha1-instrumentation; do
+                if [ $SECONDS -ge $max_wait ]; then
+                  echo "Opentelemetry Operator webhook readiness timeout exceeded, instrumentation resource was not applied."
+                  exit 1
+                fi
+                echo "Waiting for Opentelemetry Operator webhook to become ready..."
+                sleep 2
+              done
+              echo "Opentelemetry Operator webhook is ready,applying Instrumentation resources"
+              until kubectl get instrumentation {{ include "otel-operator.fullname" . }} -n {{ .Release.Namespace }}; do
+                while ! kubectl apply -f /conf/relay.yaml
+                do
+                  echo "Retrying apply, waiting for {{ include "otel-operator.fullname" . }}"
+                  sleep 5
+                  if [ $SECONDS -ge $max_wait ]; then
+                    echo "Timeout exceeded while applying Instrumentation, instrumentation resource was not applied."
+                    exit 1
+                  fi
+                done
+                echo "Applied Instrumentation, verifying..."
+                sleep 5
+              done
+              echo "Successfully applied Instrumentation resources"
+          volumeMounts:
+            - mountPath: /conf
+              name: logzio-otel-instrumentation
+      restartPolicy: OnFailure
+      volumes:
+        - name: logzio-otel-instrumentation
+          configMap:
+            name: logzio-otel-instrumentation
+            items:
+              - key: relay
+                path: relay.yaml
+  backoffLimit: 4
+{{- end -}}

--- a/charts/logzio-monitoring/templates/operator/webhook-ready-check-job.yaml
+++ b/charts/logzio-monitoring/templates/operator/webhook-ready-check-job.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: {{ include "otel-operator.fullname" . }}
       containers:
         - name: curl
-          image: kube-tools:v2.0.0
+          image: logzio/kube-tools:0.0.1
           args:
             - sh
             - -c

--- a/charts/logzio-monitoring/values.yaml
+++ b/charts/logzio-monitoring/values.yaml
@@ -137,12 +137,12 @@ instrumentation:
     # - ottrace
   
   # Specifies the Sampler used to sample traces by the SDK. (Optional)
-  sampler: {}
-    ## By default, "parentbased_always_on" is enabled, meaning new traces will always be recorded and if the parent span is sampled, then the child span will be sampled.
-    ## ref: https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler
-    # type: "parentbased_always_on"
+  sampler:
+    # By default, "parentbased_always_on" is enabled, meaning new traces will always be recorded and if the parent span is sampled, then the child span will be sampled.
+    # ref: https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler
+    type: "parentbased_always_on"
 
-    ## Each Sampler type defines its own expected args input gor configuring the sampler
+    ## Each Sampler type defines its own expected args input for configuring the sampler
     ## ref: https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler_arg
     # argument: "0.25"
   

--- a/charts/logzio-monitoring/values.yaml
+++ b/charts/logzio-monitoring/values.yaml
@@ -41,3 +41,158 @@ opencost:
     service:
       annotations:
         prometheus.io/scrape: "true"
+
+#######################################################################################################################
+# Enable Auto Instrumentation
+# ref: https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-operator
+#######################################################################################################################
+otel-operator:
+  enabled: false
+
+  # Openteleemtry operator requires a TLS certificate.
+  # ref: https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-operator#tls-certificate-requirement
+  admissionWebhooks:
+    # TLS certificate Option 1
+    # If you have cert-manager installed on your cluster, you can set `certManager.enabled` to true
+    # and the cert-manager will generate a self-signed certificate for the otel-operator automatically.
+    certManager:
+      enabled: false
+
+      # Ensure certificate and issuer are created after the CRDs are installed
+      certificateAnnotations:
+        helm.sh/hook: "post-install, post-upgrade"
+        helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
+      issuerAnnotations:
+        helm.sh/hook: "post-install, post-upgrade"
+        helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
+  
+      ## Provide the issuer kind and name to do the cert auth job.
+      ## By default, OpenTelemetry Operator will use self-signer issuer.
+      # issuerRef: {}
+      # kind:
+      # name:
+
+      ## Annotations for the cert and issuer if cert-manager is enabled.
+      # certificateAnnotations: {}
+      # issuerAnnotations: {}
+
+      ## duration must be specified by a Go time.Duration (ending in s, m or h)
+      # duration: ""
+
+      ## renewBefore must be specified by a Go time.Duration (ending in s, m or h)
+      ## Take care when setting the renewBefore field to be very close to the duration
+      ## as this can lead to a renewal loop, where the Certificate is always in the renewal period.
+      # renewBefore: ""
+    
+    # TLS certificate Option 2
+    # The default option enabled by this chart. Helm will automatically create a self-signed cert and secret for you.
+    autoGenerateCert:
+      enabled: true
+      ## If set to true, new webhook key/certificate is generated on helm upgrade.
+      # recreate: true
+
+      ## Cert period time in days. The default is 365 days.
+      # certPeriodDays: 365
+
+    ## TLS certificate Option 3
+    ## Use your own self-signed certificate
+    ## To enable this option, set `autoGenerateCert.enabled` to false and provide the necessary values:
+    ## Path to your own PEM-encoded certificate.
+    # certFile: ""
+    ## Path to your own PEM-encoded private key.
+    # keyFile: ""
+    ## Path to the CA cert.
+    # caFile: ""
+
+  # Deploying the collector using the operator is not supported currently.
+  # The collector image is specified to meet operator subchart requirments.
+  manager:
+    collectorImage:
+      repository: "otel/opentelemetry-collector-contrib"
+
+#######################################################################################################################
+# Otel Operator Auto Instrumentation configuration
+#######################################################################################################################
+instrumentation:
+  # Set the service name for metrics and traces data endpoints.
+  # If you have modified the default service names using `nameOverride` or `fullnameOverride` in the subcharts 
+  # (`logzio-apm-collector`, `logzio-k8s-telemetry`), update these values accordingly.
+  metricsServiceName: "logzio-monitoring-otel-collector"
+  tracesServiceName: "logzio-apm-collector"
+
+  # Defines whether K8s UID attributes should be collected (e.g. k8s.deployment.uid)
+  addK8sUIDAttributes: false
+
+  # Choose propagator to specify the method of injecting and extracting context from carriers.
+  # By default, "tracecontext" (W3C Trace Context) and "baggage" (W3C Correlation Context) are enabled.
+  # You can enable or disable propagators as needed, or use "none" for no automatically configured propagator
+  # ref: https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_propagators
+  propagators:
+    - tracecontext
+    - baggage
+    # - b3
+    # - b3multi
+    # - jaeger
+    # - xray
+    # - ottrace
+  
+  # Specifies the Sampler used to sample traces by the SDK. (Optional)
+  sampler: {}
+    ## By default, "parentbased_always_on" is enabled, meaning new traces will always be recorded and if the parent span is sampled, then the child span will be sampled.
+    ## ref: https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler
+    # type: "parentbased_always_on"
+
+    ## Each Sampler type defines its own expected args input gor configuring the sampler
+    ## ref: https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler_arg
+    # argument: "0.25"
+  
+  # Specifies the environment variables for the instrumentor.
+  # By default, the auto-instrumentation used with many instrumentation libraries.
+  # To turn them off, you can specify the libraries to exclude under `<<LANGUAGE>>.extraEnv`
+  dotnet:
+    traces:
+      enabled: true
+    metrics:
+      enabled: true
+    extraEnv:
+    ## ref: https://opentelemetry.io/docs/kubernetes/operator/automatic/#dotnet-excluding-auto-instrumentation
+    # - name: OTEL_DOTNET_AUTO_TRACES_GRPCNETCLIENT_INSTRUMENTATION_ENABLED
+    #   value: false
+    # - name: OTEL_DOTNET_AUTO_METRICS_PROCESS_INSTRUMENTATION_ENABLED
+    #   value: false
+
+  java:
+    traces:
+      enabled: true
+    metrics:
+      enabled: true
+    extraEnv: {}
+    ## ref: https://opentelemetry.io/docs/kubernetes/operator/automatic/#java-excluding-auto-instrumentation
+    # - name: OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED  # to disable all default libraries and enable only the ones specified
+    #   value: false
+    # - name: OTEL_INSTRUMENTATION_KAFKA_ENABLED
+    #   value: true
+    # - name: OTEL_INSTRUMENTATION_REDISCALA_ENABLED
+    #   value: true
+
+  python:
+    traces:
+      enabled: true
+    metrics:
+      enabled: true
+    extraEnv:
+    ## ref: https://opentelemetry.io/docs/kubernetes/operator/automatic/#python-excluding-auto-instrumentation
+    # - name: OTEL_PYTHON_DISABLED_INSTRUMENTATIONS
+    #   value: redis,kafka,grpc_client
+
+  nodejs:
+    traces:
+      enabled: true
+    metrics:
+      enabled: true
+    extraEnv: {}
+      ## ref: https://opentelemetry.io/docs/kubernetes/operator/automatic/#js-excluding-instrumentation-libraries
+      # - name: OTEL_NODE_ENABLED_INSTRUMENTATIONS
+      #   value: "http,express"
+      # - name: OTEL_NODE_DISABLED_INSTRUMENTATIONS
+      #   value: "fs,grpc"


### PR DESCRIPTION
## Description 

- Add option to enable OpenTelemetry Operator for auto-instrumentation of the cluster applications.
  - Include `opentelemetry-operator` as dependency
  - Allow customization of propagators, sampler, data type to collect and libraries to enable.
- Implement a workaround for a race condition when waiting for the webhook to be ready
  - Add a Job to ensure the Instrumentation resource is applied correctly
  - All resources required for the temporary job are deleted after use, including the job
- Update readme and changelog
- Add auto release to new `kube-tools` image required for the job

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
