### PR TITLE
[Release] `prometheus-alert-migrator` version `v3.0.0`

### DIFF
--- a/charts/prometheus-alerts-migrator/Chart.yaml
+++ b/charts/prometheus-alerts-migrator/Chart.yaml
@@ -4,9 +4,9 @@ description: This Helm chart serves as a Kubernetes controller that automates th
 
 type: application
 
-version: 2.1.1
+version: 3.0.0
 
-appVersion: "v1.2.1"
+appVersion: "v1.3.0"
 
 maintainers:
 - name: yotamloe

--- a/charts/prometheus-alerts-migrator/README.md
+++ b/charts/prometheus-alerts-migrator/README.md
@@ -165,6 +165,19 @@ data:
 
 
 ## Changelog
+- v3.0.0
+  - Upgrade `logzio/prometheus-alerts-migrator` image `v1.2.1`->`v1.3.0`:
+    - Upgrade to Grafana 10 API
+      - Remove support for `MSTeamsConfigs` (`msteams_configs`) due to deprecation in Grafana 10.
+    - Upgrade GoLang version to 1.24
+    - Upgrade dependencies
+      - `logzio_terraform_client`: `1.22.0` -> `v1.23.2`
+      - `prometheus/alertmanager`: `v0.28.0` -> `v0.28.1`
+      - `prometheus/common`: `v0.61.0` -> `v0.62.0`
+      - `prometheus/prometheus`: `v0.301.0` -> `v0.302.1`
+      - `k8s.io/api`: `v0.32.0` -> `v0.32.2`
+      - `k8s.io/apimachinery`: `v0.32.0` -> `v0.32.2`
+      - `k8s.io/client-go`: `v0.32.0` -> `v0.32.2`
 - v2.1.1
   - Upgrade `logzio/prometheus-alerts-migrator` image `v1.2.0`->`v1.2.1`:
     - Add support for MS Teams v2 contact points


### PR DESCRIPTION
## Description 

- Upgrade `logzio/prometheus-alerts-migrator` image `v1.2.1`->`v1.3.0`:
  - Upgrade to Grafana 10 API
    - Remove support for `MSTeamsConfigs` (`msteams_configs`) due to deprecation in Grafana 10.
  - Upgrade GoLang version to 1.24
  - Upgrade dependencies
    - `logzio_terraform_client`: `1.22.0` -> `v1.23.2`
    - `prometheus/alertmanager`: `v0.28.0` -> `v0.28.1`
    - `prometheus/common`: `v0.61.0` -> `v0.62.0`
    - `prometheus/prometheus`: `v0.301.0` -> `v0.302.1`
    - `k8s.io/api`: `v0.32.0` -> `v0.32.2`
    - `k8s.io/apimachinery`: `v0.32.0` -> `v0.32.2`
    - `k8s.io/client-go`: `v0.32.0` -> `v0.32.2`

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
