### PR TITLE
Logzio monitoring 7.10.0 windows support

### DIFF
--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changes by Version
 
 <!-- next version -->
+## 7.10.0
+- Add Windows node support for metrics and logs collection
+  - New `global.windows.enabled` and `global.windows.version` settings
+  - Upgrade `logzio-k8s-telemetry` chart to `5.9.0`
+    - Windows DaemonSet with Windows-specific OTel collector configuration
+  - Upgrade `logzio-logs-collector` chart to `2.4.0`
+    - Windows DaemonSet for log collection from Windows nodes
+
 ## 7.9.3
 - Upgrade `logzio-apm-collector` chart to `1.4.1`
   - Add span metrics attributes `http.method` , `http.status_code`

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 7.9.3
+version: 7.10.0
 
 
 sources:
@@ -13,7 +13,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "5.8.1"
+    version: "5.9.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logzio-k8s-telemetry.metrics.enabled
   - name: logzio-trivy
@@ -29,7 +29,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: deployEvents.enabled
   - name: logzio-logs-collector
-    version: "2.3.0"
+    version: "2.4.0"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-apm-collector

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -23,6 +23,7 @@ This project packages the following Helm Charts:
 ### Table of content
 - [Installation instructions](#instructions-for-standard-deployment)
   - [EKS on fargate](#sending-telemetry-data-from-eks-on-fargate)
+  - [Windows nodes support](#windows-nodes-support)
 - [Custom config](#further-configuration)
   - [Custom endpoint for logs](#send-logs-to-a-custom-endpoint)
   - [Custom endpoint for metrics](#send-metrics-to-a-custom-endpoint)
@@ -151,6 +152,59 @@ helm install -n monitoring \
 --set global.logzioTracesToken="<<TRACES-SHIPPING-TOKEN>>" \
 logzio-monitoring logzio-helm/logzio-monitoring
 ```
+
+### Windows nodes support
+
+For mixed Linux/Windows clusters, enable Windows support to collect logs, metrics, and traces from Windows nodes (From version 7.10.0)
+
+#### Full telemetry collection (logs, metrics, traces) with Windows support
+
+```shell
+helm install -n monitoring \
+--set logs.enabled=true \
+--set global.logzioLogsToken="<<LOG-SHIPPING-TOKEN>>" \
+--set global.logzioRegion="<<LOGZIO-REGION>>" \
+--set global.env_id="<<ENV-ID>>" \
+--set logzio-k8s-telemetry.metrics.enabled=true \
+--set logzio-k8s-telemetry.collector.mode=daemonset \
+--set global.logzioMetricsToken="<<PROMETHEUS-METRICS-SHIPPING-TOKEN>>" \
+--set logzio-apm-collector.enabled=true \
+--set global.logzioTracesToken="<<TRACES-SHIPPING-TOKEN>>" \
+--set logzio-apm-collector.spm.enabled=true \
+--set global.logzioSpmToken="<<SPM-SHIPPING-TOKEN>>" \
+--set global.windows.enabled=true \
+--set global.windows.version="2022" \
+--set logzio-k8s-telemetry.secrets.windowsNodeUsername="<<WINDOWS-NODE-USERNAME>>" \
+--set logzio-k8s-telemetry.secrets.windowsNodePassword="<<WINDOWS-NODE-PASSWORD>>" \
+logzio-monitoring logzio-helm/logzio-monitoring
+```
+
+#### Windows parameters
+
+| Parameter | Description |
+| --- | --- |
+| `global.windows.enabled` | Enable Windows node support |
+| `global.windows.version` | Windows Server version: `"2019"` or `"2022"` |
+| `logzio-k8s-telemetry.secrets.windowsNodeUsername` | SSH username for Windows nodes (default: `azureuser` for AKS) |
+| `logzio-k8s-telemetry.secrets.windowsNodePassword` | SSH password for Windows nodes |
+
+#### How Windows telemetry collection works
+
+**Logs:**
+- A separate Windows DaemonSet (`logzio-logs-collector-windows`) runs on each Windows node
+- Collects container logs from `C:\var\log\pods\`
+- Uses Windows-compatible OTel collector image
+
+**Metrics:**
+- A separate Windows DaemonSet (`otel-collector-ds-windows`) runs on each Windows node
+- Collects kubelet metrics using Windows file paths for credentials
+- Scrapes Windows Exporter metrics (installed automatically via CronJob)
+- Note: cadvisor job metrics are not available on Windows nodes
+
+**Traces:**
+- The APM collector (`logzio-apm-collector`) runs on Linux nodes as a cluster-wide service
+- Applications on Windows nodes send traces to the APM collector service endpoint
+- No Windows-specific deployment needed for traces
 
 ### Send logs to a custom endpoint
 

--- a/charts/logzio-monitoring/README.md
+++ b/charts/logzio-monitoring/README.md
@@ -155,7 +155,7 @@ logzio-monitoring logzio-helm/logzio-monitoring
 
 ### Windows nodes support
 
-For mixed Linux/Windows clusters, enable Windows support to collect logs, metrics, and traces from Windows nodes (From version 7.10.0)
+For mixed Linux/Windows clusters, enable Windows support to collect logs, metrics, and traces from Windows nodes (from version 7.10.0).
 
 #### Full telemetry collection (logs, metrics, traces) with Windows support
 
@@ -179,14 +179,20 @@ helm install -n monitoring \
 logzio-monitoring logzio-helm/logzio-monitoring
 ```
 
+#### Supported Windows versions
+
+| Windows Version | `global.windows.version` |
+|----------------|--------------------------|
+| Windows Server 2019 | `"2019"` |
+| Windows Server 2022 | `"2022"` |
 #### Windows parameters
 
-| Parameter | Description |
-| --- | --- |
-| `global.windows.enabled` | Enable Windows node support |
-| `global.windows.version` | Windows Server version: `"2019"` or `"2022"` |
-| `logzio-k8s-telemetry.secrets.windowsNodeUsername` | SSH username for Windows nodes (default: `azureuser` for AKS) |
-| `logzio-k8s-telemetry.secrets.windowsNodePassword` | SSH password for Windows nodes |
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `global.windows.enabled` | Enable Windows node support | `false` |
+| `global.windows.version` | Windows Server version: `"2019"` or `"2022"` | `"2022"` |
+| `logzio-k8s-telemetry.secrets.windowsNodeUsername` | SSH username for Windows nodes | `azureuser` |
+| `logzio-k8s-telemetry.secrets.windowsNodePassword` | SSH password for Windows nodes | `""` |
 
 #### How Windows telemetry collection works
 
@@ -196,10 +202,10 @@ logzio-monitoring logzio-helm/logzio-monitoring
 - Uses Windows-compatible OTel collector image
 
 **Metrics:**
-- A separate Windows DaemonSet (`otel-collector-ds-windows`) runs on each Windows node
-- Collects kubelet metrics using Windows file paths for credentials
-- Scrapes Windows Exporter metrics (installed automatically via CronJob)
-- Note: cadvisor job metrics are not available on Windows nodes
+- In **daemonset mode**: A Windows DaemonSet (`otel-collector-ds-windows`) runs on each Windows node
+- In **standalone mode**: The Linux deployment scrapes Windows nodes via service discovery (no Windows pods)
+- Windows Exporter is installed automatically on Windows nodes via a CronJob (SSH-based)
+- Kubelet metrics use Windows file paths for credentials
 
 **Traces:**
 - The APM collector (`logzio-apm-collector`) runs on Linux nodes as a cluster-wide service

--- a/charts/logzio-monitoring/values.yaml
+++ b/charts/logzio-monitoring/values.yaml
@@ -2,6 +2,14 @@ logs:
   # Enables the deployment of the sub chart for sending logs
   enabled: false
 
+# Global Windows support settings
+global:
+  windows:
+    # Enable Windows node support for metrics and logs collection
+    enabled: false
+    # Windows Server version: "2019" or "2022"
+    version: "2022"
+
 logzio-k8s-telemetry:
   metrics:
     enabled: false


### PR DESCRIPTION
## Description 

### 7.10.0
- Add Windows node support for metrics and logs collection
  - New `global.windows.enabled` and `global.windows.version` settings
  - Upgrade `logzio-k8s-telemetry` chart to `5.9.0`
    - Windows DaemonSet with Windows-specific OTel collector configuration
  - Upgrade `logzio-logs-collector` chart to `2.4.0`
    - Windows DaemonSet for log collection from Windows nodes

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
