### PR TITLE
[Release] `logzio-monitoring` version `7.10.3`

### DIFF
--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changes by Version
 
 <!-- next version -->
+## 7.10.3
+- Upgrade `logzio-k8s-telemetry` chart to `5.9.2`
+  - Add `imagePullSecrets` support to the Windows exporter installer Job and CronJob for use with private container registries.
+  - Bump `logzio-windows-exporter-installer` image to `0.0.2`.
+    - Fix Windows exporter installer failing to connect to nodes on AKS due to DNS resolution errors. The installer now uses the node's InternalIP instead of hostname.
+- Upgrade `opentelemetry-operator` chart to `~0.114.1`
+
 ## 7.10.2
 - Upgrade `logzio-k8s-telemetry` chart to `5.9.1`
     - Fix a Helm templating issue when configuring the Windows metrics exporter.

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 7.10.2
+version: 7.10.3
 
 
 sources:
@@ -13,7 +13,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "5.9.1"
+    version: "5.9.2"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logzio-k8s-telemetry.metrics.enabled
   - name: logzio-trivy
@@ -42,7 +42,7 @@ dependencies:
     condition: obi.enabled
   - name: opentelemetry-operator
     alias: otel-operator
-    version: ~0.102.0
+    version: ~0.114.1
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: otel-operator.enabled
 maintainers:


### PR DESCRIPTION
## Description 

resolves #683 

- Upgrade `logzio-k8s-telemetry` chart to `5.9.2`
  - Add `imagePullSecrets` support to the Windows exporter installer Job and CronJob for use with private container registries.
  - Bump `logzio-windows-exporter-installer` image to `0.0.2`.
    - Fix Windows exporter installer failing to connect to nodes on AKS due to DNS resolution errors. The installer now uses the node's InternalIP instead of hostname.
- Upgrade `opentelemetry-operator` chart to `~0.114.1`

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
