### PR TITLE
[Release] `logzio-monitoring` version `7.10.5`

### DIFF
--- a/charts/fluentbit/README.md
+++ b/charts/fluentbit/README.md
@@ -122,4 +122,4 @@ kubectl get nodes -o json | jq ".items[]|{name:.metadata.name, taints:.spec.tain
 * 0.0.2 
   - Upgrade docker image to v0.1.2.
 * 0.0.1 
-- Initial realese
+- Initial release

--- a/charts/logzio-monitoring/CHANGELOG.md
+++ b/charts/logzio-monitoring/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changes by Version
 
 <!-- next version -->
+## 7.10.5
+- Upgrade `logzio-k8s-telemetry` chart to `5.9.5`
+  - Quote Windows exporter installer credentials in `secrets.yaml` to fix YAML parsing errors when values contain special characters.
+  - Bump `logzio-windows-exporter-installer` image to `0.0.3`.
+      - Bump `paramiko` from `~=2.9.1` to `~=3.5.1` at .
+  - Remove unused `MY_POD_IP`, `RELEASE_NAME` and `RELEASE_NS` environment variables from the pods.
+  - Fix `CUSTOM_LOGS_ENDPOINT` environment variables injection in `standalone` mode, to not be dependent on `traces.enabled`.
+
 ## 7.10.4
 - Upgrade `logzio-k8s-telemetry` chart to `5.9.4`
   - Add `kubernetes_node` label to the `windows-metrics` scrape job relabel configs.

--- a/charts/logzio-monitoring/Chart.yaml
+++ b/charts/logzio-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logzio-monitoring
 description: logzio-monitoring allows you to ship logs, metrics, traces and security reports from your Kubernetes cluster using the OpenTelemetry collector for metrics and traces, Fluentd for logs, and Trivy for security reports.
 type: application
-version: 7.10.4
+version: 7.10.5
 
 
 sources:
@@ -13,7 +13,7 @@ dependencies:
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logs.enabled
   - name: logzio-k8s-telemetry
-    version: "5.9.4"
+    version: "5.9.5"
     repository: "https://logzio.github.io/logzio-helm/"
     condition: logzio-k8s-telemetry.metrics.enabled
   - name: logzio-trivy


### PR DESCRIPTION
## Description 

resolves #631

- Upgrade `logzio-k8s-telemetry` chart to `5.9.5`
  - Quote Windows exporter installer credentials in `secrets.yaml` to fix YAML parsing errors when values contain special characters.
  - Bump `logzio-windows-exporter-installer` image to `0.0.3`.
      - Bump `paramiko` from `~=2.9.1` to `~=3.5.1` .
  - Remove unused `MY_POD_IP`, `RELEASE_NAME` and `RELEASE_NS` environment variables from the pods.
  - Fix `CUSTOM_LOGS_ENDPOINT` environment variables injection in `standalone` mode, to not be dependent on `traces.enabled`.

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
