### PR TITLE
[Bug] `windows_exporter_installer` version `0.0.2`

### DIFF
--- a/.github/workflows/auto-release-windows-exporter-installer.yaml
+++ b/.github/workflows/auto-release-windows-exporter-installer.yaml
@@ -1,0 +1,43 @@
+name: Release windows-exporter-installer docker image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'charts/logzio-telemetry/windows_exporter_installer/windows_exporter_installer.dockerfile'
+
+permissions:
+  contents: read
+
+jobs:
+  release-docker:
+    name: release windows-exporter-installer docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Get new image version
+        id: extract_version
+        run: echo "NEW_VERSION=$(sed -n 's/^LABEL version="\([0-9.]*\)"/\1/p' charts/logzio-telemetry/windows_exporter_installer/windows_exporter_installer.dockerfile)" >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        env:
+          DOCKER_BUILD_SUMMARY: false
+        with:
+          push: true
+          platforms: linux/amd64, linux/arm/v7, linux/arm/v8, linux/arm64
+          sbom: true
+          provenance: mode=max
+          tags: logzio/logzio-windows-exporter-installer:latest, logzio/logzio-windows-exporter-installer:${{ env.NEW_VERSION }}
+          context: charts/logzio-telemetry/windows_exporter_installer
+          file: charts/logzio-telemetry/windows_exporter_installer/windows_exporter_installer.dockerfile

--- a/.github/workflows/logzio-telemetry-test.yaml
+++ b/.github/workflows/logzio-telemetry-test.yaml
@@ -9,7 +9,7 @@ on:
       - 'charts/logzio-telemetry/templates/**'
       - 'charts/logzio-telemetry/Chart.yaml'
       - 'charts/logzio-telemetry/values.yaml'
-      - 'charts/logzio-telemetry/windows_exporter_installer/**'
+      - '!charts/logzio-telemetry/windows_exporter_installer/**'
       - '!**.md'
       - '!**/**/**.md'
       - '!**/**/**/**.md'

--- a/.github/workflows/windows-exporter-installer-e2e-test.yaml
+++ b/.github/workflows/windows-exporter-installer-e2e-test.yaml
@@ -97,10 +97,10 @@ jobs:
           WIN_NODE_IP=$(kubectl get nodes --selector=kubernetes.io/os=windows -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
           echo "Windows node IP: $WIN_NODE_IP"
           # Run a debug pod to test SSH connectivity from inside the cluster
-          kubectl run ssh-test --image=busybox --restart=Never --command -- sh -c "nc -z -w 10 $WIN_NODE_IP 22 && echo 'SSH_OK' || echo 'SSH_FAIL'"
+          kubectl run ssh-test --image=busybox --restart=Never --overrides='{"spec":{"nodeSelector":{"kubernetes.io/os":"linux"}}}' --command -- sh -c "nc -z -w 10 $WIN_NODE_IP 22 && echo 'SSH_OK' || echo 'SSH_FAIL'"
           kubectl wait --for=condition=Ready pod/ssh-test --timeout=60s || true
           sleep 15
-          SSH_RESULT=$(kubectl logs ssh-test)
+          SSH_RESULT=$(kubectl logs ssh-test 2>/dev/null || echo "NO_LOGS")
           echo "SSH connectivity result: $SSH_RESULT"
           kubectl delete pod ssh-test --ignore-not-found
           if echo "$SSH_RESULT" | grep -q "SSH_FAIL"; then

--- a/.github/workflows/windows-exporter-installer-e2e-test.yaml
+++ b/.github/workflows/windows-exporter-installer-e2e-test.yaml
@@ -1,0 +1,176 @@
+name: Test Windows Exporter Installer E2E
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'charts/logzio-telemetry/windows_exporter_installer/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test-windows-exporter-installer:
+    name: Test Windows Exporter Installer on AKS
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      RESOURCE_GROUP: rg-win-exporter-test-${{ github.run_id }}
+      CLUSTER_NAME: aks-win-exporter-test-${{ github.run_id }}
+      ACR_NAME: acrwintest${{ github.run_id }}
+      LOCATION: eastus
+      WIN_ADMIN_USERNAME: ${{ secrets.WIN_ADMIN_USERNAME }}
+      WIN_ADMIN_PASSWORD: ${{ secrets.WIN_ADMIN_PASSWORD }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.3.0
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Create resource group
+        run: az group create --name $RESOURCE_GROUP --location $LOCATION
+
+      - name: Create ACR
+        run: az acr create --resource-group $RESOURCE_GROUP --name $ACR_NAME --sku Basic
+
+      - name: Build installer image in ACR
+        run: |
+          az acr build \
+            --registry $ACR_NAME \
+            --image logzio-windows-exporter-installer:test-${{ github.run_id }} \
+            --file charts/logzio-telemetry/windows_exporter_installer/windows_exporter_installer.dockerfile \
+            charts/logzio-telemetry/windows_exporter_installer/
+
+      - name: Create AKS cluster with Windows node pool
+        run: |
+          az aks create \
+            --resource-group $RESOURCE_GROUP \
+            --name $CLUSTER_NAME \
+            --node-count 1 \
+            --node-vm-size Standard_B2s \
+            --network-plugin azure \
+            --windows-admin-username $WIN_ADMIN_USERNAME \
+            --windows-admin-password "$WIN_ADMIN_PASSWORD" \
+            --generate-ssh-keys
+
+          az aks nodepool add \
+            --resource-group $RESOURCE_GROUP \
+            --cluster-name $CLUSTER_NAME \
+            --name npwin \
+            --os-type Windows \
+            --node-count 1 \
+            --node-vm-size Standard_B2ms
+
+      - name: Get AKS credentials
+        run: az aks get-credentials --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME --overwrite-existing
+
+      - name: Create ACR image pull secret
+        run: |
+          az acr update --name $ACR_NAME --admin-enabled true
+          ACR_LOGIN_SERVER=$(az acr show --name $ACR_NAME --query loginServer -o tsv)
+          ACR_USERNAME=$(az acr credential show --name $ACR_NAME --query username -o tsv)
+          ACR_PASSWORD=$(az acr credential show --name $ACR_NAME --query "passwords[0].value" -o tsv)
+          kubectl create secret docker-registry acr-pull-secret \
+            --docker-server=$ACR_LOGIN_SERVER \
+            --docker-username=$ACR_USERNAME \
+            --docker-password=$ACR_PASSWORD
+
+      - name: Wait for nodes to be ready
+        run: |
+          echo "Waiting for all nodes to be ready..."
+          kubectl wait --for=condition=Ready nodes --all --timeout=300s
+          echo "=== Node Status ==="
+          kubectl get nodes -o wide
+
+      - name: Verify SSH access to Windows node
+        run: |
+          WIN_NODE_IP=$(kubectl get nodes --selector=kubernetes.io/os=windows -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+          echo "Windows node IP: $WIN_NODE_IP"
+          # Run a debug pod to test SSH connectivity from inside the cluster
+          kubectl run ssh-test --image=busybox --restart=Never --command -- sh -c "nc -z -w 10 $WIN_NODE_IP 22 && echo 'SSH_OK' || echo 'SSH_FAIL'"
+          kubectl wait --for=condition=Ready pod/ssh-test --timeout=60s || true
+          sleep 15
+          SSH_RESULT=$(kubectl logs ssh-test)
+          echo "SSH connectivity result: $SSH_RESULT"
+          kubectl delete pod ssh-test --ignore-not-found
+          if echo "$SSH_RESULT" | grep -q "SSH_FAIL"; then
+            echo "ERROR: SSH port 22 is not reachable on Windows node $WIN_NODE_IP"
+            echo "AKS Windows nodes may not have OpenSSH server enabled."
+            exit 1
+          fi
+
+      - name: Deploy Helm chart
+        run: |
+          cd charts/logzio-telemetry
+          helm dependency build
+          ACR_LOGIN_SERVER=$(az acr show --name $ACR_NAME --query loginServer -o tsv)
+          helm upgrade --install logzio-k8s-telemetry . \
+            --set metrics.enabled=true \
+            --set global.logzioMetricsToken=dummy \
+            --set global.logzioRegion=us \
+            --set secrets.windowsNodeUsername=$WIN_ADMIN_USERNAME \
+            --set secrets.windowsNodePassword="$WIN_ADMIN_PASSWORD" \
+            --set windowsExporterInstallerImage.repository=${ACR_LOGIN_SERVER}/logzio-windows-exporter-installer \
+            --set windowsExporterInstallerImage.tag=test-${{ github.run_id }} \
+            --set imagePullSecrets[0].name=acr-pull-secret
+
+      - name: Wait for installer Job to complete
+        run: |
+          echo "Waiting for windows-exporter-installer Job to complete..."
+          kubectl wait --for=condition=complete job/windows-exporter-installer --timeout=600s
+
+      - name: Verify installer logs
+        run: |
+          echo "=== Installer Job Logs ==="
+          JOB_POD=$(kubectl get pods --selector=job-name=windows-exporter-installer -o jsonpath='{.items[0].metadata.name}')
+          kubectl logs $JOB_POD
+
+          # Verify success messages and no errors
+          LOGS=$(kubectl logs $JOB_POD)
+          if echo "$LOGS" | grep -q "Finished installing windows exporter"; then
+            echo "SUCCESS: Windows exporter was installed"
+          elif echo "$LOGS" | grep -q "already running windows_exporter"; then
+            echo "SUCCESS: Windows exporter was already running"
+          else
+            echo "FAILURE: Expected success message not found in logs"
+            exit 1
+          fi
+
+          if echo "$LOGS" | grep -qi "error"; then
+            echo "WARNING: Errors found in logs:"
+            echo "$LOGS" | grep -i "error"
+            exit 1
+          fi
+
+      - name: Debug on failure
+        if: failure()
+        run: |
+          echo "=== Job Status ==="
+          kubectl get jobs -o wide
+          echo "=== Pod Status ==="
+          kubectl get pods -o wide
+          echo "=== Pod Descriptions ==="
+          kubectl describe pods --selector=job-name=windows-exporter-installer
+          echo "=== Events ==="
+          kubectl get events --sort-by=.metadata.creationTimestamp
+          echo "=== All Pod Logs ==="
+          for pod in $(kubectl get pods --selector=job-name=windows-exporter-installer -o jsonpath='{.items[*].metadata.name}'); do
+            echo "--- Logs for pod: $pod ---"
+            kubectl logs $pod || echo "Failed to get logs for $pod"
+          done
+          echo "=== Windows Nodes ==="
+          kubectl get nodes --selector=kubernetes.io/os=windows -o json | jq '.items[].status.addresses'
+
+      - name: Cleanup Azure resources
+        if: always()
+        run: az group delete --name $RESOURCE_GROUP --yes --no-wait

--- a/charts/logzio-telemetry/CHANGELOG.md
+++ b/charts/logzio-telemetry/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- next version -->
 
+## 5.9.2
+- Fix Windows exporter installer failing to connect to nodes on AKS due to DNS resolution errors. The installer now uses the node's InternalIP instead of hostname.
+- Add `imagePullSecrets` support to the Windows exporter installer Job and CronJob for use with private container registries.
+- Bump `logzio-windows-exporter-installer` image to `0.0.2`.
+
 ## 5.9.1
 - Fix a Helm templating issue when configuring the Windows metrics exporter.
 

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 5.9.1
+version: 5.9.2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/templates/job.yaml
+++ b/charts/logzio-telemetry/templates/job.yaml
@@ -39,6 +39,10 @@ spec:
             {{- with .Values.containerSecurityContext }}
             {{- toYaml . | nindent 12 }}
             {{- end }}            
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
       {{- if .Values.tolerations }}
@@ -88,6 +92,10 @@ spec:
                 {{- with .Values.containerSecurityContext }}
                 {{- toYaml . | nindent 16 }}
                 {{- end }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           nodeSelector:
             kubernetes.io/os: linux
           {{- if .Values.tolerations }}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -605,7 +605,7 @@ windowsExporterInstallerImage:
   # Job image to install windows exporter on windows nodes
   repository: logzio/logzio-windows-exporter-installer
   pullPolicy: IfNotPresent
-  tag: "0.0.1"
+  tag: "0.0.2"
 spmImage:
   repository: otel/opentelemetry-collector-contrib
   pullPolicy: IfNotPresent

--- a/charts/logzio-telemetry/windows_exporter_installer/windows_exporter_installer.dockerfile
+++ b/charts/logzio-telemetry/windows_exporter_installer/windows_exporter_installer.dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.9
 
+LABEL version="0.0.2"
+
 # Download and install kubectl
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
-RUN apt-get update \  
+RUN apt-get update \
     && apt-get -y install curl
 
 WORKDIR /etc/kubectl

--- a/charts/logzio-telemetry/windows_exporter_installer/windows_exporter_installer.py
+++ b/charts/logzio-telemetry/windows_exporter_installer/windows_exporter_installer.py
@@ -4,57 +4,83 @@ import paramiko
 import logging
 import sys
 
-from paramiko.client import AutoAddPolicy
-from paramiko.ssh_exception import AuthenticationException
+from paramiko.client import WarningPolicy
+from paramiko.ssh_exception import AuthenticationException, SSHException
 
 KUBECTL_WINDOWS_NODES_QUERY = ["kubectl", "get", "nodes", "--selector=kubernetes.io/os=windows", "--output=json"]
 
 
-def close_connection(ssh_stdin, ssh_stderr, ssh_stdout, ssh_client):
+def run_ssh_command(ssh_client, command):
+    ssh_stdin, ssh_stdout, ssh_stderr = ssh_client.exec_command(command)
+    exit_code = ssh_stdout.channel.recv_exit_status()
+    stdout = ssh_stdout.read().decode("utf-8")
+    stderr = ssh_stderr.read().decode("utf-8")
     ssh_stdin.close()
     ssh_stdout.close()
     ssh_stderr.close()
-    ssh_client.exec_command("exit")
+    return stdout, stderr, exit_code
 
 
 def install_windows_exporter(ssh_client, win_node_hostname):
-    logging.debug("Installing windows exporter client as a service.")
-    ssh_client.exec_command(
+    logging.debug(f"Downloading windows exporter on {win_node_hostname}.")
+    stdout, stderr, exit_code = run_ssh_command(
+        ssh_client,
         "curl -L -o windows-exporter.msi https://github.com/prometheus-community/windows_exporter/releases"
         "/download/v0.16.0/windows_exporter-0.16.0-amd64.msi")
-    ssh_client.exec_command(
+    if exit_code != 0:
+        logging.error(f"Failed to download windows exporter on {win_node_hostname}: {stderr}")
+        return False
+
+    logging.debug(f"Installing windows exporter on {win_node_hostname}.")
+    stdout, stderr, exit_code = run_ssh_command(
+        ssh_client,
         "msiexec /i %cd%\\windows-exporter.msi LISTEN_PORT=9100 ENABLED_COLLECTORS=cpu,cs,container,"
         "logical_disk,"
         "memory,net,os,service,system,tcp")
+    if exit_code != 0:
+        logging.error(f"Failed to install windows exporter on {win_node_hostname}: {stderr}")
+        return False
+
     logging.debug(f"Finished installing windows exporter on {win_node_hostname}")
+    return True
 
 
 def main(win_node_username, win_node_password):
     windows_nodes = subprocess.check_output(
         KUBECTL_WINDOWS_NODES_QUERY).decode('utf-8')
     windows_nodes = json.loads(windows_nodes)
-    ssh_client = paramiko.SSHClient()
-    ssh_client.set_missing_host_key_policy(AutoAddPolicy())
 
     if len(windows_nodes['items']) == 0:
         logging.debug("No windows nodes found, skipping job")
         return
     for win_node in windows_nodes['items']:
-        win_node_hostname = win_node['status']['addresses'][1]['address']
+        win_node_hostname = None
+        for addr in win_node['status']['addresses']:
+            if addr['type'] == 'InternalIP':
+                win_node_hostname = addr['address']
+                break
+        if win_node_hostname is None:
+            logging.error(f"No InternalIP found for node {win_node['metadata']['name']}, skipping")
+            continue
+
+        ssh_client = paramiko.SSHClient()
+        ssh_client.set_missing_host_key_policy(WarningPolicy())
         try:
             ssh_client.connect(win_node_hostname, username=win_node_username, password=win_node_password)
-        except AuthenticationException:
-            logging.error(f"SSH connection to node {win_node_hostname} failed, please check username and password")
+        except (AuthenticationException, SSHException, OSError) as e:
+            logging.error(f"SSH connection to node {win_node_hostname} failed: {e}")
+            ssh_client.close()
             continue
+
         logging.debug(f"Connected to windows node {win_node_hostname}")
-        ssh_stdin, ssh_stdout, ssh_stderr = ssh_client.exec_command('net start')
-        running_services = ssh_stdout.read()
-        if running_services.decode("utf-8").find("windows_exporter") != -1:
-            logging.debug(f"Node {win_node_hostname} already running windows_exporter, closing connection.")
-            close_connection(ssh_stdin, ssh_stderr, ssh_stdout, ssh_client)
-            continue
-        install_windows_exporter(ssh_client, win_node_hostname)
-        close_connection(ssh_stdin, ssh_stderr, ssh_stdout, ssh_client)
+        try:
+            stdout, stderr, exit_code = run_ssh_command(ssh_client, 'net start')
+            if "windows_exporter" in stdout:
+                logging.debug(f"Node {win_node_hostname} already running windows_exporter, skipping.")
+                continue
+            install_windows_exporter(ssh_client, win_node_hostname)
+        finally:
+            ssh_client.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## Description 

for fixing issue raised at #683 

- resolve installation issues
  - changed `addresses[1]` to iterating through `status.addresses` and selecting the one with `type == 'InternalIP'`, with a  fallback error log if no `InternalIP` is found
  - add `run_ssh_command()` helper that calls `recv_exit_status()` to block until the command completes, to make sure download finishes before the install starts.
  - add cover for auth failures, SSH protocol errors, and network-level issues, so the job continues to the next node instead of crashing
  -  create `SSHClient` per node, and properly closed with `ssh_client.close()`
- add e2e test on azure
- add auto-release for `windows_exporter_installer`
  - add `VERSION` label to the dockerfile for triggering a new release
- add `imagePullSecrets` support to the windows jobs
- update changelog

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [x] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
