### PR TITLE
[Bug] fix folder name bug when too long uid `prometheus-alert-migrator` version `3.0.2`

### DIFF
--- a/charts/prometheus-alerts-migrator/CHANGELOG.md
+++ b/charts/prometheus-alerts-migrator/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changes by Version
 
 <!-- next version -->
+## v3.0.2
+- Upgrade `logzio/prometheus-alerts-migrator` image `v1.3.1`->`v1.3.2`:
+  - Fix folder name to not get truncated when name is longer than 40 characters.
 ## v3.0.1
 - Upgrade `logzio/prometheus-alerts-migrator` image `v1.3.0`->`v1.3.1`:
   - Enforce a 40-character limit on the auto-generated Grafana folder UIDs to prevent runtime exceptions when the generated UID is too long.

--- a/charts/prometheus-alerts-migrator/Chart.yaml
+++ b/charts/prometheus-alerts-migrator/Chart.yaml
@@ -4,9 +4,9 @@ description: This Helm chart serves as a Kubernetes controller that automates th
 
 type: application
 
-version: 3.0.1
+version: 3.0.2
 
-appVersion: "v1.3.1"
+appVersion: "v1.3.2"
 
 maintainers:
 - name: yotamloe


### PR DESCRIPTION
## Description 

- Upgrade `logzio/prometheus-alerts-migrator` image `v1.3.1`->`v1.3.2`:
  - Fix folder name to not get truncated when name is longer than 40 characters.

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
