### PR TITLE
Release `fluentbit` Helm chart v0.0.8

### DIFF
--- a/charts/fluentbit/Chart.yaml
+++ b/charts/fluentbit/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - fluent-bit
   - fluentd
 type: application
-version: 0.0.7
-appVersion: 0.6.2
+version: 0.0.8
+appVersion: 0.6.3
 sources:
   - https://github.com/logzio/logzio-helm
   - https://github.com/fluent/fluent-bit/

--- a/charts/fluentbit/README.md
+++ b/charts/fluentbit/README.md
@@ -90,6 +90,10 @@ kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.tain
 
 
 ## Change log
+* 0.0.8 
+  - Upgrade 'fluent-bit-output' image to 0.6.3
+    - Fix potential stack overflow: Reduced default bulk size to 2MB, added logzio_bulk_size_mb config (1-9 MB).
+  - Add required `id` to Logz.io output configuration
 * 0.0.7 
   - Upgrade 'fluent-bit-output' image to 0.6.2
     - Resolve bug with exit code handling to ensure all buffered logs are flushed before termination.

--- a/charts/fluentbit/values.yaml
+++ b/charts/fluentbit/values.yaml
@@ -215,6 +215,7 @@ config:
   outputs: |
     [OUTPUT]
         Name  logzio
+        id logzio_output_1
         Match *
         logzio_token {{ .Values.logzio.token }}
         logzio_url   https://{{ .Values.logzio.listenerHost }}:8071
@@ -237,6 +238,7 @@ config:
 #     example.conf: |
 #       [OUTPUT]
 #           Name example
+#           id example_output_1
 #           Match foo.*
 #           Host bar
 


### PR DESCRIPTION
* 0.0.8
  - Upgrade 'fluent-bit-output' image to 0.6.3
    - Fix potential stack overflow: Reduced default bulk size to 2MB, added logzio_bulk_size_mb config (1-9 MB).
  - Add required `id` to Logz.io output configuration

## Description 

<!-- 
    "This PR [adds/removes/fixes/replaces] the [feature/bug/etc].."
    Do not leave this blank.
    If relevant, describe the previous behaviour compared to the behaviour post your code change.
-->

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
