### PR TITLE
[Release] `logzio-monitoring` version `v7.1.1`

### DIFF
--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- next version -->
 
+## 7.1.1
+- Upgrade `opentelemetry-operator` chart to `~0.81.1`
+- Explicitly specified the API group when applying the `instrumentation` resource to prevent conflicts in clusters that have multiple `Instrumentation` CRDs from different API groups
+
 ## 7.1.0
 - Add option to enable OpenTelemetry Operator for auto-instrumentation of the cluster applications.
   - Included `opentelemetry-operator` chart in version `~0.79.0`

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 7.1.0
+version: 7.1.1
 
 
 
@@ -39,7 +39,7 @@ dependencies:
     condition: logzio-apm-collector.enabled
   - name: opentelemetry-operator
     alias: otel-operator
-    version: ~0.79.0
+    version: ~0.81.1
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: otel-operator.enabled
 maintainers:

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -453,7 +453,8 @@ Follow the guide below to enable this feature.
 
 ### Step by step
 
-**Step 1:** Make sure to enable the OpenTelemetry operator in the chart:
+#### Step 1:
+Make sure to enable the OpenTelemetry operator in the chart:
 ```shell
 --set otel-operator.enabled=true \
 ```
@@ -461,7 +462,8 @@ Follow the guide below to enable this feature.
 > [!NOTE]
 > It can take a few minutes for the OpenTelemetry Operator components to be installed and deployed on your cluster.
 
-**Step 2:** Add annotations to your relevant Kubernetes object. You can annotate individual resources such as a Deployment, StatefulSet, DaemonSet, or Pod, or apply annotations at the Namespace level to instrument all pods within that namespace. These annotations should specify the programming language used in your application:
+#### Step 2:
+Add annotations to your relevant Kubernetes object. You can annotate individual resources such as a Deployment, StatefulSet, DaemonSet, or Pod, or apply annotations at the Namespace level to instrument all pods within that namespace. These annotations should specify the programming language used in your application:
 ```yaml
 instrumentation.opentelemetry.io/inject-<APP_LANGUAGE>: "monitoring/logzio-monitoring-instrumentation"
 ```
@@ -485,6 +487,8 @@ instrumentation.opentelemetry.io/<APP_LANGUAGE_2>-container-names: "myapp3"
 > [!TIP]
 > `<APP_LANGUAGE>`, `<APP_LANGUAGE_2>` can be one of `apache-httpd`, `dotnet`, `go`, `java`, `nginx`, `nodejs` or `python`.
 
+> [!WARNING]
+> Go auto-instrumentation does not support multicontainer pods.
 
 ## Customize Auto-instrumentation
 Below you can find multiple ways in which you can customize the OpenTelemetry Operator Auto-instrumentation.
@@ -529,3 +533,22 @@ There are 3 TLS certificate options, by default this chart is using option 2.
 --set otel-operator.admissionWebhooks.keyFile="<<PEM_KEY_PATH>>" \
 --set otel-operator.admissionWebhooks.caFile="<<CA_CERT_PATH>>" \
 ```
+
+### Enable Go Instrumentation
+Go Instrumentation is disabled by default in the OpenTelemetry Operator. To enable it, follow the below steps:
+
+#### Step 1
+Add the following configuration to your `values.yaml`:
+
+```yaml
+otel-operator:
+  manager:
+    extraArgs:
+      - "--enable-go-instrumentation=true"
+```
+
+#### Step 2
+Set the `OTEL_GO_AUTO_TARGET_EXE` environment variable in your Go application to the path of the target executable.
+
+> [!NOTE]
+> For further details, refer to the [OpenTelemetry Go Instrumentation documentation](https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/v0.21.0/docs/how-it-works.md#opentelemetry-go-instrumentation---how-it-works).

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -478,9 +478,9 @@ instrumentation.opentelemetry.io/inject-<APP_LANGUAGE>: "monitoring/logzio-monit
 By default, in multi-container pods, instrumentation is performed on the first container available in the pod spec.
 To fine tune which containers to instrument, add the below annotations to your pod:
 ```yaml
-instrumentation.opentelemetry.io/inject-<APP_LANGUAGE>: "monitoring/logzio-apm-collector"
+instrumentation.opentelemetry.io/inject-<APP_LANGUAGE>: "monitoring/logzio-monitoring-instrumentation"
 instrumentation.opentelemetry.io/<APP_LANGUAGE>-container-names: "myapp,myapp2"
-instrumentation.opentelemetry.io/inject-<APP_LANGUAGE_2>: "monitoring/logzio-apm-collector"
+instrumentation.opentelemetry.io/inject-<APP_LANGUAGE_2>: "monitoring/logzio-monitoring-instrumentation"
 instrumentation.opentelemetry.io/<APP_LANGUAGE_2>-container-names: "myapp3"
 ```
 

--- a/charts/logzio-monitoring/templates/operator/webhook-ready-check-job.yaml
+++ b/charts/logzio-monitoring/templates/operator/webhook-ready-check-job.yaml
@@ -45,7 +45,7 @@ spec:
               done
 
               echo "Opentelemetry Operator webhook is ready, checking if Instrumentation resource exists"
-              if kubectl get instrumentation logzio-monitoring-instrumentation -n monitoring; then
+              if kubectl get instrumentation.opentelemetry.io logzio-monitoring-instrumentation -n monitoring; then
                 echo "Instrumentation resource already exists, checking for changes"
                 while true; do
                   kubectl diff -f /conf/relay.yaml
@@ -69,7 +69,7 @@ spec:
               fi
 
               echo "Applying Instrumentation resources"
-              until kubectl get instrumentation {{ include "otel-operator.fullname" . }} -n {{ .Release.Namespace }}; do
+              until kubectl get instrumentation.opentelemetry.io {{ include "otel-operator.fullname" . }} -n {{ .Release.Namespace }}; do
                 apply_instrumentation
                 echo "Applied Instrumentation, verifying..."
                 sleep 5

--- a/charts/logzio-monitoring/templates/operator/webhook-ready-check-job.yaml
+++ b/charts/logzio-monitoring/templates/operator/webhook-ready-check-job.yaml
@@ -45,7 +45,7 @@ spec:
               done
 
               echo "Opentelemetry Operator webhook is ready, checking if Instrumentation resource exists"
-              if kubectl get instrumentation.opentelemetry.io logzio-monitoring-instrumentation -n monitoring; then
+              if kubectl get instrumentation.opentelemetry.io {{ include "otel-operator.fullname" . }} -n {{ .Release.Namespace }}; then
                 echo "Instrumentation resource already exists, checking for changes"
                 while true; do
                   kubectl diff -f /conf/relay.yaml

--- a/charts/logzio-monitoring/values.yaml
+++ b/charts/logzio-monitoring/values.yaml
@@ -109,6 +109,9 @@ otel-operator:
   manager:
     collectorImage:
       repository: "otel/opentelemetry-collector-contrib"
+    # To enable Go instrumentation support
+    # extraArgs:
+    #   - "--enable-go-instrumentation=true"
 
 #######################################################################################################################
 # Otel Operator Auto Instrumentation configuration


### PR DESCRIPTION
## Description 

- Explicitly specify the API group when applying the `instrumentation` resource, to prevent conflicts in clusters that have multiple `Instrumentation` CRDs
- Upgrade otel operator to version `0.81.1`
- Add readme section on enabling Go instrumentation
  - I kept it optional since it enables extra permissions, due to the use of EBPF
- add changelog entry

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
