### PR TITLE
[Release] `logzio-apm-collector` - resolve error when trying to enable only traces

### DIFF
--- a/charts/logzio-apm-collector/CHANGELOG.md
+++ b/charts/logzio-apm-collector/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 <!-- next version -->
 ## 1.2.4
-- Resolve resource detection installation error when enabling only traces.
+- Resolve resource detection installation error when only traces is enabled.
+- Upgrade OpenTelemetry Collector from `0.123.0` to `0.129.0`
+  - `logzioexporter` now exports logs and traces in `otlp` format.
 
 ## 1.2.3
 - Expose collector metrics port by default 

--- a/charts/logzio-apm-collector/CHANGELOG.md
+++ b/charts/logzio-apm-collector/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changes by Version
 
 <!-- next version -->
+## 1.2.4
+- Resolve resource detection installation error when enabling only traces.
+
 ## 1.2.3
 - Expose collector metrics port by default 
+
 ## 1.2.2
 - Add support for auto resource detection with `distribution` and `resourceDetection.enabled` flags.
   - The old `resourcedetection/all` configuration now serves as fallback if `distribution` is empty or with unknown value.

--- a/charts/logzio-apm-collector/Chart.yaml
+++ b/charts/logzio-apm-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: logzio-apm-collector
-version: 1.2.3
+version: 1.2.4
 description: Kubernetes APM agent for Logz.io based on OpenTelemetry Collector
 type: application
 home: https://logz.io/
@@ -8,4 +8,4 @@ icon: https://logzbucket.s3.eu-west-1.amazonaws.com/logz-io-img/logo400x400.png
 maintainers:
   - name: Naama Bendalak
     email: naama.bendalak@logz.io
-appVersion: 0.123.0
+appVersion: 0.129.1

--- a/charts/logzio-apm-collector/templates/_config.tpl
+++ b/charts/logzio-apm-collector/templates/_config.tpl
@@ -69,9 +69,6 @@
 {{/* Build config file for APM Collector */}}
 {{- define "apm-collector.config" -}}
 {{- $tracesConfig := deepCopy .Values.traceConfig }}
-{{- if not (or .Values.spm.enabled .Values.serviceGraph.enabled) }}
-{{- $_ := unset $tracesConfig.service.pipelines "traces/spm" }}
-{{- end -}}
 
 {{- if (eq (include "apm-collector.resourceDetectionEnabled" .) "true") }}
 {{- $resDetectionConfig := (include "apm-collector.resourceDetectionConfig" .Values.global.distribution | fromYaml) }}
@@ -83,6 +80,10 @@
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{- if not (or .Values.spm.enabled .Values.serviceGraph.enabled) }}
+{{- $_ := unset $tracesConfig.service.pipelines "traces/spm" }}
+{{- end -}}
 
 {{- tpl ($tracesConfig | toYaml) . }}
 {{- end -}}


### PR DESCRIPTION
## Description 

- Resolve resource detection installation error when enabling only traces.
  - Changed the order of actions when generating the config, to remove the `traces/spm` from pipelines only after the resource detection adds the processor to the list
- Upgrade OpenTelemetry Collector from `0.123.0` to `0.129.0`
  - `logzioexporter` now exports logs and traces in `otlp` format.

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
