### PR TITLE
Release `logzio k8s telemetry` v5.5.0

### DIFF
--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -104,7 +104,9 @@ jobs:
           --set logzio-apm-collector.filters.exclude.namespace='kube-system'"
         
           if [ "${{ matrix.environment }}" == "eks-fargate" ]; then
-            HELM_CMD="$HELM_CMD --set logzio-logs-collector.fargateLogRouter.enabled='true' --set logzio-k8s-telemetry.collector.mode=standalone --set logzio-apm-collector.livenessProbe.initialDelaySeconds=15 --set logzio-apm-collector.readinessProbe.initialDelaySeconds=15"
+            HELM_CMD="$HELM_CMD --set logzio-logs-collector.fargateLogRouter.enabled='true' --set logzio-k8s-telemetry.collector.mode=standalone --set logzio-apm-collector.livenessProbe.initialDelaySeconds=15 --set logzio-apm-collector.readinessProbe.initialDelaySeconds=15 --set logzio-k8s-telemetry.standaloneCollector.resources.requests.cpu=200m --set logzio-k8s-telemetry.standaloneCollector.resources.requests.memory=512Mi"
+          else
+            HELM_CMD="$HELM_CMD --set logzio-k8s-telemetry.daemonsetCollector.resources.requests.cpu=150m --set logzio-k8s-telemetry.daemonsetCollector.resources.requests.memory=250Mi"
           fi
           
           HELM_CMD="$HELM_CMD logzio-monitoring ."
@@ -147,6 +149,27 @@ jobs:
             kubectl get ds logzio-monitoring-otel-collector-ds -o jsonpath='{.spec.template.spec.tolerations}' | grep -q $GLOBAL_TOLERATION_KEY || (echo "Missing global toleration in logzio-monitoring-otel-collector-ds" && exit 1)
           fi
           echo "✅ All expected tolerations are present."
+
+      - name: Verify Telemetry Resource Configuration in Monitoring Chart
+        run: |
+          echo "=== Verifying telemetry collector resource configuration within monitoring chart ==="
+          if [ "${{ matrix.environment }}" == "eks-fargate" ]; then
+            echo "Checking standalone collector resources..."
+            CONTAINER_RESOURCES=$(kubectl get deployment/logzio-monitoring-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources}')
+            echo "Container resources: $CONTAINER_RESOURCES"
+            # Verify requests are set for fargate (standalone mode)
+            kubectl get deployment/logzio-monitoring-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}' | grep -q "200m" || (echo "❌ Expected CPU request 200m not found" && exit 1)
+            kubectl get deployment/logzio-monitoring-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}' | grep -q "512Mi" || (echo "❌ Expected memory request 512Mi not found" && exit 1)
+            echo "✅ Standalone collector resources verified successfully in monitoring chart"
+          else
+            echo "Checking daemonset collector resources..."
+            CONTAINER_RESOURCES=$(kubectl get daemonset/logzio-monitoring-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources}')
+            echo "Container resources: $CONTAINER_RESOURCES"
+            # Verify requests are set for linux (daemonset mode)
+            kubectl get daemonset/logzio-monitoring-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}' | grep -q "150m" || (echo "❌ Expected CPU request 150m not found" && exit 1)
+            kubectl get daemonset/logzio-monitoring-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}' | grep -q "250Mi" || (echo "❌ Expected memory request 250Mi not found" && exit 1)
+            echo "✅ Daemonset collector resources verified successfully in monitoring chart"
+          fi
 
       - name: Check `aws-observability` namespace and configmap (fargate)
         if: matrix.environment == 'eks-fargate'

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -8,6 +8,8 @@ on:
       - 'charts/logzio-monitoring/templates/**'
       - 'charts/logzio-monitoring/Chart.yaml'
       - 'charts/logzio-monitoring/values.yaml'
+      - '!**.md'
+      - '!**/**/**.md'
 jobs:
   eks-e2e-test:
     name: EKS e2e Test

--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -104,9 +104,9 @@ jobs:
           --set logzio-apm-collector.filters.exclude.namespace='kube-system'"
         
           if [ "${{ matrix.environment }}" == "eks-fargate" ]; then
-            HELM_CMD="$HELM_CMD --set logzio-logs-collector.fargateLogRouter.enabled='true' --set logzio-k8s-telemetry.collector.mode=standalone --set logzio-apm-collector.livenessProbe.initialDelaySeconds=15 --set logzio-apm-collector.readinessProbe.initialDelaySeconds=15 --set logzio-k8s-telemetry.standaloneCollector.resources.requests.cpu=200m --set logzio-k8s-telemetry.standaloneCollector.resources.requests.memory=512Mi"
+            HELM_CMD="$HELM_CMD --set logzio-logs-collector.fargateLogRouter.enabled='true' --set logzio-k8s-telemetry.collector.mode=standalone --set logzio-apm-collector.livenessProbe.initialDelaySeconds=15 --set logzio-apm-collector.readinessProbe.initialDelaySeconds=15 --set logzio-k8s-telemetry.standaloneCollector.resources.requests.cpu=200m --set logzio-k8s-telemetry.standaloneCollector.resources.requests.memory=512Mi --set logzio-k8s-telemetry.standaloneCollector.resources.limits.cpu=500m --set logzio-k8s-telemetry.standaloneCollector.resources.limits.memory=1Gi"
           else
-            HELM_CMD="$HELM_CMD --set logzio-k8s-telemetry.daemonsetCollector.resources.requests.cpu=150m --set logzio-k8s-telemetry.daemonsetCollector.resources.requests.memory=250Mi"
+            HELM_CMD="$HELM_CMD --set logzio-k8s-telemetry.daemonsetCollector.resources.requests.cpu=150m --set logzio-k8s-telemetry.daemonsetCollector.resources.requests.memory=250Mi --set logzio-k8s-telemetry.daemonsetCollector.resources.limits.cpu=300m --set logzio-k8s-telemetry.daemonsetCollector.resources.limits.memory=512Mi"
           fi
           
           HELM_CMD="$HELM_CMD logzio-monitoring ."
@@ -157,17 +157,21 @@ jobs:
             echo "Checking standalone collector resources..."
             CONTAINER_RESOURCES=$(kubectl get deployment/logzio-monitoring-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources}')
             echo "Container resources: $CONTAINER_RESOURCES"
-            # Verify requests are set for fargate (standalone mode)
+            # Verify requests and limits are set for fargate (standalone mode)
             kubectl get deployment/logzio-monitoring-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}' | grep -q "200m" || (echo "❌ Expected CPU request 200m not found" && exit 1)
             kubectl get deployment/logzio-monitoring-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}' | grep -q "512Mi" || (echo "❌ Expected memory request 512Mi not found" && exit 1)
+            kubectl get deployment/logzio-monitoring-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources.limits.cpu}' | grep -q "500m" || (echo "❌ Expected CPU limit 500m not found" && exit 1)
+            kubectl get deployment/logzio-monitoring-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' | grep -q "1Gi" || (echo "❌ Expected memory limit 1Gi not found" && exit 1)
             echo "✅ Standalone collector resources verified successfully in monitoring chart"
           else
             echo "Checking daemonset collector resources..."
             CONTAINER_RESOURCES=$(kubectl get daemonset/logzio-monitoring-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources}')
             echo "Container resources: $CONTAINER_RESOURCES"
-            # Verify requests are set for linux (daemonset mode)
+            # Verify requests and limits are set for linux (daemonset mode)
             kubectl get daemonset/logzio-monitoring-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}' | grep -q "150m" || (echo "❌ Expected CPU request 150m not found" && exit 1)
             kubectl get daemonset/logzio-monitoring-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}' | grep -q "250Mi" || (echo "❌ Expected memory request 250Mi not found" && exit 1)
+            kubectl get daemonset/logzio-monitoring-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources.limits.cpu}' | grep -q "300m" || (echo "❌ Expected CPU limit 300m not found" && exit 1)
+            kubectl get daemonset/logzio-monitoring-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' | grep -q "512Mi" || (echo "❌ Expected memory limit 512Mi not found" && exit 1)
             echo "✅ Daemonset collector resources verified successfully in monitoring chart"
           fi
 

--- a/.github/workflows/logzio-telemetry-test.yaml
+++ b/.github/workflows/logzio-telemetry-test.yaml
@@ -10,6 +10,8 @@ on:
       - 'charts/logzio-telemetry/Chart.yaml'
       - 'charts/logzio-telemetry/values.yaml'
       - 'charts/logzio-telemetry/windows_exporter_installer/**'
+      - '!**.md'
+      - '!**/**/**.md'
 jobs:
   test-helm-chart:
     name: Test Helm Chart on Kind

--- a/.github/workflows/logzio-telemetry-test.yaml
+++ b/.github/workflows/logzio-telemetry-test.yaml
@@ -52,6 +52,15 @@ jobs:
         run: |
           cd charts/logzio-telemetry
           helm dependency build
+          
+          # Set collector-specific resource configuration for testing
+          RESOURCE_CONFIG=""
+          if [[ "${{ matrix.mode }}" == "standalone" ]]; then
+            RESOURCE_CONFIG="--set standaloneCollector.resources.requests.cpu=200m --set standaloneCollector.resources.requests.memory=512Mi --set standaloneCollector.resources.limits.cpu=500m --set standaloneCollector.resources.limits.memory=1Gi"
+          else
+            RESOURCE_CONFIG="--set daemonsetCollector.resources.requests.cpu=150m --set daemonsetCollector.resources.requests.memory=250Mi --set daemonsetCollector.resources.limits.cpu=300m --set daemonsetCollector.resources.limits.memory=512Mi"
+          fi
+          
           helm upgrade --install \
           --set traces.enabled=true \
           --set spm.enabled=true \
@@ -72,6 +81,7 @@ jobs:
           --set filters.infrastructure.exclude.namespace="kube-system" \
           --set signalFx.enabled=true \
           --set carbon.enabled=true \
+          $RESOURCE_CONFIG \
           logzio-k8s-telemetry .
       
       - name: Verify deployment Status
@@ -82,6 +92,31 @@ jobs:
           kubectl describe deployment/logzio-k8s-telemetry-otel-collector-standalone
           kubectl get deployment/logzio-k8s-telemetry-otel-collector-spm -o jsonpath='{.spec.template.spec.tolerations}' | jq -r '.[] | select(.key=="global-key")'
           kubectl get deployment/logzio-k8s-telemetry-otel-collector-standalone -o jsonpath='{.spec.template.spec.tolerations}' | jq -r '.[] | select(.key=="global-key")'
+      
+      - name: Verify Resource Configuration
+        run: |
+          echo "=== Verifying collector resource configuration ==="
+          if [[ "${{ matrix.mode }}" == "standalone" ]]; then
+            echo "Checking standalone collector resources..."
+            CONTAINER_RESOURCES=$(kubectl get deployment/logzio-k8s-telemetry-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources}')
+            echo "Container resources: $CONTAINER_RESOURCES"
+            # Verify requests and limits are set
+            kubectl get deployment/logzio-k8s-telemetry-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}' | grep -q "200m" || (echo "❌ Expected CPU request 200m not found" && exit 1)
+            kubectl get deployment/logzio-k8s-telemetry-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}' | grep -q "512Mi" || (echo "❌ Expected memory request 512Mi not found" && exit 1)
+            kubectl get deployment/logzio-k8s-telemetry-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources.limits.cpu}' | grep -q "500m" || (echo "❌ Expected CPU limit 500m not found" && exit 1)
+            kubectl get deployment/logzio-k8s-telemetry-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' | grep -q "1Gi" || (echo "❌ Expected memory limit 1Gi not found" && exit 1)
+            echo "✅ Standalone collector resources verified successfully"
+          else
+            echo "Checking daemonset collector resources..."
+            CONTAINER_RESOURCES=$(kubectl get daemonset/logzio-k8s-telemetry-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources}')
+            echo "Container resources: $CONTAINER_RESOURCES"
+            # Verify requests and limits are set
+            kubectl get daemonset/logzio-k8s-telemetry-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}' | grep -q "150m" || (echo "❌ Expected CPU request 150m not found" && exit 1)
+            kubectl get daemonset/logzio-k8s-telemetry-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}' | grep -q "250Mi" || (echo "❌ Expected memory request 250Mi not found" && exit 1)
+            kubectl get daemonset/logzio-k8s-telemetry-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources.limits.cpu}' | grep -q "300m" || (echo "❌ Expected CPU limit 300m not found" && exit 1)
+            kubectl get daemonset/logzio-k8s-telemetry-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' | grep -q "512Mi" || (echo "❌ Expected memory limit 512Mi not found" && exit 1)
+            echo "✅ Daemonset collector resources verified successfully"
+          fi
       
       - name: Run trace generator
         run: |
@@ -223,6 +258,33 @@ jobs:
               exit 1
             }
             kubectl get daemonset/logzio-k8s-telemetry-otel-collector-ds -o jsonpath='{.spec.template.spec.tolerations}' | jq -r '.[] | select(.key=="global-key")'
+          fi
+
+      - name: Verify Default Resource Configuration (Empty)
+        run: |
+          echo "=== Verifying default (empty) resource configuration ==="
+          if [[ "${{ matrix.mode }}" == "standalone" ]]; then
+            echo "Checking standalone collector for no resource constraints..."
+            CONTAINER_RESOURCES=$(kubectl get deployment/logzio-k8s-telemetry-otel-collector-standalone -o jsonpath='{.spec.template.spec.containers[0].resources}')
+            echo "Container resources: $CONTAINER_RESOURCES"
+            # Verify that resources is empty or null (default behavior)
+            if [[ "$CONTAINER_RESOURCES" == "{}" || "$CONTAINER_RESOURCES" == "" || "$CONTAINER_RESOURCES" == "null" ]]; then
+              echo "✅ Standalone collector has no resource constraints (default behavior verified)"
+            else
+              echo "❌ Expected no resource constraints but found: $CONTAINER_RESOURCES"
+              exit 1
+            fi
+          else
+            echo "Checking daemonset collector for no resource constraints..."
+            CONTAINER_RESOURCES=$(kubectl get daemonset/logzio-k8s-telemetry-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources}')
+            echo "Container resources: $CONTAINER_RESOURCES"
+            # Verify that resources is empty or null (default behavior)
+            if [[ "$CONTAINER_RESOURCES" == "{}" || "$CONTAINER_RESOURCES" == "" || "$CONTAINER_RESOURCES" == "null" ]]; then
+              echo "✅ Daemonset collector has no resource constraints (default behavior verified)"
+            else
+              echo "❌ Expected no resource constraints but found: $CONTAINER_RESOURCES"
+              exit 1
+            fi
           fi
 
       - name: Run metric generator

--- a/.github/workflows/logzio-telemetry-test.yaml
+++ b/.github/workflows/logzio-telemetry-test.yaml
@@ -61,6 +61,9 @@ jobs:
             RESOURCE_CONFIG="--set daemonsetCollector.resources.requests.cpu=150m --set daemonsetCollector.resources.requests.memory=250Mi --set daemonsetCollector.resources.limits.cpu=300m --set daemonsetCollector.resources.limits.memory=512Mi"
           fi
           
+          # Add span metrics resource configuration for testing
+          SPM_RESOURCE_CONFIG="--set spanMetricsAgregator.resources.requests.cpu=256m --set spanMetricsAgregator.resources.requests.memory=512Mi --set spanMetricsAgregator.resources.limits.cpu=512m --set spanMetricsAgregator.resources.limits.memory=1Gi"
+          
           helm upgrade --install \
           --set traces.enabled=true \
           --set spm.enabled=true \
@@ -82,6 +85,7 @@ jobs:
           --set signalFx.enabled=true \
           --set carbon.enabled=true \
           $RESOURCE_CONFIG \
+          $SPM_RESOURCE_CONFIG \
           logzio-k8s-telemetry .
       
       - name: Verify deployment Status
@@ -117,6 +121,16 @@ jobs:
             kubectl get daemonset/logzio-k8s-telemetry-otel-collector-ds -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' | grep -q "512Mi" || (echo "❌ Expected memory limit 512Mi not found" && exit 1)
             echo "✅ Daemonset collector resources verified successfully"
           fi
+          
+          # Verify span metrics aggregator resources
+          echo "Checking span metrics aggregator resources..."
+          SPM_CONTAINER_RESOURCES=$(kubectl get deployment/logzio-k8s-telemetry-otel-collector-spm -o jsonpath='{.spec.template.spec.containers[0].resources}')
+          echo "SPM Container resources: $SPM_CONTAINER_RESOURCES"
+          kubectl get deployment/logzio-k8s-telemetry-otel-collector-spm -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}' | grep -q "256m" || (echo "❌ Expected SPM CPU request 256m not found" && exit 1)
+          kubectl get deployment/logzio-k8s-telemetry-otel-collector-spm -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}' | grep -q "512Mi" || (echo "❌ Expected SPM memory request 512Mi not found" && exit 1)
+          kubectl get deployment/logzio-k8s-telemetry-otel-collector-spm -o jsonpath='{.spec.template.spec.containers[0].resources.limits.cpu}' | grep -q "512m" || (echo "❌ Expected SPM CPU limit 512m not found" && exit 1)
+          kubectl get deployment/logzio-k8s-telemetry-otel-collector-spm -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' | grep -q "1Gi" || (echo "❌ Expected SPM memory limit 1Gi not found" && exit 1)
+          echo "✅ Span metrics aggregator resources verified successfully"
       
       - name: Run trace generator
         run: |

--- a/charts/logzio-telemetry/CHANGELOG.md
+++ b/charts/logzio-telemetry/CHANGELOG.md
@@ -6,7 +6,6 @@
   - Default resource requests and limits for `standaloneCollector` & `daemonsetCollector` are now empty by default and are configurable, only applies when explicitly set.
  - Add `priorityClassName`
  - Add `extraConfigMapMounts`
-
 ## 5.4.3
  - Add `enableServiceLinks` flag to control loading of service environment variables.
 ## 5.4.2

--- a/charts/logzio-telemetry/CHANGELOG.md
+++ b/charts/logzio-telemetry/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changes by Version
 
 <!-- next version -->
+## 5.5.0
+ - **Breaking change:** 
+  - Default resource requests and limits for `standaloneCollector` & `daemonsetCollector` are now empty by default and are configurable, only applies when explicitly set.
+ - Add `priorityClassName`
+ - Add `extraConfigMapMounts`
+
 ## 5.4.3
  - Add `enableServiceLinks` flag to control loading of service environment variables.
 ## 5.4.2

--- a/charts/logzio-telemetry/CHANGELOG.md
+++ b/charts/logzio-telemetry/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- next version -->
 ## 5.5.0
  - **Breaking change:** 
-  - Default resource requests and limits for `standaloneCollector` & `daemonsetCollector` are now empty by default and are configurable, only applies when explicitly set.
+  - Default resource requests and limits for `standaloneCollector`,  `daemonsetCollector` &  `spanMetricsAgregator` are now empty by default and are configurable, only applies when explicitly set.
  - Add `priorityClassName`
  - Add `extraConfigMapMounts`
 ## 5.4.3

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 5.4.3
+version: 5.5.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -313,9 +313,10 @@ spanMetricsAgregator:
       cpu: "512m"
 ```
 
-When the `requests` and `limits` objects are empty (`{}`), no resource constraints are applied to the pods.
-
-**⚠️ WARNING**: Running pods without resource limits in production environments can lead to resource contention and cluster instability if the collector consumes excessive memory or CPU.
+> [!WARNING]
+> When the `requests` and `limits` objects are empty (`{}`), no resource constraints are applied to the pods.
+> 
+> Running pods without resource limits in production environments can lead to resource contention and cluster instability if the collector consumes excessive memory or CPU.
 
 ### Adding application metrics
 

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -267,6 +267,38 @@ The default configuration uses the Prometheus receiver with the following scrape
 
 To customize your configuration, edit the `config` section in the `values.yaml` file.
 
+#### Configuring resource requests and limits
+
+By default, the OpenTelemetry collector pods do not have resource requests or limits set, allowing for flexibility in different cluster environments. You can configure resource requirements by setting the following values:
+
+For standalone collector:
+```yaml
+standaloneCollector:
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "200m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+```
+
+For daemonset collector:
+```yaml
+daemonsetCollector:
+  resources:
+    requests:
+      memory: "250Mi"
+      cpu: "150m"
+    limits:
+      memory: "512Mi"
+      cpu: "300m"
+```
+
+When the `requests` and `limits` objects are empty (`{}`), no resource constraints are applied to the pods.
+
+**⚠️ WARNING**: Running pods without resource limits in production environments can lead to resource contention and cluster instability if the collector consumes excessive memory or CPU.
+
 ### Adding application metrics
 
 To enable applications metrics scraping set the `applicationMetrics.enabled` value to `true`

--- a/charts/logzio-telemetry/README.md
+++ b/charts/logzio-telemetry/README.md
@@ -274,6 +274,8 @@ By default, the OpenTelemetry collector pods do not have resource requests or li
 For standalone collector:
 ```yaml
 standaloneCollector:
+  # Default: resources: {} (no resource constraints)
+  # Example with resource constraints:
   resources:
     requests:
       memory: "512Mi"
@@ -286,6 +288,8 @@ standaloneCollector:
 For daemonset collector:
 ```yaml
 daemonsetCollector:
+  # Default: resources: {} (no resource constraints)
+  # Example with resource constraints:
   resources:
     requests:
       memory: "250Mi"
@@ -293,6 +297,20 @@ daemonsetCollector:
     limits:
       memory: "512Mi"
       cpu: "300m"
+```
+
+For span metrics collector:
+```yaml
+spanMetricsAgregator:
+  # Default: resources: {} (no resource constraints)
+  # Example with resource constraints:
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "256m"
+    limits:
+      memory: "1Gi"
+      cpu: "512m"
 ```
 
 When the `requests` and `limits` objects are empty (`{}`), no resource constraints are applied to the pods.

--- a/charts/logzio-telemetry/VALUES.md
+++ b/charts/logzio-telemetry/VALUES.md
@@ -57,12 +57,12 @@ logzio-k8s-telemetry allows you to ship metrics and traces from your Kubernetes 
 | global.env_id | string | `"my_environment"` | Env id to be used with k8s 360. |
 | secrets.windowsNodePassword | string | `""` | Windows node password - will be used to install node-exporter for windows nodes. |
 | secrets.windowsNodeUsername | string | `""` | Windows username - will be used to install node-exporter for windows nodes. |
-| standaloneCollector.resources.limits.cpu | string | `"200m"` | Cpu limit for the opentelemetry collector pod. |
-| standaloneCollector.resources.limits.memory | string | `"512Mi"` | Memory limit for the opentelemetry colletor pods. |
+| standaloneCollector.resources.requests | object | `{}` | Resource requests for the standalone opentelemetry collector pod. When empty, no resource requests are set. |
+| standaloneCollector.resources.limits | object | `{}` | Resource limits for the standalone opentelemetry collector pod. When empty, no resource limits are set. |
 | standaloneCollector.podLabels | string | `nil` | Selector labels that will be added to the collector pods. |
 | standaloneCollector.podAnnotations | string | `nil` | Selector labels that will be added to the collector pods. |
-| daemonsetCollector.resources.limits.cpu | string | `"150m"` | Cpu limit for the opentelemetry colletor pods. |
-| daemonsetCollector.resources.limits.memory | string | `"250Mi"` | Memory limit for the opentelemetry colletor pods. |
+| daemonsetCollector.resources.requests | object | `{}` | Resource requests for the daemonset opentelemetry collector pods. When empty, no resource requests are set. |
+| daemonsetCollector.resources.limits | object | `{}` | Resource limits for the daemonset opentelemetry collector pods. When empty, no resource limits are set. |
 | daemonsetCollector.podLabels | string | `nil` | Selector labels that will be added to the collector pods. |
 | daemonsetCollector.podAnnotations | string | `nil` | Selector annotations that will be added to the collector pods. |
 | windowsExporterInstallerJob.interval | string | `"*/10 * * * *"` | Cronjob expression for the windows exporter installer job. |

--- a/charts/logzio-telemetry/VALUES.md
+++ b/charts/logzio-telemetry/VALUES.md
@@ -57,13 +57,12 @@ logzio-k8s-telemetry allows you to ship metrics and traces from your Kubernetes 
 | global.env_id | string | `"my_environment"` | Env id to be used with k8s 360. |
 | secrets.windowsNodePassword | string | `""` | Windows node password - will be used to install node-exporter for windows nodes. |
 | secrets.windowsNodeUsername | string | `""` | Windows username - will be used to install node-exporter for windows nodes. |
-| standaloneCollector.resources.requests | object | `{}` | Resource requests for the standalone opentelemetry collector pod. When empty, no resource requests are set. |
-| standaloneCollector.resources.limits | object | `{}` | Resource limits for the standalone opentelemetry collector pod. When empty, no resource limits are set. |
+| standaloneCollector.resources | object | `{}` | Resource constraints for the standalone opentelemetry collector pod. When empty, no resource constraints are applied. Example: `{ requests: { cpu: "100m", memory: "256Mi" }, limits: { cpu: "200m", memory: "512Mi" } }` |
 | standaloneCollector.podLabels | string | `nil` | Selector labels that will be added to the collector pods. |
 | standaloneCollector.podAnnotations | string | `nil` | Selector labels that will be added to the collector pods. |
-| daemonsetCollector.resources.requests | object | `{}` | Resource requests for the daemonset opentelemetry collector pods. When empty, no resource requests are set. |
-| daemonsetCollector.resources.limits | object | `{}` | Resource limits for the daemonset opentelemetry collector pods. When empty, no resource limits are set. |
+| daemonsetCollector.resources | object | `{}` | Resource constraints for the daemonset opentelemetry collector pods. When empty, no resource constraints are applied. Example: `{ requests: { cpu: "50m", memory: "128Mi" }, limits: { cpu: "100m", memory: "256Mi" } }` |
 | daemonsetCollector.podLabels | string | `nil` | Selector labels that will be added to the collector pods. |
+| spanMetricsAgregator.resources | object | `{}` | Resource constraints for the span metrics aggregator pod. When empty, no resource constraints are applied. Example: `{ requests: { cpu: "256m", memory: "512Mi" }, limits: { cpu: "512m", memory: "1Gi" } }` |
 | daemonsetCollector.podAnnotations | string | `nil` | Selector annotations that will be added to the collector pods. |
 | windowsExporterInstallerJob.interval | string | `"*/10 * * * *"` | Cronjob expression for the windows exporter installer job. |
 | signalFx.enabled | bool | `false` | Enable SignalFx receiver to accept metrics from SignalFx client libraries. |

--- a/charts/logzio-telemetry/VALUES.md
+++ b/charts/logzio-telemetry/VALUES.md
@@ -57,12 +57,12 @@ logzio-k8s-telemetry allows you to ship metrics and traces from your Kubernetes 
 | global.env_id | string | `"my_environment"` | Env id to be used with k8s 360. |
 | secrets.windowsNodePassword | string | `""` | Windows node password - will be used to install node-exporter for windows nodes. |
 | secrets.windowsNodeUsername | string | `""` | Windows username - will be used to install node-exporter for windows nodes. |
-| standaloneCollector.resources | object | `{}` | Resource constraints for the standalone opentelemetry collector pod. When empty, no resource constraints are applied. Example: `{ requests: { cpu: "100m", memory: "256Mi" }, limits: { cpu: "200m", memory: "512Mi" } }` |
+| standaloneCollector.resources | object | `{}` | Resource constraints for the standalone opentelemetry collector pod. When empty, no resource constraints are applied. [Example](README.md#configuring-resource-requests-and-limits). |
 | standaloneCollector.podLabels | string | `nil` | Selector labels that will be added to the collector pods. |
 | standaloneCollector.podAnnotations | string | `nil` | Selector labels that will be added to the collector pods. |
-| daemonsetCollector.resources | object | `{}` | Resource constraints for the daemonset opentelemetry collector pods. When empty, no resource constraints are applied. Example: `{ requests: { cpu: "50m", memory: "128Mi" }, limits: { cpu: "100m", memory: "256Mi" } }` |
+| daemonsetCollector.resources | object | `{}` | Resource constraints for the daemonset opentelemetry collector pods. When empty, no resource constraints are applied. [Example](README.md#configuring-resource-requests-and-limits). |
 | daemonsetCollector.podLabels | string | `nil` | Selector labels that will be added to the collector pods. |
-| spanMetricsAgregator.resources | object | `{}` | Resource constraints for the span metrics aggregator pod. When empty, no resource constraints are applied. Example: `{ requests: { cpu: "256m", memory: "512Mi" }, limits: { cpu: "512m", memory: "1Gi" } }` |
+| spanMetricsAgregator.resources | object | `{}` | Resource constraints for the span metrics aggregator pod. When empty, no resource constraints are applied. [Example](README.md#configuring-resource-requests-and-limits). |
 | daemonsetCollector.podAnnotations | string | `nil` | Selector annotations that will be added to the collector pods. |
 | windowsExporterInstallerJob.interval | string | `"*/10 * * * *"` | Cronjob expression for the windows exporter installer job. |
 | signalFx.enabled | bool | `false` | Enable SignalFx receiver to accept metrics from SignalFx client libraries. |

--- a/charts/logzio-telemetry/templates/_daemonset-pod.tpl
+++ b/charts/logzio-telemetry/templates/_daemonset-pod.tpl
@@ -110,13 +110,7 @@ containers:
       httpGet:
         path: /
         port: 13133
-    {{- if .Values.daemonsetCollector.resources }}
-    {{- $resources := .Values.daemonsetCollector.resources }}
-    {{- if or (and $resources.requests (keys $resources.requests)) (and $resources.limits (keys $resources.limits)) }}
-    resources:
-      {{- toYaml $resources | nindent 6 }}
-    {{- end }}
-    {{- end }}
+    {{- include "opentelemetry-collector.resources" .Values.daemonsetCollector.resources | nindent 4 }}
     volumeMounts:
       - mountPath: /conf
         name: {{ .Chart.Name }}-configmap

--- a/charts/logzio-telemetry/templates/_daemonset-pod.tpl
+++ b/charts/logzio-telemetry/templates/_daemonset-pod.tpl
@@ -110,8 +110,13 @@ containers:
       httpGet:
         path: /
         port: 13133
+    {{- if .Values.daemonsetCollector.resources }}
+    {{- $resources := .Values.daemonsetCollector.resources }}
+    {{- if or (and $resources.requests (keys $resources.requests)) (and $resources.limits (keys $resources.limits)) }}
     resources:
-      {{- toYaml .Values.resources | nindent 6 }}
+      {{- toYaml $resources | nindent 6 }}
+    {{- end }}
+    {{- end }}
     volumeMounts:
       - mountPath: /conf
         name: {{ .Chart.Name }}-configmap

--- a/charts/logzio-telemetry/templates/_helpers.tpl
+++ b/charts/logzio-telemetry/templates/_helpers.tpl
@@ -275,3 +275,20 @@ https://listener.logz.io:8071
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Common resources template that handles conditional rendering of resources section.
+Only renders the resources section if there are actual requests or limits defined.
+Usage: {{ include "opentelemetry-collector.resources" .Values.standaloneCollector.resources }}
+       {{ include "opentelemetry-collector.resources" .Values.daemonsetCollector.resources }}
+       {{ include "opentelemetry-collector.resources" .Values.spanMetricsAgregator.resources }}
+*/}}
+{{- define "opentelemetry-collector.resources" -}}
+{{- if . }}
+{{- $resources := . }}
+{{- if or (and $resources.requests (keys $resources.requests)) (and $resources.limits (keys $resources.limits)) }}
+resources:
+  {{- toYaml $resources | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/logzio-telemetry/templates/_pod-spm.tpl
+++ b/charts/logzio-telemetry/templates/_pod-spm.tpl
@@ -53,8 +53,13 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: env_id
+    {{- if .Values.spanMetricsAgregator.resources }}
+    {{- $resources := .Values.spanMetricsAgregator.resources }}
+    {{- if or (and $resources.requests (keys $resources.requests)) (and $resources.limits (keys $resources.limits)) }}
     resources:
-    {{- toYaml .Values.spanMetricsAgregator.resources | nindent 6 }}
+      {{- toYaml $resources | nindent 6 }}
+    {{- end }}
+    {{- end }}
     volumeMounts:
       - mountPath: /conf
         name: {{ .Chart.Name }}-configmap-spm    

--- a/charts/logzio-telemetry/templates/_pod-spm.tpl
+++ b/charts/logzio-telemetry/templates/_pod-spm.tpl
@@ -53,13 +53,7 @@ containers:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
             key: env_id
-    {{- if .Values.spanMetricsAgregator.resources }}
-    {{- $resources := .Values.spanMetricsAgregator.resources }}
-    {{- if or (and $resources.requests (keys $resources.requests)) (and $resources.limits (keys $resources.limits)) }}
-    resources:
-      {{- toYaml $resources | nindent 6 }}
-    {{- end }}
-    {{- end }}
+    {{- include "opentelemetry-collector.resources" .Values.spanMetricsAgregator.resources | nindent 4 }}
     volumeMounts:
       - mountPath: /conf
         name: {{ .Chart.Name }}-configmap-spm    

--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -150,13 +150,7 @@ containers:
       httpGet:
         path: /
         port: 13133
-    {{- if .Values.standaloneCollector.resources }}
-    {{- $resources := .Values.standaloneCollector.resources }}
-    {{- if or (and $resources.requests (keys $resources.requests)) (and $resources.limits (keys $resources.limits)) }}
-    resources:
-      {{- toYaml $resources | nindent 6 }}
-    {{- end }}
-    {{- end }}
+    {{- include "opentelemetry-collector.resources" .Values.standaloneCollector.resources | nindent 4 }}
     volumeMounts:
       - mountPath: /conf
         name: {{ .Chart.Name }}-configmap

--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -150,8 +150,13 @@ containers:
       httpGet:
         path: /
         port: 13133
+    {{- if .Values.standaloneCollector.resources }}
+    {{- $resources := .Values.standaloneCollector.resources }}
+    {{- if or (and $resources.requests (keys $resources.requests)) (and $resources.limits (keys $resources.limits)) }}
     resources:
-      {{- toYaml .Values.resources | nindent 6 }}
+      {{- toYaml $resources | nindent 6 }}
+    {{- end }}
+    {{- end }}
     volumeMounts:
       - mountPath: /conf
         name: {{ .Chart.Name }}-configmap

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -1062,7 +1062,16 @@ spanMetricsAgregator:
       servicePort: 9411
       hostPort: 9411
       protocol: TCP
-  # Example: resources: { requests: { cpu: "256m", memory: "512Mi" }, limits: { cpu: "512m", memory: "1Gi" } }
+
+  # Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## Example:
+  ## resources:
+  ##   requests:
+  ##     cpu: 256m
+  ##     memory: 512Mi
+  ##   limits:
+  ##     cpu: 512m
+  ##     memory: 1024Mi
   resources: {}
 
 
@@ -1073,7 +1082,15 @@ standaloneCollector:
   containerLogs:
     enabled: false
 
-  # Example: resources: { requests: { cpu: "100m", memory: "256Mi" }, limits: { cpu: "200m", memory: "512Mi" } }
+  # Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## Example:
+  ## resources:
+  ##   requests:
+  ##     cpu: 200m
+  ##     memory: 512Mi
+  ##   limits:
+  ##     cpu: 500m
+  ##     memory: 1024Mi  
   resources: {}
   podLabels:  {}
 
@@ -1099,7 +1116,15 @@ daemonsetCollector:
               - key: eks.amazonaws.com/compute-type
                 operator: DoesNotExist
 
-  # Example: resources: { requests: { cpu: "50m", memory: "128Mi" }, limits: { cpu: "100m", memory: "256Mi" } }
+  # Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## Example:
+  ## resources:
+  ##   requests:
+  ##     cpu: 150m
+  ##     memory: 256Mi
+  ##   limits:
+  ##     cpu: 300m
+  ##     memory: 512Mi  
   resources: {}
 
   podLabels:  {}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -1062,10 +1062,8 @@ spanMetricsAgregator:
       servicePort: 9411
       hostPort: 9411
       protocol: TCP
-  resources:
-    requests:
-      cpu: 256m
-      memory: 512Mi
+  # Example: resources: { requests: { cpu: "256m", memory: "512Mi" }, limits: { cpu: "512m", memory: "1Gi" } }
+  resources: {}
 
 
 # Configuration for standalone OpenTelemetry Collector deployment, enabled by default
@@ -1075,10 +1073,8 @@ standaloneCollector:
   containerLogs:
     enabled: false
 
-  resources:
-    requests: {}
-    limits: {}
-      
+  # Example: resources: { requests: { cpu: "100m", memory: "256Mi" }, limits: { cpu: "200m", memory: "512Mi" } }
+  resources: {}
   podLabels:  {}
 
   podAnnotations: {}
@@ -1103,9 +1099,8 @@ daemonsetCollector:
               - key: eks.amazonaws.com/compute-type
                 operator: DoesNotExist
 
-  resources:
-    requests: {}
-    limits: {}
+  # Example: resources: { requests: { cpu: "50m", memory: "128Mi" }, limits: { cpu: "100m", memory: "256Mi" } }
+  resources: {}
 
   podLabels:  {}
 

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -651,8 +651,12 @@ podDisruptionBudget:
 # If both defined only maxUnavailable will be used
 
 extraEnvs: []
+extraConfigMapMounts: []
 extraHostPathMounts: []
 secretMounts: []
+
+# PriorityClass name for the collector pods
+priorityClassName: ""
 
 # Configuration for ports, shared between daemonsetCollector, standaloneCollector and service.
 # Can be overridden here or for daemonsetCollector and standaloneCollector independently.
@@ -1072,9 +1076,8 @@ standaloneCollector:
     enabled: false
 
   resources:
-    requests:
-      memory: 512Mi
-      cpu: 200m
+    requests: {}
+    limits: {}
       
   podLabels:  {}
 
@@ -1101,9 +1104,8 @@ daemonsetCollector:
                 operator: DoesNotExist
 
   resources:
-    requests:
-      cpu: 150m
-      memory: 250Mi
+    requests: {}
+    limits: {}
 
   podLabels:  {}
 

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -1063,17 +1063,16 @@ spanMetricsAgregator:
       hostPort: 9411
       protocol: TCP
 
-  # Set container requests and limits for different resources like CPU or memory (essential for production workloads)
-  ## Example:
-  ## resources:
-  ##   requests:
-  ##     cpu: 256m
-  ##     memory: 512Mi
-  ##   limits:
-  ##     cpu: 512m
-  ##     memory: 1024Mi
-  resources: {}
 
+  resources: {}
+   ## Resources are not specified by default, to ensure the chart runs on environments with little resources.
+   ## If you want to specify resources, uncomment the following  lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 256m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 512m
+    #   memory: 1024Mi
 
 # Configuration for standalone OpenTelemetry Collector deployment, enabled by default
 standaloneCollector:
@@ -1082,16 +1081,15 @@ standaloneCollector:
   containerLogs:
     enabled: false
 
-  # Set container requests and limits for different resources like CPU or memory (essential for production workloads)
-  ## Example:
-  ## resources:
-  ##   requests:
-  ##     cpu: 200m
-  ##     memory: 512Mi
-  ##   limits:
-  ##     cpu: 500m
-  ##     memory: 1024Mi  
   resources: {}
+   ## Resources are not specified by default, to ensure the chart runs on environments with little resources.
+   ## If you want to specify resources, uncomment the following  lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 200m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 500m
+    #   memory: 1024Mi
   podLabels:  {}
 
   podAnnotations: {}
@@ -1116,17 +1114,16 @@ daemonsetCollector:
               - key: eks.amazonaws.com/compute-type
                 operator: DoesNotExist
 
-  # Set container requests and limits for different resources like CPU or memory (essential for production workloads)
-  ## Example:
-  ## resources:
-  ##   requests:
-  ##     cpu: 150m
-  ##     memory: 256Mi
-  ##   limits:
-  ##     cpu: 300m
-  ##     memory: 512Mi  
-  resources: {}
 
+  resources: {}
+   ## Resources are not specified by default, to ensure the chart runs on environments with little resources.
+   ## If you want to specify resources, uncomment the following  lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 150m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 300m
+    #   memory: 512Mi
   podLabels:  {}
 
   podAnnotations: {}


### PR DESCRIPTION
 - **Breaking change:**
    -  Default resource requests and limits for `standaloneCollector` & `daemonsetCollector` are now empty by default and are configurable, only applies when explicitly set.
 - Add missing `priorityClassName` value.
 - Add missing `extraConfigMapMounts` value.
 - Add `standaloneCollecter`, `daemonsetCollector` & `spanMetricsAgregator ` resources set commands to monitoring & telemetry tests workflow
 - Add resources empty state test under protocol receiver job in monitoring & telemetry tests workflow
## Description 

<!-- 
    "This PR [adds/removes/fixes/replaces] the [feature/bug/etc].."
    Do not leave this blank.
    If relevant, describe the previous behaviour compared to the behaviour post your code change.
-->

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
