### PR TITLE
[Feature] Add global `nodeSelector` and `affinity`

### DIFF
--- a/charts/logzio-apm-collector/CHANGELOG.md
+++ b/charts/logzio-apm-collector/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changes by Version
 
 <!-- next version -->
+
+## 1.4.0
+- Upgrade OpenTelemetry Collector from `0.129.0` to `0.133.0`.
+- Support global setting for `nodeSelector` and `affinity`.
+
 ## 1.3.0
 - Add **trace filtering** capability via the new `filters` values key.
   - Supports `exclude` (drop) and `include` (keep) rules on `namespace`, `service`, any `attribute.*` or `resource.*` fields using regular expressions.

--- a/charts/logzio-apm-collector/Chart.yaml
+++ b/charts/logzio-apm-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: logzio-apm-collector
-version: 1.3.0
+version: 1.4.0
 
 description: Kubernetes APM agent for Logz.io based on OpenTelemetry Collector
 type: application
@@ -9,4 +9,4 @@ icon: https://logzbucket.s3.eu-west-1.amazonaws.com/logz-io-img/logo400x400.png
 maintainers:
   - name: Naama Bendalak
     email: naama.bendalak@logz.io
-appVersion: 0.129.1
+appVersion: 0.133.0

--- a/charts/logzio-apm-collector/templates/_helpers.tpl
+++ b/charts/logzio-apm-collector/templates/_helpers.tpl
@@ -180,3 +180,31 @@ Returns a YAML array of key=regex strings.
 {{- end }}
 {{- toYaml $out }}
 {{- end }}
+
+{{/*
+Merges local and global affinity settings.
+*/}}
+{{- define "apm-collector.affinity" -}}
+{{- $affinity := deepCopy .Values.affinity -}}
+{{- if .Values.global.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.global.affinity -}}
+{{- end -}}
+{{- if $affinity -}}
+affinity:
+  {{- toYaml $affinity | nindent 2 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Merges local and global nodeSelector settings.
+*/}}
+{{- define "apm-collector.nodeSelector" -}}
+{{- $nodeSelector := deepCopy .Values.nodeSelector -}}
+{{- if .Values.global.nodeSelector -}}
+  {{- $nodeSelector = merge $nodeSelector .Values.global.nodeSelector -}}
+{{- end -}}
+{{- if $nodeSelector -}}
+nodeSelector:
+  {{- toYaml $nodeSelector | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/charts/logzio-apm-collector/templates/_helpers.tpl
+++ b/charts/logzio-apm-collector/templates/_helpers.tpl
@@ -185,7 +185,10 @@ Returns a YAML array of key=regex strings.
 Merges local and global affinity settings.
 */}}
 {{- define "apm-collector.affinity" -}}
-{{- $affinity := deepCopy .Values.affinity -}}
+{{- $affinity := dict -}}
+{{- if .Values.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.affinity -}}
+{{- end -}}
 {{- if .Values.global.affinity -}}
   {{- $affinity = mergeOverwrite $affinity .Values.global.affinity -}}
 {{- end -}}
@@ -199,7 +202,10 @@ affinity:
 Merges local and global nodeSelector settings.
 */}}
 {{- define "apm-collector.nodeSelector" -}}
-{{- $nodeSelector := deepCopy .Values.nodeSelector -}}
+{{- $nodeSelector := dict -}}
+{{- if .Values.nodeSelector -}}
+  {{- $nodeSelector = merge $nodeSelector .Values.nodeSelector -}}
+{{- end -}}
 {{- if .Values.global.nodeSelector -}}
   {{- $nodeSelector = merge $nodeSelector .Values.global.nodeSelector -}}
 {{- end -}}

--- a/charts/logzio-apm-collector/templates/_helpers.tpl
+++ b/charts/logzio-apm-collector/templates/_helpers.tpl
@@ -186,11 +186,11 @@ Merges local and global affinity settings.
 */}}
 {{- define "apm-collector.affinity" -}}
 {{- $affinity := dict -}}
-{{- if .Values.affinity -}}
-  {{- $affinity = mergeOverwrite $affinity .Values.affinity -}}
-{{- end -}}
 {{- if .Values.global.affinity -}}
   {{- $affinity = mergeOverwrite $affinity .Values.global.affinity -}}
+{{- end -}}
+{{- if .Values.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.affinity -}}
 {{- end -}}
 {{- if $affinity -}}
 affinity:
@@ -203,11 +203,11 @@ Merges local and global nodeSelector settings.
 */}}
 {{- define "apm-collector.nodeSelector" -}}
 {{- $nodeSelector := dict -}}
-{{- if .Values.nodeSelector -}}
-  {{- $nodeSelector = merge $nodeSelector .Values.nodeSelector -}}
-{{- end -}}
 {{- if .Values.global.nodeSelector -}}
   {{- $nodeSelector = merge $nodeSelector .Values.global.nodeSelector -}}
+{{- end -}}
+{{- if .Values.nodeSelector -}}
+  {{- $nodeSelector = merge $nodeSelector .Values.nodeSelector -}}
 {{- end -}}
 {{- if $nodeSelector -}}
 nodeSelector:

--- a/charts/logzio-apm-collector/templates/_pod-spm.tpl
+++ b/charts/logzio-apm-collector/templates/_pod-spm.tpl
@@ -140,14 +140,8 @@ volumes:
   {{- if .Values.extraVolumes }}
   {{- toYaml .Values.extraVolumes | nindent 2 }}
   {{- end }}
-{{- with .Values.nodeSelector }}
-nodeSelector:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
-{{- with .Values.affinity }}
-affinity:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
+{{ with (include "apm-collector.nodeSelector" .) }}{{ . }}{{ end }}
+{{ with (include "apm-collector.affinity" .) }}{{ . }}{{ end }}
 {{- if or .Values.tolerations .Values.global.tolerations }}
   {{- $allTolerations := concat (.Values.tolerations | default list) (.Values.global.tolerations | default list) }}
 tolerations:

--- a/charts/logzio-apm-collector/templates/_pod.tpl
+++ b/charts/logzio-apm-collector/templates/_pod.tpl
@@ -160,14 +160,8 @@ volumes:
   {{- if .Values.extraVolumes }}
   {{- toYaml .Values.extraVolumes | nindent 2 }}
   {{- end }}
-{{- with .Values.nodeSelector }}
-nodeSelector:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
-{{- with .Values.affinity }}
-affinity:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
+{{ with (include "apm-collector.nodeSelector" .) }}{{ . }}{{ end }}
+{{ with (include "apm-collector.affinity" .) }}{{ . }}{{ end }}
 {{- if or .Values.tolerations .Values.global.tolerations }}
   {{- $allTolerations := concat (.Values.tolerations | default list) (.Values.global.tolerations | default list) }}
 tolerations:

--- a/charts/logzio-k8s-events/CHANGELOG.md
+++ b/charts/logzio-k8s-events/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changes by Version
 
 <!-- next version -->
+## 2.0.0
+- Support global setting for `nodeSelector` and `affinity`.
+- **Breaking changes:**
+  - Deprecate `nodeArchitectures` setting (can be configured directly under `affinity`).
+
 ## 1.0.1
 - Add support for configuring tolerations
 ## 1.0.0

--- a/charts/logzio-k8s-events/Chart.yaml
+++ b/charts/logzio-k8s-events/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - logging
   - k8s
   - kubernetes
-version: 1.0.1
+version: 2.0.0
 appVersion: 0.0.4
 maintainers:
   - name: Raul Gurshumov

--- a/charts/logzio-k8s-events/templates/_helpers.tpl
+++ b/charts/logzio-k8s-events/templates/_helpers.tpl
@@ -78,3 +78,37 @@ Builds the full logzio listener host
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merges local and global affinity settings.
+*/}}
+{{- define "logzio-k8s-events.affinity" -}}
+{{- $affinity := dict -}}
+{{- if .Values.global.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.global.affinity -}}
+{{- end -}}
+{{- if .Values.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.affinity -}}
+{{- end -}}
+{{- if $affinity -}}
+affinity:
+  {{- toYaml $affinity | nindent 2 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Merges local and global nodeSelector settings.
+*/}}
+{{- define "logzio-k8s-events.nodeSelector" -}}
+{{- $nodeSelector := dict -}}
+{{- if .Values.global.nodeSelector -}}
+  {{- $nodeSelector = merge $nodeSelector .Values.global.nodeSelector -}}
+{{- end -}}
+{{- if .Values.nodeSelector -}}
+  {{- $nodeSelector = merge $nodeSelector .Values.nodeSelector -}}
+{{- end -}}
+{{- if $nodeSelector -}}
+nodeSelector:
+  {{- toYaml $nodeSelector | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/charts/logzio-k8s-events/templates/deployment.yaml
+++ b/charts/logzio-k8s-events/templates/deployment.yaml
@@ -23,17 +23,8 @@ spec:
       tolerations:
 {{ toYaml $allTolerations | nindent 8 }}
       {{- end }}
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values: 
-                {{- range .Values.nodeArchitectures }}
-                  - {{ . }}
-                {{- end }}
+      {{ with (include "logzio-k8s-events.nodeSelector" .) }}{{ . | nindent 6 }}{{ end }}
+      {{ with (include "logzio-k8s-events.affinity" .) }}{{ . | nindent 6 }}{{ end }}
       {{- if .Values.isRBAC }}
       serviceAccountName: {{ template "logzio-k8s-events.serviceAccountName" . }}
       {{- end }}

--- a/charts/logzio-k8s-events/values.yaml
+++ b/charts/logzio-k8s-events/values.yaml
@@ -38,15 +38,24 @@ serviceAccount:
   name: ""
 
 tolerations: []
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/arch
+          operator: In
+          values: 
+            - arm64
+            - amd64
+nodeSelector: {}
 
 resources:
   requests:
     cpu: 100m
     memory: 200Mi
 terminationGracePeriodSeconds: 30
-nodeArchitectures: 
-  - arm64
-  - amd64
+
 secret:
   enabled: true
   name: logzio-k8s-events-secret

--- a/charts/logzio-logs-collector/CHANGELOG.md
+++ b/charts/logzio-logs-collector/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changes by Version
 
 <!-- next version -->
+## 2.3.0
+- Support global setting for `nodeSelector` and `affinity`.
+  - Upgrade `otel/opentelemetry-collector-contrib` image to version `0.133.0`.
+
 ## 2.2.1
 - Add SignalFx logs support
 ## 2.2.0

--- a/charts/logzio-logs-collector/CHANGELOG.md
+++ b/charts/logzio-logs-collector/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- next version -->
 ## 2.3.0
 - Support global setting for `nodeSelector` and `affinity`.
-  - Upgrade `otel/opentelemetry-collector-contrib` image to version `0.133.0`.
+- Upgrade `otel/opentelemetry-collector-contrib` image to version `0.133.0`.
 
 ## 2.2.1
 - Add SignalFx logs support

--- a/charts/logzio-logs-collector/Chart.yaml
+++ b/charts/logzio-logs-collector/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: logzio-logs-collector
-version: 2.2.1
+version: 2.3.0
 description: kubernetes logs collection agent for logz.io based on opentelemetry collector
 type: application
 home: https://logz.io/
 maintainers:
   - name: yotam loewenbach
     email: yotam.loewenbach@logz.io
-appVersion: 0.127.0
+appVersion: 0.133.0

--- a/charts/logzio-logs-collector/templates/_helpers.tpl
+++ b/charts/logzio-logs-collector/templates/_helpers.tpl
@@ -238,3 +238,36 @@ Returns a YAML array of key=regex strings.
 {{- toYaml $out }}
 {{- end }}
 
+{{/*
+Merges local and global affinity settings.
+*/}}
+{{- define "logs-collector.affinity" -}}
+{{- $affinity := dict -}}
+{{- if .Values.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.affinity -}}
+{{- end -}}
+{{- if .Values.global.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.global.affinity -}}
+{{- end -}}
+{{- if $affinity -}}
+affinity:
+  {{- toYaml $affinity | nindent 2 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Merges local and global nodeSelector settings.
+*/}}
+{{- define "logs-collector.nodeSelector" -}}
+{{- $nodeSelector := dict -}}
+{{- if .Values.nodeSelector -}}
+  {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.nodeSelector -}}
+{{- end -}}
+{{- if .Values.global.nodeSelector -}}
+  {{- $nodeSelector = merge $nodeSelector .Values.global.nodeSelector -}}
+{{- end -}}
+{{- if $nodeSelector -}}
+nodeSelector:
+  {{- toYaml $nodeSelector | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/charts/logzio-logs-collector/templates/_helpers.tpl
+++ b/charts/logzio-logs-collector/templates/_helpers.tpl
@@ -264,7 +264,7 @@ Merges local and global nodeSelector settings.
   {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.nodeSelector -}}
 {{- end -}}
 {{- if .Values.global.nodeSelector -}}
-  {{- $nodeSelector = merge $nodeSelector .Values.global.nodeSelector -}}
+  {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.global.nodeSelector -}}
 {{- end -}}
 {{- if $nodeSelector -}}
 nodeSelector:

--- a/charts/logzio-logs-collector/templates/_helpers.tpl
+++ b/charts/logzio-logs-collector/templates/_helpers.tpl
@@ -243,11 +243,11 @@ Merges local and global affinity settings.
 */}}
 {{- define "logs-collector.affinity" -}}
 {{- $affinity := dict -}}
-{{- if .Values.affinity -}}
-  {{- $affinity = mergeOverwrite $affinity .Values.affinity -}}
-{{- end -}}
 {{- if .Values.global.affinity -}}
   {{- $affinity = mergeOverwrite $affinity .Values.global.affinity -}}
+{{- end -}}
+{{- if .Values.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.affinity -}}
 {{- end -}}
 {{- if $affinity -}}
 affinity:
@@ -260,11 +260,11 @@ Merges local and global nodeSelector settings.
 */}}
 {{- define "logs-collector.nodeSelector" -}}
 {{- $nodeSelector := dict -}}
-{{- if .Values.nodeSelector -}}
-  {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.nodeSelector -}}
-{{- end -}}
 {{- if .Values.global.nodeSelector -}}
   {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.global.nodeSelector -}}
+{{- end -}}
+{{- if .Values.nodeSelector -}}
+  {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.nodeSelector -}}
 {{- end -}}
 {{- if $nodeSelector -}}
 nodeSelector:

--- a/charts/logzio-logs-collector/templates/_pod.tpl
+++ b/charts/logzio-logs-collector/templates/_pod.tpl
@@ -187,14 +187,8 @@ volumes:
   {{- if .Values.extraVolumes }}
   {{- toYaml .Values.extraVolumes | nindent 2 }}
   {{- end }}
-{{- with .Values.nodeSelector }}
-nodeSelector:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
-{{- with .Values.affinity }}
-affinity:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
+{{ with (include "logs-collector.nodeSelector" .) }}{{ . }}{{ end }}
+{{ with (include "logs-collector.affinity" .) }}{{ . }}{{ end }}
 {{- if or .Values.tolerations .Values.global.tolerations }}
   {{- $allTolerations := concat (.Values.tolerations | default list) (.Values.global.tolerations | default list) }}
 tolerations:

--- a/charts/logzio-logs-collector/values.yaml
+++ b/charts/logzio-logs-collector/values.yaml
@@ -223,7 +223,13 @@ config:
         - filelog
     telemetry:
       metrics:
-        address: ${env:MY_POD_IP}:8888
+        readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_units: true
       logs:
         level: info
 # SignalFx config

--- a/charts/logzio-telemetry/CHANGELOG.md
+++ b/charts/logzio-telemetry/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changes by Version
 
 <!-- next version -->
+## 5.7.0
+- Support global setting for `nodeSelector` and `affinity`.
 ## 5.6.0
 - **Breaking change:** 
   - Upgrade OpenTelemetry collector image to v0.131.0

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 5.6.0
+version: 5.7.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/templates/_daemonset-pod.tpl
+++ b/charts/logzio-telemetry/templates/_daemonset-pod.tpl
@@ -199,14 +199,8 @@ volumes:
     secret:
       secretName: {{ .secretName }}
   {{- end }}
-{{- with .Values.linuxNodeSelector }}
-nodeSelector:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
-{{- with .Values.daemonsetCollector.affinity }}
-affinity:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
+{{ with (include "opentelemetry-collector.nodeSelector" .) }}{{ . }}{{ end }}
+{{ with (include "opentelemetry-collector.daemonsetAffinity" .) }}{{ . }}{{ end }}
 {{- if or .Values.tolerations .Values.global.tolerations }}
   {{- $allTolerations := concat (.Values.tolerations | default list) (.Values.global.tolerations | default list) }}
 tolerations:

--- a/charts/logzio-telemetry/templates/_helpers.tpl
+++ b/charts/logzio-telemetry/templates/_helpers.tpl
@@ -226,6 +226,61 @@ component: standalone-collector-spm
 {{- end }}
 
 {{/*
+Merges local and global affinity settings for the standalone collector.
+*/}}
+{{- define "opentelemetry-collector.affinity" -}}
+{{- $affinity := dict -}}
+{{- if .Values.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.affinity -}}
+{{- end -}}
+{{- if .Values.global.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.global.affinity -}}
+{{- end -}}
+{{- if $affinity -}}
+affinity:
+  {{- toYaml $affinity | nindent 2 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Merges local daemonsetCollector affinity with global affinity settings.
+*/}}
+{{- define "opentelemetry-collector.daemonsetAffinity" -}}
+{{- $affinity := dict -}}
+{{- if .Values.daemonsetCollector.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.daemonsetCollector.affinity -}}
+{{- end -}}
+{{- if .Values.global.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.global.affinity -}}
+{{- end -}}
+{{- if $affinity -}}
+affinity:
+  {{- toYaml $affinity | nindent 2 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Merges linuxNodeSelector, local nodeSelector and global nodeSelector settings.
+Global keys override local ones if duplicated.
+*/}}
+{{- define "opentelemetry-collector.nodeSelector" -}}
+{{- $nodeSelector := dict -}}
+{{- if .Values.nodeSelector -}}
+  {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.nodeSelector -}}
+{{- end -}}
+{{- if .Values.linuxNodeSelector -}}
+  {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.linuxNodeSelector -}}
+{{- end -}}
+{{- if .Values.global.nodeSelector -}}
+  {{- $nodeSelector = merge $nodeSelector .Values.global.nodeSelector -}}
+{{- end -}}
+{{- if $nodeSelector -}}
+nodeSelector:
+  {{- toYaml $nodeSelector | nindent 2 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Recursively flattens a map into dot-separated keys for filters.
 Usage: include "opentelemetry-collector.flattenFilters" (dict "m" . "prefix" "")
 Returns a YAML array of key=regex strings.

--- a/charts/logzio-telemetry/templates/_helpers.tpl
+++ b/charts/logzio-telemetry/templates/_helpers.tpl
@@ -230,11 +230,11 @@ Merges local and global affinity settings for the standalone collector.
 */}}
 {{- define "opentelemetry-collector.affinity" -}}
 {{- $affinity := dict -}}
-{{- if .Values.affinity -}}
-  {{- $affinity = mergeOverwrite $affinity .Values.affinity -}}
-{{- end -}}
 {{- if .Values.global.affinity -}}
   {{- $affinity = mergeOverwrite $affinity .Values.global.affinity -}}
+{{- end -}}
+{{- if .Values.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.affinity -}}
 {{- end -}}
 {{- if $affinity -}}
 affinity:
@@ -247,11 +247,11 @@ Merges local daemonsetCollector affinity with global affinity settings.
 */}}
 {{- define "opentelemetry-collector.daemonsetAffinity" -}}
 {{- $affinity := dict -}}
-{{- if .Values.daemonsetCollector.affinity -}}
-  {{- $affinity = mergeOverwrite $affinity .Values.daemonsetCollector.affinity -}}
-{{- end -}}
 {{- if .Values.global.affinity -}}
   {{- $affinity = mergeOverwrite $affinity .Values.global.affinity -}}
+{{- end -}}
+{{- if .Values.daemonsetCollector.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.daemonsetCollector.affinity -}}
 {{- end -}}
 {{- if $affinity -}}
 affinity:
@@ -265,14 +265,14 @@ Global keys override local ones if duplicated.
 */}}
 {{- define "opentelemetry-collector.nodeSelector" -}}
 {{- $nodeSelector := dict -}}
+{{- if .Values.global.nodeSelector -}}
+  {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.global.nodeSelector -}}
+{{- end -}}
 {{- if .Values.nodeSelector -}}
   {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.nodeSelector -}}
 {{- end -}}
 {{- if .Values.linuxNodeSelector -}}
   {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.linuxNodeSelector -}}
-{{- end -}}
-{{- if .Values.global.nodeSelector -}}
-  {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.global.nodeSelector -}}
 {{- end -}}
 {{- if $nodeSelector -}}
 nodeSelector:

--- a/charts/logzio-telemetry/templates/_helpers.tpl
+++ b/charts/logzio-telemetry/templates/_helpers.tpl
@@ -272,7 +272,7 @@ Global keys override local ones if duplicated.
   {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.linuxNodeSelector -}}
 {{- end -}}
 {{- if .Values.global.nodeSelector -}}
-  {{- $nodeSelector = merge $nodeSelector .Values.global.nodeSelector -}}
+  {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.global.nodeSelector -}}
 {{- end -}}
 {{- if $nodeSelector -}}
 nodeSelector:

--- a/charts/logzio-telemetry/templates/_pod-spm.tpl
+++ b/charts/logzio-telemetry/templates/_pod-spm.tpl
@@ -67,14 +67,8 @@ volumes:
       items:
         - key: relay
           path: relay.yaml
-{{- with .Values.linuxNodeSelector }}
-nodeSelector:
-{{- toYaml . | nindent 2 }}
-{{- end }}
-{{- with .Values.affinity }}
-affinity:
-{{- toYaml . | nindent 2 }}
-{{- end }}
+{{ with (include "opentelemetry-collector.nodeSelector" .) }}{{ . }}{{ end }}
+{{ with (include "opentelemetry-collector.affinity" .) }}{{ . }}{{ end }}
 {{- if or .Values.tolerations .Values.global.tolerations }}
   {{- $allTolerations := concat (.Values.tolerations | default list) (.Values.global.tolerations | default list) }}
 tolerations:

--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -239,14 +239,8 @@ volumes:
     secret:
       secretName: {{ .secretName }}
   {{- end }}
-{{- with .Values.linuxNodeSelector }}
-nodeSelector:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
-{{- with .Values.affinity }}
-affinity:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
+{{ with (include "opentelemetry-collector.nodeSelector" .) }}{{ . }}{{ end }}
+{{ with (include "opentelemetry-collector.affinity" .) }}{{ . }}{{ end }}
 {{- if or .Values.tolerations .Values.global.tolerations }}
   {{- $allTolerations := concat (.Values.tolerations | default list) (.Values.global.tolerations | default list) }}
 tolerations:

--- a/charts/logzio-trivy/CHANGELOG.md
+++ b/charts/logzio-trivy/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changes by Version
 
 <!-- next version -->
+## 1.1.0
+- Support global setting for `nodeSelector` and `affinity`.
+- Upgrade Trivy-Operator version to `0.28.0`.
+
 ## 1.0.2
 - Add support for global tolerations
 

--- a/charts/logzio-trivy/Chart.yaml
+++ b/charts/logzio-trivy/Chart.yaml
@@ -5,13 +5,13 @@ keywords:
   - logging
   - trivy
   - security
-version: 1.0.2
+version: 1.1.0
 appVersion: 0.2.3
 sources:
   - https://github.com/logzio/logzio-helm
 dependencies:
   - name: trivy-operator
-    version: "0.24.1"
+    version: "0.28.0"
     repository: "https://aquasecurity.github.io/helm-charts/"
 maintainers:
   - name: Miri Bar

--- a/charts/logzio-trivy/templates/_helpers.tpl
+++ b/charts/logzio-trivy/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Merges local and global nodeSelector settings.
   {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.nodeSelector -}}
 {{- end -}}
 {{- if .Values.global.nodeSelector -}}
-  {{- $nodeSelector = merge $nodeSelector .Values.global.nodeSelector -}}
+  {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.global.nodeSelector -}}
 {{- end -}}
 {{- if $nodeSelector -}}
 nodeSelector:

--- a/charts/logzio-trivy/templates/_helpers.tpl
+++ b/charts/logzio-trivy/templates/_helpers.tpl
@@ -39,3 +39,37 @@ https://listener.logz.io:8071
 {{- printf "https://listener-%s.logz.io:8071" $region }}
 {{- end }}
 {{- end }}
+
+{{/*
+Merges local and global affinity settings.
+*/}}
+{{- define "trivy-to-logzio.affinity" -}}
+{{- $affinity := dict -}}
+{{- if .Values.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.affinity -}}
+{{- end -}}
+{{- if .Values.global.affinity -}}
+  {{- $affinity = mergeOverwrite $affinity .Values.global.affinity -}}
+{{- end -}}
+{{- if $affinity -}}
+affinity:
+  {{- toYaml $affinity | nindent 2 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Merges local and global nodeSelector settings.
+*/}}
+{{- define "trivy-to-logzio.nodeSelector" -}}
+{{- $nodeSelector := dict -}}
+{{- if .Values.nodeSelector -}}
+  {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.nodeSelector -}}
+{{- end -}}
+{{- if .Values.global.nodeSelector -}}
+  {{- $nodeSelector = merge $nodeSelector .Values.global.nodeSelector -}}
+{{- end -}}
+{{- if $nodeSelector -}}
+nodeSelector:
+  {{- toYaml $nodeSelector | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/charts/logzio-trivy/templates/_helpers.tpl
+++ b/charts/logzio-trivy/templates/_helpers.tpl
@@ -62,11 +62,11 @@ Merges local and global nodeSelector settings.
 */}}
 {{- define "trivy-to-logzio.nodeSelector" -}}
 {{- $nodeSelector := dict -}}
-{{- if .Values.nodeSelector -}}
-  {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.nodeSelector -}}
-{{- end -}}
 {{- if .Values.global.nodeSelector -}}
   {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.global.nodeSelector -}}
+{{- end -}}
+{{- if .Values.nodeSelector -}}
+  {{- $nodeSelector = mergeOverwrite $nodeSelector .Values.nodeSelector -}}
 {{- end -}}
 {{- if $nodeSelector -}}
 nodeSelector:

--- a/charts/logzio-trivy/templates/deployment.yaml
+++ b/charts/logzio-trivy/templates/deployment.yaml
@@ -39,14 +39,8 @@ spec:
         - name: LOG_LEVEL
           value: {{ .Values.scriptLogLevel }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 2 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 2 }}
-      {{- end }}
+      {{ with (include "trivy-to-logzio.nodeSelector" .) }}{{ . | nindent 6 }}{{ end }}
+      {{ with (include "trivy-to-logzio.affinity" .) }}{{ . | nindent 6 }}{{ end }}
       {{- if or .Values.tolerations .Values.global.tolerations }}
       {{- $allTolerations := concat (.Values.tolerations | default list) (.Values.global.tolerations | default list) }}
       tolerations:


### PR DESCRIPTION
## Description 

- add global `nodeSelector` and `affinity`
- update changelogs
- delete `Timestamp` check from SingalFX tests (they caused [failure](https://github.com/logzio/logzio-helm/actions/runs/17586438312/job/50012335609?pr=660) due to bug timestamp supporting both numeric and string) - the check is redundant since all ingested logs are guaranteed to have `@timestamp` 

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
