### PR TITLE
[Release] upgrade otel collector version in logs chart

### DIFF
--- a/charts/logzio-logs-collector/CHANGELOG.md
+++ b/charts/logzio-logs-collector/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changes by Version
 
 <!-- next version -->
+# 2.1.0
+- **Breaking changes**
+  - Upgrade `otel/opentelemetry-collector-contrib` image to version `0.127.0`
+    - The `time` attribute is no longer present as field in the log record. The log timestamp is now only available under `@timestamp` in Logz.io.
+
 ## 2.0.2
 - Add support for auto resource detection with `distribution` and `resourceDetection.enabled` flags.
 

--- a/charts/logzio-logs-collector/Chart.yaml
+++ b/charts/logzio-logs-collector/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: logzio-logs-collector
-version: 2.0.2
+version: 2.1.0
 description: kubernetes logs collection agent for logz.io based on opentelemetry collector
 type: application
 home: https://logz.io/
 maintainers:
   - name: yotam loewenbach
     email: yotam.loewenbach@logz.io
-appVersion: 0.109.0
+appVersion: 0.127.0


### PR DESCRIPTION
## Description 

- upgrade OpenTelemetry collector version in the logs chart
- update changelog about `time` field removal from record breaking change 
  - clarified the log timestamp is still the `@timestamp` in the record at Logz.io, as it was previously

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
