### PR TITLE
Upgrade `logzio-monitoring` chart to v7.6.0

### DIFF
--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changes by Version
 
 <!-- next version -->
+## 7.6.0
+- Upgrade `logzio-k8s-telemetry` chart to `5.5.0`
+  - **Breaking change:** 
+    - Default resource requests and limits for `standaloneCollector`,  `daemonsetCollector` &  `spanMetricsAgregator` are now empty by default and are configurable, only applies when explicitly set.
+  - Add `priorityClassName` value.
+  - Add `extraConfigMapMounts` value.
 ## 7.5.2
 - Upgrade `logzio-k8s-telemetry` chart to `5.4.3`
   - Add `enableServiceLinks` flag to control loading of service environment variables.

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 7.5.2
+version: 7.6.0
 
 
 sources:
@@ -13,7 +13,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "5.4.3"
+    version: "5.5.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logzio-k8s-telemetry.metrics.enabled
   - name: logzio-trivy


### PR DESCRIPTION
- Upgrade `logzio-k8s-telemetry` chart to `5.5.0`
  - **Breaking change:**
    - Default resource requests and limits for `standaloneCollector`,  `daemonsetCollector` &  `spanMetricsAgregator` are now empty by default and are configurable, only applies when explicitly set.
  - Add `priorityClassName` value.
  - Add `extraConfigMapMounts` value.

## Description 

<!-- 
    "This PR [adds/removes/fixes/replaces] the [feature/bug/etc].."
    Do not leave this blank.
    If relevant, describe the previous behaviour compared to the behaviour post your code change.
-->

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
