### PR TITLE
[Release] `logzio-monitroing` version `7.3.2`

### DIFF
--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes_version: ['1.26', '1.30', '1.32']
+        kubernetes_version: ['1.27', '1.30', '1.32']
         environment: [eks-linux, eks-fargate]
     steps:
       - name: Generate random id

--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changes by Version
 
 <!-- next version -->
+## 7.3.2
+- Upgrade `opentelemetry-operator` chart to `~0.90.4`
+- Change Java instrumentation default endpoint to `otlp/grpc` instead of `otlp/http` for compatibility with the Java instrumentation version used by the Operator
+- Upgrade `logzio-apm-collector` chart to `1.2.4`
+  - Resolve resource detection installation error when only traces is enabled.
+  - Upgrade OpenTelemetry Collector from `0.123.0` to `0.129.0`
+    - `logzioexporter` now exports logs and traces in `otlp` format.
+
 ## 7.3.1
 - Upgrade `logzio-k8s-telemetry` chart to `5.2.1`
   - Fix Pod disruption budget selector label for SPM collector (Contributed by @jod972)

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,8 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 7.3.1
-
+version: 7.3.2
 
 
 sources:
@@ -34,12 +33,12 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-apm-collector
-    version: "1.2.3"
+    version: "1.2.4"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logzio-apm-collector.enabled
   - name: opentelemetry-operator
     alias: otel-operator
-    version: ~0.86.2
+    version: ~0.90.4
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: otel-operator.enabled
 maintainers:

--- a/charts/logzio-monitoring/templates/operator/_instrumentation.tpl
+++ b/charts/logzio-monitoring/templates/operator/_instrumentation.tpl
@@ -42,6 +42,10 @@ spec:
     {{- end }}
   java:
     env:
+      - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+        value: {{ include "otel-operator.serviceAddr" (dict "serviceName" .Values.instrumentation.tracesServiceName "releaseNamespace" .Release.Namespace) }}:4317
+      - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+        value: {{ include "otel-operator.serviceAddr" (dict "serviceName" .Values.instrumentation.metricsServiceName "releaseNamespace" .Release.Namespace) }}:4317
       - name: OTEL_METRICS_EXPORTER
         value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.java.metrics.enabled "enabledSubChart" $metricsEnabled) }}
       - name: OTEL_TRACES_EXPORTER


### PR DESCRIPTION
## Description 

- update java instrumentation destination to match the current default operator instrumentation
  - default operator instrumentation is currently `v1.33.6`, and only at version [`2.0.0`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/CHANGELOG.md#version-200-2024-01-12) they changed the default protocol to `http/otlp`.
- Upgrade `logzio-apm-collector` chart to `1.2.4`
  - Resolve resource detection installation error when only traces is enabled.
  - Upgrade OpenTelemetry Collector from `0.123.0` to `0.129.0`
    - `logzioexporter` now exports logs and traces in `otlp` format.
- upgrade the operator version on the way

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
