### PR TITLE
[Feature] add dynamic resource detection

### DIFF
--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 5.1.0
+version: 5.2.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -397,6 +397,11 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 5.2.0
+- Add support for auto resource detection with `distribution` and `resourceDetection.enabled` flags.
+  - The old `resourcedetection/all` configuration now serves as fallback if `distribution` is empty or with unknown value.
+- **Breaking changes:** Resource detection is disabled by default. Meaning, the old `resourcedetection/all` for trace and SPM is not applied by default.
+  - If you use this chart for trace and SPM collection, you can enable it by setting `resourceDetection.enabled=true`.
 * 5.1.0
   - Respect metric filters in `prometheus/kubelet` scrape endpoint
 * 5.0.4

--- a/charts/logzio-telemetry/templates/_helpers.tpl
+++ b/charts/logzio-telemetry/templates/_helpers.tpl
@@ -165,3 +165,18 @@ https://listener.logz.io:8053
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the value of resource detection enablement state
+*/}}
+{{- define "opentelemetry-collector.resourceDetectionEnabled" -}}
+{{- if (hasKey .Values "resourceDetection") }}
+{{- if (hasKey .Values.resourceDetection "enabled") }}
+{{- .Values.resourceDetection.enabled }}
+{{- else }}
+{{- .Values.global.resourceDetection.enabled }}
+{{- end }}
+{{- else }}
+{{- .Values.global.resourceDetection.enabled }}
+{{- end }}
+{{- end }}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -44,6 +44,11 @@ global:
   customTracesEndpoint: ""
   # Custom Metrics endpoint, overrides global.LogzioRegion listener address
   customMetricsEndpoint: ""
+  # Optional - Identifier for the Kubernetes distribution used. One of "eks", "aks" or "gke".
+  distribution: ""
+  # Optional - Control enabling of the OpenTelemetry Collector's resource detection feature. Dependent on `distribution` value.
+  resourceDetection:
+    enabled: false
 
 secrets:
   name: logzio-secret  # Secret name
@@ -275,8 +280,6 @@ tracesConfig:
     zipkin:
       endpoint: "0.0.0.0:9411"
   processors:
-    resourcedetection/all:
-      detectors: [ec2, azure, gcp]
     tail_sampling:
       policies:
         [
@@ -304,7 +307,7 @@ tracesConfig:
     pipelines:
       traces:
         receivers: [jaeger, zipkin, otlp]
-        processors: [resourcedetection/all,attributes/env_id, k8sattributes, resource/k8s, tail_sampling, batch]
+        processors: [attributes/env_id, k8sattributes, resource/k8s, tail_sampling, batch]
         exporters: [logzio]
 
 spmForwarderConfig:
@@ -317,7 +320,7 @@ spmForwarderConfig:
     pipelines:
       traces/spm:
         receivers: [jaeger, zipkin, otlp]
-        processors: [resourcedetection/all, attributes/env_id, k8sattributes, batch]
+        processors: [attributes/env_id, k8sattributes, batch]
         exporters: [logging, otlp]
 # Metrics standalone collector configuration 
 metricsConfig:
@@ -1052,8 +1055,6 @@ daemonsetConfig:
   extensions:
     health_check: {}
   processors:
-    resourcedetection/all:
-      detectors: [ec2, azure, gcp]
     filter/kubernetes360:
       metrics:
         datapoint:


### PR DESCRIPTION
## Description 

- Replace the current static traces and SPM resource detection `resourcedetection/all` with dynamic resource detection based on a provided `distribution` flag.
  - Causing breaking changes if someone still uses the `telemetry` chart for traces and SPM collection, since the detection is disabled by default. This default was chosen to avoid causing changes in Metrics collection (the primary use case for the parent monitoring chart). 
- Update readme


## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
