### PR TITLE
[Bug Fix] `logzio-monitoing` version `v7.1.2`

### DIFF
--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- next version -->
 
+## 7.1.2
+- Upgrade `opentelemetry-operator` chart to `~0.82.0`
+  - Resolve errors regarding `ServiceMonitor` and `PodMonitor` resources which are not utilized by this chart.
+- Upgrade `logzio-fluentd` chart to `1.0.1`
+  - Upgrade ARM and AMD fluentd image version to `v1.18.0-debian-logzio-amd64-1.3` and `v1.18.0-debian-logzio-arm64-1.3`
+
 ## 7.1.1
 - Upgrade `opentelemetry-operator` chart to `~0.81.1`
 - Explicitly specified the API group when applying the `instrumentation` resource to prevent conflicts in clusters that have multiple `Instrumentation` CRDs from different API groups

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 7.1.1
+version: 7.1.2
 
 
 
@@ -10,7 +10,7 @@ sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: logzio-fluentd
-    version: "1.0.0"
+    version: "1.0.1"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
@@ -39,7 +39,7 @@ dependencies:
     condition: logzio-apm-collector.enabled
   - name: opentelemetry-operator
     alias: otel-operator
-    version: ~0.81.1
+    version: ~0.82.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: otel-operator.enabled
 maintainers:


### PR DESCRIPTION
## Description 

- Bump OpenTelemetry operator chart to version `0.82.0`
  - resolve errors regarding `ServiceMonitor` and `PodMonitor` resources which are not utilized by this chart (as we don' t use the Collector resource)
- bump `logzio-fluentd` chart to `1.0.1`
  - Upgrade ARM and AMD fluentd image version to `v1.18.0-debian-logzio-amd64-1.3` and `v1.18.0-debian-logzio-arm64-1.3`

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
