### PR TITLE
[Release] `logzio-telemetry` 5.2.0 + `logzio-apm-collector`  1.2.3

### DIFF
--- a/charts/logzio-apm-collector/CHANGELOG.md
+++ b/charts/logzio-apm-collector/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changes by Version
 
 <!-- next version -->
+## 1.2.3
+- Expose collector metrics port by default 
 ## 1.2.2
 - Add support for auto resource detection with `distribution` and `resourceDetection.enabled` flags.
   - The old `resourcedetection/all` configuration now serves as fallback if `distribution` is empty or with unknown value.

--- a/charts/logzio-apm-collector/Chart.yaml
+++ b/charts/logzio-apm-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: logzio-apm-collector
-version: 1.2.2
+version: 1.2.3
 description: Kubernetes APM agent for Logz.io based on OpenTelemetry Collector
 type: application
 home: https://logz.io/

--- a/charts/logzio-apm-collector/values.yaml
+++ b/charts/logzio-apm-collector/values.yaml
@@ -474,6 +474,12 @@ ports:
     servicePort: 9411
     hostPort: 9411
     protocol: TCP
+  metrics:
+    enabled: true
+    containerPort: 8888
+    servicePort: 8888
+    hostPort: 8888
+    protocol: TCP
 
 portsSpm:
   otlp:
@@ -482,7 +488,12 @@ portsSpm:
     servicePort: 4317
     hostPort: 4317
     protocol: TCP
-
+  metrics:
+    enabled: true
+    containerPort: 8888
+    servicePort: 8888
+    hostPort: 8888
+    protocol: TCP
 # Common labels to add to all otel-collector resources. Evaluated as a template.
 additionalLabels: {}
 #  app.kubernetes.io/part-of: my-app

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 5.1.1
+version: 5.2.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 5.1.0
+version: 5.2.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 5.1.0
+version: 5.1.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -397,8 +397,10 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
-* 5.1.1
+* 5.2.0
   - Expose collector metrics port by default
+  - Add `podDisruptionBudget` (Contributed by @jod972)
+  - Add `topologySpreadConstraints` (Contributed by @jod972)
 * 5.1.0
   - Respect metric filters in `prometheus/kubelet` scrape endpoint
 * 5.0.4

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -397,6 +397,11 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 5.2.0
+- Add support for auto resource detection with `distribution` and `resourceDetection.enabled` flags.
+  - The old `resourcedetection/all` configuration now serves as fallback if `distribution` is empty or with unknown value.
+- **Breaking changes:** Resource detection is disabled by default. Meaning, the old `resourcedetection/all` for trace and SPM is not applied by default.
+  - If you use this chart for trace and SPM collection, you can enable it by setting `resourceDetection.enabled=true`.
 * 5.1.0
   - Respect metric filters in `prometheus/kubelet` scrape endpoint
 * 5.0.4

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -397,6 +397,8 @@ If you don't want the sub charts to installed add the relevant flag per sub char
 
 
 ## Change log
+* 5.1.1
+  - Expose collector metrics port by default
 * 5.1.0
   - Respect metric filters in `prometheus/kubelet` scrape endpoint
 * 5.0.4

--- a/charts/logzio-telemetry/templates/_daemonset-pod.tpl
+++ b/charts/logzio-telemetry/templates/_daemonset-pod.tpl
@@ -162,4 +162,8 @@ affinity:
 tolerations:
 {{ toYaml $allTolerations | nindent 2 }}
 {{- end }}
+{{- if .Values.topologySpreadConstraints }}
+topologySpreadConstraints:
+{{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+{{- end }}
 {{- end }}

--- a/charts/logzio-telemetry/templates/_daemonset-pod.tpl
+++ b/charts/logzio-telemetry/templates/_daemonset-pod.tpl
@@ -18,7 +18,7 @@ containers:
       {{- toYaml .Values.containerSecurityContext | nindent 6 }}
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
     imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if (and (not .Values.traces.enabled) .Values.metrics.enabled) }}
+{{- if .Values.metrics.enabled }}
     ports:
       {{- range $key, $port := .Values.ports }}
       {{- if $port.enabled }}

--- a/charts/logzio-telemetry/templates/_helpers.tpl
+++ b/charts/logzio-telemetry/templates/_helpers.tpl
@@ -165,3 +165,18 @@ https://listener.logz.io:8053
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the value of resource detection enablement state
+*/}}
+{{- define "opentelemetry-collector.resourceDetectionEnabled" -}}
+{{- if (hasKey .Values "resourceDetection") }}
+{{- if (hasKey .Values.resourceDetection "enabled") }}
+{{- .Values.resourceDetection.enabled }}
+{{- else }}
+{{- .Values.global.resourceDetection.enabled }}
+{{- end }}
+{{- else }}
+{{- .Values.global.resourceDetection.enabled }}
+{{- end }}
+{{- end }}

--- a/charts/logzio-telemetry/templates/_pod-spm.tpl
+++ b/charts/logzio-telemetry/templates/_pod-spm.tpl
@@ -77,4 +77,8 @@ affinity:
 tolerations:
 {{ toYaml $allTolerations | nindent 2 }}
 {{- end }}
+{{- if .Values.topologySpreadConstraints }}
+topologySpreadConstraints:
+{{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+{{- end }}
 {{- end}}

--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -202,4 +202,8 @@ affinity:
 tolerations:
 {{ toYaml $allTolerations | nindent 2 }}
 {{- end }}
+{{- if .Values.topologySpreadConstraints }}
+topologySpreadConstraints:
+{{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+{{- end }}
 {{- end }}

--- a/charts/logzio-telemetry/templates/poddisruptionbudget.yaml
+++ b/charts/logzio-telemetry/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "opentelemetry-collector.fullname" . }}
+  labels:
+    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "opentelemetry-collector.selectorLabels" . | nindent 6 }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+{{- if and .Values.podDisruptionBudget.minAvailable (not .Values.podDisruptionBudget.maxUnavailable)}}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- end }}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -653,7 +653,7 @@ ports:
     servicePort: 9411
     hostPort: 9411
     protocol: TCP
-  collector-metrics:
+  metrics:
     enabled: true
     containerPort: 8888
     servicePort: 8888

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -44,6 +44,11 @@ global:
   customTracesEndpoint: ""
   # Custom Metrics endpoint, overrides global.LogzioRegion listener address
   customMetricsEndpoint: ""
+  # Optional - Identifier for the Kubernetes distribution used. One of "eks", "aks" or "gke".
+  distribution: ""
+  # Optional - Control enabling of the OpenTelemetry Collector's resource detection feature. Dependent on `distribution` value.
+  resourceDetection:
+    enabled: false
 
 secrets:
   name: logzio-secret  # Secret name
@@ -275,8 +280,6 @@ tracesConfig:
     zipkin:
       endpoint: "0.0.0.0:9411"
   processors:
-    resourcedetection/all:
-      detectors: [ec2, azure, gcp]
     tail_sampling:
       policies:
         [
@@ -304,7 +307,7 @@ tracesConfig:
     pipelines:
       traces:
         receivers: [jaeger, zipkin, otlp]
-        processors: [resourcedetection/all,attributes/env_id, k8sattributes, resource/k8s, tail_sampling, batch]
+        processors: [attributes/env_id, k8sattributes, resource/k8s, tail_sampling, batch]
         exporters: [logzio]
 
 spmForwarderConfig:
@@ -317,7 +320,7 @@ spmForwarderConfig:
     pipelines:
       traces/spm:
         receivers: [jaeger, zipkin, otlp]
-        processors: [resourcedetection/all, attributes/env_id, k8sattributes, batch]
+        processors: [attributes/env_id, k8sattributes, batch]
         exporters: [logging, otlp]
 # Metrics standalone collector configuration 
 metricsConfig:
@@ -1052,8 +1055,6 @@ daemonsetConfig:
   extensions:
     health_check: {}
   processors:
-    resourcedetection/all:
-      detectors: [ec2, azure, gcp]
     filter/kubernetes360:
       metrics:
         datapoint:

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -653,6 +653,12 @@ ports:
     servicePort: 9411
     hostPort: 9411
     protocol: TCP
+  collector-metrics:
+    enabled: true
+    containerPort: 8888
+    servicePort: 8888
+    hostPort: 8888
+    protocol: TCP
 
 # Kubernetes Object logs
 k8sObjectsConfig:

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -604,6 +604,19 @@ tolerations: []
 
 affinity: {}
 
+## Topology spread constraints for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: []
+
+# Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget:
+  enabled: false
+# Set the minimum available replicas
+#  minAvailable: 1
+# OR Set the maximum unavailable replicas
+#  maxUnavailable: 1
+# If both defined only maxUnavailable will be used
+
 extraEnvs: []
 extraHostPathMounts: []
 secretMounts: []


### PR DESCRIPTION
## Description 

Solves: #613 
- Expose the collector metrics port by default in logzio telemetry chart 
- Expose the collector metrics port by default in logzio apm chart 

Includes: #616
- Replace the current static traces and SPM resource detection `resourcedetection/all` with dynamic resource detection based on a provided `distribution` flag.
  - Causing breaking changes if someone still uses the `telemetry` chart for traces and SPM collection, since the detection is disabled by default. This default was chosen to avoid causing changes in Metrics collection (the primary use case for the parent monitoring chart). 
- Update readme

Includes: #617 #618 
- Add `podDisruptionBudget` in logzio telemetry chart (Contributed by @jod972)
- Add `topologySpreadConstraints` in logzio telemetry chart (Contributed by @jod972)



## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
