### PR TITLE
[Feat] monitoring 7.9.2

### DIFF
--- a/.github/workflows/logzio-monitoring-test.yaml
+++ b/.github/workflows/logzio-monitoring-test.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes_version: ['1.28', '1.30', '1.32']
+        kubernetes_version: ['1.30', '1.32', '1.34']
         environment: [eks-linux, eks-fargate]
     steps:
       - name: Generate random id

--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changes by Version
 
 <!-- next version -->
+## 7.9.2
+- Upgrade `obi` chart to `1.0.3`:
+  - Removed `privileged: true`
+  - Added `CAP_SYS_ADMIN`
+  - Made `CAP_SYS_RESOURCE` optional (commented out by default) - only needed for kernels < 5.11
+  - Added `CAP_NET_RAW`
+  - Added `CAP_KILL`
+  - Added default traces sampler 
+  - Made ClusterRole rules fully configurable via `clusterRole.rules` in values.yaml
+  - ConfigMaps read permissions to ClusterRole for cluster name detection 
 ## 7.9.1
 - Upgrade `logzio-k8s-telemetry` chart to `5.8.1`
   - Fix custom tracing endpoint: `global.CustomTracingEndpoint` >> `global.customTracesEndpoint`

--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!-- next version -->
 ## 7.9.2
-- Upgrade `obi` chart to `1.0.3`:
+- Upgrade `obi` chart to `1.0.4`:
   - Removed `privileged: true`
   - Added `CAP_SYS_ADMIN`
   - Made `CAP_SYS_RESOURCE` optional (commented out by default) - only needed for kernels < 5.11
@@ -11,6 +11,8 @@
   - Added default traces sampler 
   - Made ClusterRole rules fully configurable via `clusterRole.rules` in values.yaml
   - ConfigMaps read permissions to ClusterRole for cluster name detection 
+  - Disable metrics export by default
+  - Use pinned image version `v0.3.0`
 ## 7.9.1
 - Upgrade `logzio-k8s-telemetry` chart to `5.8.1`
   - Fix custom tracing endpoint: `global.CustomTracingEndpoint` >> `global.customTracesEndpoint`

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -37,7 +37,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logzio-apm-collector.enabled
   - name: obi
-    version: "1.0.3"
+    version: "1.0.4"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: obi.enabled
   - name: opentelemetry-operator

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 7.9.1
+version: 7.9.2
 
 
 sources:
@@ -37,7 +37,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logzio-apm-collector.enabled
   - name: obi
-    version: "1.0.2"
+    version: "1.0.3"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: obi.enabled
   - name: opentelemetry-operator


### PR DESCRIPTION
## Description 

## 7.9.2
- Upgrade `obi` chart to `1.0.4`:
  - Removed `privileged: true`
  - Added `CAP_SYS_ADMIN`
  - Made `CAP_SYS_RESOURCE` optional (commented out by default) - only needed for kernels < 5.11
  - Added `CAP_NET_RAW`
  - Added `CAP_KILL`
  - Added default traces sampler 
  - Made ClusterRole rules fully configurable via `clusterRole.rules` in values.yaml
  - ConfigMaps read permissions to ClusterRole for cluster name detection 
  - Disable metrics export by default
  - Use pinned image version `v0.3.0`

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
