### PR TITLE
[Feat] Upgrade otel operator

### DIFF
--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changes by Version
 
 <!-- next version -->
+## 7.10.1
+- otel-operator:
+  - Update opentelemetry-operator subchart `0.93.1` -> `0.102.0`
+  - Use explicit `grpc` protocol for instrumentation export 
+  - Disable logs exporter By default
+
 ## 7.10.0
 - Add Windows node support for metrics and logs collection
   - New `global.windows.enabled` and `global.windows.version` settings

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -42,7 +42,7 @@ dependencies:
     condition: obi.enabled
   - name: opentelemetry-operator
     alias: otel-operator
-    version: ~0.93.1
+    version: ~0.102.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: otel-operator.enabled
 maintainers:

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 7.10.0
+version: 7.10.1
 
 
 sources:

--- a/charts/logzio-monitoring/templates/operator/_instrumentation.tpl
+++ b/charts/logzio-monitoring/templates/operator/_instrumentation.tpl
@@ -13,13 +13,15 @@ metadata:
     helm.sh/hook-weight: "3"
 spec:
   env:
+    - name: OTEL_EXPORTER_OTLP_PROTOCOL
+      value: grpc
     {{- if $metricsEnabled }}
     - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-      value: {{ include "otel-operator.serviceAddr" (dict "serviceName" .Values.instrumentation.metricsServiceName "releaseNamespace" .Release.Namespace) }}:4318
+      value: {{ include "otel-operator.serviceAddr" (dict "serviceName" .Values.instrumentation.metricsServiceName "releaseNamespace" .Release.Namespace) }}:4317
     {{- end }}
     {{- if $tracesEnabled }}
     - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-      value: {{ include "otel-operator.serviceAddr" (dict "serviceName" .Values.instrumentation.tracesServiceName "releaseNamespace" .Release.Namespace) }}:4318
+      value: {{ include "otel-operator.serviceAddr" (dict "serviceName" .Values.instrumentation.tracesServiceName "releaseNamespace" .Release.Namespace) }}:4317
     {{- end }}
   resource:
     addK8sUIDAttributes: {{ .Values.instrumentation.addK8sUIDAttributes }}
@@ -37,6 +39,8 @@ spec:
         value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.dotnet.metrics.enabled "enabledSubChart" $metricsEnabled) }}
       - name: OTEL_TRACES_EXPORTER
         value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.dotnet.traces.enabled "enabledSubChart" $tracesEnabled) }}
+      - name: OTEL_LOGS_EXPORTER
+        value: none
     {{- with .Values.instrumentation.dotnet.extraEnv }}
       {{- . | toYaml | nindent 6 }}
     {{- end }}
@@ -50,6 +54,8 @@ spec:
         value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.java.metrics.enabled "enabledSubChart" $metricsEnabled) }}
       - name: OTEL_TRACES_EXPORTER
         value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.java.traces.enabled "enabledSubChart" $tracesEnabled) }}
+      - name: OTEL_LOGS_EXPORTER
+        value: none
     {{- with .Values.instrumentation.java.extraEnv }}
       {{- . | toYaml | nindent 6 }}
     {{- end }}
@@ -59,6 +65,8 @@ spec:
         value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.python.metrics.enabled "enabledSubChart" $metricsEnabled) }}
       - name: OTEL_TRACES_EXPORTER
         value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.python.traces.enabled "enabledSubChart" $tracesEnabled) }}
+      - name: OTEL_LOGS_EXPORTER
+        value: none
     {{- with .Values.instrumentation.python.extraEnv }}
       {{- . | toYaml | nindent 6 }}
     {{- end }}
@@ -72,6 +80,8 @@ spec:
         value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.nodejs.metrics.enabled "enabledSubChart" $metricsEnabled) }}
       - name: OTEL_TRACES_EXPORTER
         value: {{ include "otel-operator.rsourceExporterType" (dict "enabledResource" .Values.instrumentation.nodejs.traces.enabled "enabledSubChart" $tracesEnabled) }}
+      - name: OTEL_LOGS_EXPORTER
+        value: none
     {{- with .Values.instrumentation.nodejs.extraEnv }}
       {{- . | toYaml | nindent 6 }}
     {{- end -}}


### PR DESCRIPTION
## Description 

- Update opentelemetry-operator subchart `0.93.1` -> `0.102.0`
- Use explicit `grpc` protocol for instrumentation export (If nothing is specified the instrumentation picks up `http/protobuf` and the default url points at grpc port 4317, creates protocol missmatch)
- Disable logs exporter since we still not exposing values to configure logs export (If not specified Instrumentation will try to export logs to `localhost` and it can create transient error logs )

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
