### PR TITLE
[Release] `logzio-monitoring` version `7.8.0`

### DIFF
--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changes by Version
 
 <!-- next version -->
+## 7.8.0
+- Upgrade `logzio-logs-collector` chart to `2.3.0`
+  - Support global setting for `nodeSelector` and `affinity`.
+  - Upgrade `otel/opentelemetry-collector-contrib` image to version `0.133.0`.
+- Upgrade `logzio-apm-collector` chart to `1.3.0`
+  - Support global setting for `nodeSelector` and `affinity`.
+  - Upgrade OpenTelemetry Collector from `0.129.0` to `0.133.0`.
+- Upgrade `logzio-k8s-events` chart to `2.0.0`
+  - Support global setting for `nodeSelector` and `affinity`.
+  - **Breaking changes:**
+    - Deprecate `nodeArchitectures` setting (can be configured directly under `affinity`).
+- Upgrade `logzio-k8s-telemetry` chart to `5.7.0`
+  - Support global setting for `nodeSelector` and `affinity`.
+- Upgrade `logzio-trivy` chart to `1.1.0`
+  - Support global setting for `nodeSelector` and `affinity`.
+  - Upgrade Trivy-Operator version to `0.28.0`.
+- Upgrade `opentelemetry-operator` chart to `~0.93.1`
 ## 7.7.0
 - Upgrade `logzio-k8s-telemetry` chart to `5.5.1`
   - **Breaking change:** 
@@ -43,7 +60,7 @@
 ## 7.4.0
 - Upgrade `logzio-k8s-telemetry` chart to `5.3.1`
 - Upgrade `logzio-logs-collector` chart to `2.2.0`
-- Upgrade `logzio-apm-telemetry` chart to `1.3.0`
+- Upgrade `logzio-apm-collector` chart to `1.3.0`
 - Add support for filter syntax (include/exclude) for metrics, logs, and traces in subcharts (logzio-k8s-telemetry, logzio-logs-collector, logzio-apm-collector).
   - Allows advanced filtering using `filters` key in values.yaml or via --set flags.
 

--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Upgrade `logzio-logs-collector` chart to `2.3.0`
   - Support global setting for `nodeSelector` and `affinity`.
   - Upgrade `otel/opentelemetry-collector-contrib` image to version `0.133.0`.
-- Upgrade `logzio-apm-collector` chart to `1.3.0`
+- Upgrade `logzio-apm-collector` chart to `1.4.0`
   - Support global setting for `nodeSelector` and `affinity`.
   - Upgrade OpenTelemetry Collector from `0.129.0` to `0.133.0`.
 - Upgrade `logzio-k8s-events` chart to `2.0.0`

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 7.7.0
+version: 7.8.0
 
 
 sources:
@@ -13,11 +13,11 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "5.6.0"
+    version: "5.7.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logzio-k8s-telemetry.metrics.enabled
   - name: logzio-trivy
-    version: "1.0.1"
+    version: "1.1.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: securityReport.enabled
   - name: opencost
@@ -25,20 +25,20 @@ dependencies:
     repository: "https://opencost.github.io/opencost-helm-chart"
     condition: finops.enabled
   - name: logzio-k8s-events
-    version: "1.0.1"
+    version: "2.0.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
   - name: logzio-logs-collector
-    version: "2.2.1"
+    version: "2.3.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-apm-collector
-    version: "1.3.0"
+    version: "1.4.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logzio-apm-collector.enabled
   - name: opentelemetry-operator
     alias: otel-operator
-    version: ~0.90.4
+    version: ~0.93.1
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: otel-operator.enabled
 maintainers:

--- a/charts/logzio-monitoring/MIGRATE_TO_7.x.x.md
+++ b/charts/logzio-monitoring/MIGRATE_TO_7.x.x.md
@@ -1,0 +1,203 @@
+# Migrating to `logzio-monitoring` 7.0.0
+
+## Step 1: Update helm repositories
+
+Run the following command to ensure you have the latest chart versions:
+
+```shell
+helm repo update
+```
+
+## Step 2: Build the upgrade command
+
+Choose the appropriate upgrade command for your current setup. If you're unsure of your configuration, use the following command to retrieve the current values
+
+```shell
+helm get values logzio-monitoring -n monitoring
+```
+
+> [!IMPORTANT]
+> If you have enabled any of the following
+> - `logzio-k8s-events` (`deployEvents`)
+> - `logzio-trivy` (`securityReport`)
+> - `logzio-k8s-telemetry.k8sObjectsConfig`
+> You must use one of the Logs command options as part of the upgrade process.
+
+<details>
+  <summary>Logs, Metrics and Traces:</summary>
+
+```shell
+helm upgrade logzio-monitoring logzio-helm/logzio-monitoring -n monitoring \
+--set global.logzioRegion="<<LOGZIO-REGION>>" \
+--set global.env_id="<<ENV-ID>>" \
+--set global.logzioLogsToken="<<LOG-SHIPPING-TOKEN>>" \
+--set global.logzioMetricsToken="<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>" \
+--set logzio-k8s-telemetry.traces.enabled=false \
+--set logzio-apm-collector.enabled=true \
+--set global.logzioTracesToken="<<TRACES-SHIPPING-TOKEN>>" \
+
+# If you also send SPM or ServiceGraph, add the relevant enable flag for them and the token
+--set logzio-apm-collector.spm.enabled=true \
+--set logzio-apm-collector.serviceGraph.enabled=true \
+--set global.logzioSpmToken="<<SPM-SHIPPING-TOKEN>>" \
+
+--reuse-values
+```
+
+> [!NOTE]
+> If you were using `logzio-logs-collector.secrets.logType`, add to your command `--set global.logType=<<LOG-TYPE>> \`
+
+> [!IMPORTANT]
+> Make sure to update your Instrumentation service endpoint from `logzio-monitoring-otel-collector.monitoring.svc.cluster.local` to `logzio-apm-collector.monitoring.svc.cluster.local`.
+
+</details>
+
+<details>
+  <summary>Logs and Metrics:</summary>
+
+```shell
+helm upgrade logzio-monitoring logzio-helm/logzio-monitoring -n monitoring \
+--set global.logzioRegion="<<LOGZIO-REGION>>" \
+--set global.env_id="<<ENV-ID>>" \
+--set global.logzioLogsToken="<<LOG-SHIPPING-TOKEN>>" \
+--set global.logzioMetricsToken="<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>" \
+--reuse-values
+```
+
+> [!NOTE]
+> If you were using `logzio-logs-collector.secrets.logType`, add to your command `--set global.logType=<<LOG-TYPE>> \`
+
+</details>
+
+<details>
+  <summary>Metrics and Traces:</summary>
+
+```shell
+helm upgrade logzio-monitoring logzio-helm/logzio-monitoring -n monitoring \
+--set global.logzioRegion="<<LOGZIO-REGION>>" \
+--set global.env_id="<<ENV-ID>>" \
+--set global.logzioMetricsToken="<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>" \
+--set logzio-k8s-telemetry.traces.enabled=false \
+--set logzio-apm-collector.enabled=true \
+--set global.logzioTracesToken="<<TRACES-SHIPPING-TOKEN>>" \
+
+# If you also send SPM or ServiceGraph, add the relevant enable flag for them and the token
+--set logzio-apm-collector.spm.enabled=true \
+--set logzio-apm-collector.serviceGraph.enabled=true \
+--set global.logzioSpmToken="<<SPM-SHIPPING-TOKEN>>" \
+
+--reuse-values
+```
+
+> [!IMPORTANT]
+> Make sure to update your Instrumentation service endpoint from `logzio-monitoring-otel-collector.monitoring.svc.cluster.local` to `logzio-apm-collector.monitoring.svc.cluster.local`.
+
+</details>
+
+<details>
+  <summary>Logs and Traces:</summary>
+
+```shell
+helm upgrade logzio-monitoring logzio-helm/logzio-monitoring -n monitoring \
+--set global.logzioRegion="<<LOGZIO-REGION>>" \
+--set global.env_id="<<ENV-ID>>" \
+--set global.logzioLogsToken="<<LOG-SHIPPING-TOKEN>>" \
+--set logzio-k8s-telemetry.traces.enabled=false \
+--set logzio-apm-collector.enabled=true \
+--set global.logzioTracesToken="<<TRACES-SHIPPING-TOKEN>>" \
+
+# If you also send SPM or ServiceGraph, add the relevant enable flag for them and the token
+--set logzio-apm-collector.spm.enabled=true \
+--set logzio-apm-collector.serviceGraph.enabled=true \
+--set global.logzioSpmToken="<<SPM-SHIPPING-TOKEN>>" \
+
+--reuse-values
+```
+
+> [!NOTE]
+> If you were using `logzio-logs-collector.secrets.logType`, add to your command `--set global.logType=<<LOG-TYPE>> \`
+
+> [!IMPORTANT]
+> Make sure to update your Instrumentation service endpoint from `logzio-monitoring-otel-collector.monitoring.svc.cluster.local` to `logzio-apm-collector.monitoring.svc.cluster.local`.
+
+</details>
+
+
+<details>
+  <summary>Only Logs:</summary>
+
+```shell
+helm upgrade logzio-monitoring logzio-helm/logzio-monitoring -n monitoring \
+--set global.logzioRegion="<<LOGZIO-REGION>>" \
+--set global.env_id="<<ENV-ID>>" \
+--set global.logzioLogsToken="<<LOG-SHIPPING-TOKEN>>" \
+--reuse-values
+```
+
+> [!NOTE]
+> If you were using `logzio-logs-collector.secrets.logType`, add to your command `--set global.logType=<<LOG-TYPE>> \`
+
+</details>
+
+<details>
+  <summary>Only Metrics:</summary>
+
+```shell
+helm upgrade logzio-monitoring logzio-helm/logzio-monitoring -n monitoring \
+--set global.logzioRegion="<<LOGZIO-REGION>>" \
+--set global.env_id="<<ENV-ID>>" \
+--set global.logzioMetricsToken="<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>" \
+--reuse-values
+```
+
+</details>
+
+<details>
+  <summary>Only Traces:</summary>
+
+```shell
+helm upgrade logzio-monitoring logzio-helm/logzio-monitoring -n monitoring \
+--set global.logzioRegion="<<LOGZIO-REGION>>" \
+--set global.env_id="<<ENV-ID>>" \
+--set logzio-k8s-telemetry.traces.enabled=false \
+--set logzio-apm-collector.enabled=true \
+--set global.logzioTracesToken="<<TRACES-SHIPPING-TOKEN>>" \
+
+# If you also send SPM or ServiceGraph, add the relevant enable flag for them and the token
+--set logzio-apm-collector.spm.enabled=true \
+--set logzio-apm-collector.serviceGraph.enabled=true \
+--set global.logzioSpmToken="<<SPM-SHIPPING-TOKEN>>" \
+
+--reuse-values
+```
+
+> [!IMPORTANT]
+> Make sure to update your Instrumentation service endpoint from `logzio-monitoring-otel-collector.monitoring.svc.cluster.local` to `logzio-apm-collector.monitoring.svc.cluster.local`.
+
+</details>
+
+### Managing own secret
+If you manage your own secret for the Logz.io charts, please also add to your command:
+
+ ```shell
+--set sub-chart-name.secret.name="<<NAME-OF-SECRET>>" \
+--set sub-chart-name.secret.enabled=false \
+```
+
+> [!IMPORTANT]
+> This change is not relevant for the `logzio-k8s-telemetry` chart.
+
+Replace `sub-chart-name` with the name of the sub chart which you manage the secrets for.
+
+For example, if you manage secret for both `logzio-logs-collector` and for `logzio-trivy`, use:
+
+ ```shell
+helm upgrade logzio-monitoring logzio-helm/logzio-monitoring -n monitoring \
+--set global.logzioRegion="<<LOGZIO-REGION>>" \
+--set global.env_id="<<ENV-ID>>" \
+--set logzio-logs-collector.secret.name="<<NAME-OF-SECRET>>" \
+--set logzio-logs-collector.secret.enabled=false \
+--set logzio-trivy.secret.name="<<NAME-OF-SECRET>>" \
+--set logzio-trivy.secret.enabled=false \
+--reuse-values
+```

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -251,7 +251,7 @@ By following these steps, you can ensure that your pods are scheduled on nodes w
 ### Adding Global `affinity` and `nodeSelector` Settings
 
 > [!NOTE]
-> Supported **strating from version `7.8.0`**
+> Supported **starting from version `7.8.0`**
 
 You can apply `affinity` and `nodeSelector` settings across all enabled `logzio-monitoring` subcharts, by using the `global` configuration. Example:
 ```yaml

--- a/charts/logzio-monitoring/templates/operator/webhook-ready-check-job.yaml
+++ b/charts/logzio-monitoring/templates/operator/webhook-ready-check-job.yaml
@@ -13,6 +13,14 @@ spec:
   ttlSecondsAfterFinished: 30
   template:
     spec:
+      {{- with .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "otel-operator.fullname" . }}
       containers:
         - name: curl


### PR DESCRIPTION
## Description 

- Upgrade `logzio-logs-collector` chart to `2.3.0`
  - Support global setting for `nodeSelector` and `affinity`.
  - Upgrade `otel/opentelemetry-collector-contrib` image to version `0.133.0`.
- Upgrade `logzio-apm-collector` chart to `1.3.0`
  - Support global setting for `nodeSelector` and `affinity`.
  - Upgrade OpenTelemetry Collector from `0.129.0` to `0.133.0`.
- Upgrade `logzio-k8s-events` chart to `2.0.0`
  - Support global setting for `nodeSelector` and `affinity`.
  - **Breaking changes:**
    - Deprecate `nodeArchitectures` setting (can be configured directly under `affinity`).
- Upgrade `logzio-k8s-telemetry` chart to `5.7.0`
  - Support global setting for `nodeSelector` and `affinity`.
- Upgrade `logzio-trivy` chart to `1.1.0`
  - Support global setting for `nodeSelector` and `affinity`.
  - Upgrade Trivy-Operator version to `0.28.0`.
- Upgrade `opentelemetry-operator` chart to `~0.93.1`
- Add support for global `nodeSelector` and `affinity` to otel-operator helper self cleanup job.
- Split the migration to v7 from readme to it's own file
- Order the readme
- update the changelog

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
