### PR TITLE
[Release] `logzio-telemetry` version `5.9.5`

### DIFF
--- a/charts/logzio-telemetry/CHANGELOG.md
+++ b/charts/logzio-telemetry/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 5.9.5
 - Quote Windows exporter installer credentials in `secrets.yaml` to fix YAML parsing errors when values contain special characters.
+- Bump `logzio-windows-exporter-installer` image to `0.0.3`.
+  - Bump `paramiko` from `~=2.9.1` to `~=3.5.1` at .
+- Remove unused `MY_POD_IP`, `RELEASE_NAME` and `RELEASE_NS` environment variables from the pods.
+- Fix `CUSTOM_LOGS_ENDPOINT` environment variables injection in `standalone` mode, to not be dependent on `traces.enabled`.
 
 ## 5.9.4
 - Add missing `k8sObjectsConfig`, `opencost`, `signalFx`, and `carbon` config to Windows daemonset collector.
@@ -96,6 +100,10 @@
       - `secrets.CustomTracingEndpoint` >> `global.customTracesEndpoint`
       - Deprecate `secrets.p8s_logzio_name` and `secrets.ListenerHost`
         - Add `global.customMetricsEndpoint` to support sending metrics to a custom endpoint
+
+<details>
+  <summary markdown="span"> Expand to check old versions </summary>
+
 ## 4.3.2
   - Fix `prometheus/kubelet` scrape endpoint for standalone deployment
 ## 4.3.1
@@ -157,11 +165,6 @@
       - `kubeStateMetrics.enabled`
       - `pushGateway.enabled`
       - `nodeExporter.enabled`
-
-
-
-<details>
-  <summary markdown="span"> Expand to check old versions </summary>
 
 ## 2.2.0
   - Upgraded SPM collector image to version `0.80.0`.

--- a/charts/logzio-telemetry/CHANGELOG.md
+++ b/charts/logzio-telemetry/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 <!-- next version -->
 
+## 5.9.5
+- Quote Windows exporter installer credentials in `secrets.yaml` to fix YAML parsing errors when values contain special characters.
+
 ## 5.9.4
 - Add missing `k8sObjectsConfig`, `opencost`, `signalFx`, and `carbon` config to Windows daemonset collector.
 

--- a/charts/logzio-telemetry/Chart.yaml
+++ b/charts/logzio-telemetry/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 5.9.4
+version: 5.9.5
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/logzio-telemetry/templates/_daemonset-pod-windows.tpl
+++ b/charts/logzio-telemetry/templates/_daemonset-pod-windows.tpl
@@ -44,11 +44,6 @@ containers:
       {{- end }}
 {{- end }}
     env:
-      - name: MY_POD_IP
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: status.podIP
       - name: KUBE_NODE_NAME
         valueFrom:
           fieldRef:
@@ -57,10 +52,6 @@ containers:
         value: {{ include "opentelemetry-collector.k360Metrics" . }}
       - name: LOGZIO_AGENT_VERSION
         value: {{.Chart.Version}}
-      - name: REALESE_NAME
-        value: {{.Release.Name}}
-      - name: REALESE_NS
-        value: {{.Release.Namespace}}
       - name: METRICS_TOKEN
         valueFrom:
           secretKeyRef:

--- a/charts/logzio-telemetry/templates/_daemonset-pod.tpl
+++ b/charts/logzio-telemetry/templates/_daemonset-pod.tpl
@@ -40,11 +40,6 @@ containers:
       {{- end }}
 {{- end }}
     env:
-      - name: MY_POD_IP
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: status.podIP
       - name: KUBE_NODE_NAME
         valueFrom:
           fieldRef:
@@ -53,10 +48,6 @@ containers:
         value: {{ include "opentelemetry-collector.k360Metrics" . }}
       - name: LOGZIO_AGENT_VERSION
         value: {{.Chart.Version}}
-      - name: REALESE_NAME
-        value: {{.Release.Name}}
-      - name: REALESE_NS
-        value: {{.Release.Namespace}}
       - name: METRICS_TOKEN
         valueFrom:
           secretKeyRef:

--- a/charts/logzio-telemetry/templates/_pod-spm.tpl
+++ b/charts/logzio-telemetry/templates/_pod-spm.tpl
@@ -27,17 +27,8 @@ containers:
       {{- end }}
       {{- end }}
     env:
-      - name: MY_POD_IP
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: status.podIP
       - name: LOGZIO_AGENT_VERSION
         value: {{.Chart.Version}}
-      - name: REALESE_NAME
-        value: {{.Release.Name}}
-      - name: REALESE_NS
-        value: {{.Release.Namespace}}
       - name: LISTENER_URL
         valueFrom:
           secretKeyRef:

--- a/charts/logzio-telemetry/templates/_pod.tpl
+++ b/charts/logzio-telemetry/templates/_pod.tpl
@@ -40,11 +40,6 @@ containers:
       {{- end }}
 {{- end }}
     env:
-      - name: MY_POD_IP
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: status.podIP
       - name: KUBE_NODE_NAME
         valueFrom:
           fieldRef:
@@ -53,10 +48,6 @@ containers:
         value: {{ include "opentelemetry-collector.k360Metrics" . }}
       - name: LOGZIO_AGENT_VERSION
         value: {{.Chart.Version}}
-      - name: REALESE_NAME
-        value: {{.Release.Name}}
-      - name: REALESE_NS
-        value: {{.Release.Namespace}}
       - name: SPM_SERVICE_ENDPOINT
         {{- $serviceName := include "opentelemetry-spm.fullname" .}}
         value: {{ printf "http://%s.%s.svc.cluster.local:4317" $serviceName .Release.Namespace }}
@@ -102,13 +93,6 @@ containers:
             name: {{ .Values.secrets.name }}
             key: custom-tracing-endpoint
       {{ end }}
-      {{ if .Values.global.customLogsEndpoint }}
-      - name: CUSTOM_LOGS_ENDPOINT
-        valueFrom:
-          secretKeyRef:
-            name: {{ .Values.secrets.name }}
-            key: custom-logs-endpoint
-      {{ end }}
       - name: SAMPLING_PROBABILITY
         valueFrom:
           secretKeyRef:
@@ -124,9 +108,16 @@ containers:
         valueFrom:
           secretKeyRef:
             name: {{ .Values.secrets.name }}
-            key: logzio-spm-shipping-token        
+            key: logzio-spm-shipping-token
 {{ end }}
 {{- end }}
+      {{ if .Values.global.customLogsEndpoint }}
+      - name: CUSTOM_LOGS_ENDPOINT
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.secrets.name }}
+            key: custom-logs-endpoint
+      {{ end }}
       - name: ENV_ID
         valueFrom:
           secretKeyRef:

--- a/charts/logzio-telemetry/templates/secrets.yaml
+++ b/charts/logzio-telemetry/templates/secrets.yaml
@@ -51,8 +51,8 @@ metadata:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 stringData:
-  username: {{.Values.secrets.windowsNodeUsername}}
-  password: {{.Values.secrets.windowsNodePassword}}
+  username: {{ .Values.secrets.windowsNodeUsername | quote }}
+  password: {{ .Values.secrets.windowsNodePassword | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/logzio-telemetry/values.yaml
+++ b/charts/logzio-telemetry/values.yaml
@@ -12,7 +12,7 @@ spm:
   enabled: false # Send Span metrics, requires `traces.enabled`
 
 applicationMetrics:
-  ## Send application metrics, requires `metrics.enabled` and the `prometheus.io/scrape: true` annotaion set.
+  ## Send application metrics, requires `metrics.enabled` and the `prometheus.io/scrape: true` annotation set.
   enabled: false 
 kubeStateMetrics:
   ## If false, kube-state-metrics sub-chart will not be installed
@@ -190,7 +190,7 @@ prometheus-pushgateway:
     prometheus.io/scrape: "true"
   nodeSelector:
     kubernetes.io/os: linux
-# Configuration merge from the colelctor configs
+# Configuration merge from the collector configs
 emptyConfig: {}
 # Base configuration of the collector
 baseCollectorConfig:

--- a/charts/logzio-telemetry/windows_exporter_installer/requirements.txt
+++ b/charts/logzio-telemetry/windows_exporter_installer/requirements.txt
@@ -1,1 +1,1 @@
-paramiko~=2.9.1
+paramiko~=3.5.1

--- a/charts/logzio-telemetry/windows_exporter_installer/windows_exporter_installer.dockerfile
+++ b/charts/logzio-telemetry/windows_exporter_installer/windows_exporter_installer.dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-LABEL version="0.0.2"
+LABEL version="0.0.3"
 
 # Download and install kubectl
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
@@ -17,14 +17,3 @@ COPY windows_exporter_installer.py etc/windows_exporter_installer.py
 # Python package that handles ssh connections
 RUN pip install paramiko
 ENTRYPOINT [ "python","./etc/windows_exporter_installer.py"]
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Description 

- allow special chars in windows password
- Bump `logzio-windows-exporter-installer` image to `0.0.3`
  - Bump `paramiko` from `~=2.9.1` to `~=3.5.1`
- Remove unused `MY_POD_IP`, `RELEASE_NAME` and `RELEASE_NS` environment variables from the pods.
- Fix `CUSTOM_LOGS_ENDPOINT` environment variables injection in `standalone` mode, to not be dependent on `traces.enabled`

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
